### PR TITLE
feat: security vulns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,6 +135,26 @@ updates:
     directory: "/providers/goff"
     schedule: { interval: weekly }
     labels: [dependencies, go, provider:goff]
+  # The client half of the config server: a mamori:// provider that resolves
+  # binding names against a running server rather than an upstream ref.
+  - package-ecosystem: gomod
+    directory: "/providers/mamori"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, provider:mamori]
+
+  # The config server. It concentrates every backend credential its bindings
+  # touch into one process, so it is the highest-blast-radius module here and
+  # the one that least tolerates a stale dependency.
+  - package-ecosystem: gomod
+    directory: "/server"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, server]
+
+  # Extensions
+  - package-ecosystem: gomod
+    directory: "/x/authjwt"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, authjwt]
   - package-ecosystem: gomod
     directory: "/x/otel"
     schedule: { interval: weekly }

--- a/.github/scripts/check_dependabot_coverage.py
+++ b/.github/scripts/check_dependabot_coverage.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Assert that every Go module in the repo has a gomod entry in dependabot.yml.
+
+.github/dependabot.yml is hand-maintained while CI discovers modules
+dynamically, so the two drift apart silently: a new module gets built, tested,
+and linted from day one but never receives a dependency update. This check
+closes that gap by failing CI instead.
+
+Usage:
+    check_dependabot_coverage.py            # discover modules itself
+    check_dependabot_coverage.py '["...", ...]'   # take the CI discover job's JSON list
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
+
+
+def discover_modules() -> list[str]:
+    """Find every Go module, matching the CI discover job's find invocation."""
+    out = subprocess.run(
+        [
+            "find", ".", "-name", "go.mod",
+            "-not", "-path", "./site/*",
+            "-not", "-path", "./**/testdata/*",
+            "-exec", "dirname", "{}", ";",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return sorted(line for line in out.splitlines() if line)
+
+
+def as_dependabot_dir(module_dir: str) -> str:
+    """Map a find-style module path onto dependabot's `directory` convention."""
+    if module_dir == ".":
+        return "/"
+    if module_dir.startswith("./"):
+        return module_dir[1:]
+    return "/" + module_dir.lstrip("/")
+
+
+def main() -> int:
+    modules = json.loads(sys.argv[1]) if len(sys.argv) > 1 else discover_modules()
+
+    config = yaml.safe_load(DEPENDABOT.read_text())
+    covered = {
+        update["directory"]
+        for update in config.get("updates", [])
+        if update.get("package-ecosystem") == "gomod"
+    }
+
+    missing = [
+        (module, as_dependabot_dir(module))
+        for module in modules
+        if as_dependabot_dir(module) not in covered
+    ]
+
+    # The reverse direction matters too: an entry left behind after a module is
+    # renamed or removed makes dependabot log an error on every run.
+    stale = sorted(covered - {as_dependabot_dir(m) for m in modules})
+
+    for module, directory in missing:
+        print(
+            f'::error file=.github/dependabot.yml::Go module {module} has no gomod '
+            f'entry in dependabot.yml (expected directory: "{directory}")'
+        )
+    for directory in stale:
+        print(
+            f'::error file=.github/dependabot.yml::gomod entry directory: "{directory}" '
+            f"does not correspond to any Go module in the repo"
+        )
+
+    if missing or stale:
+        print(f"\n{len(missing)} missing, {len(stale)} stale, {len(modules)} modules total")
+        return 1
+
+    print(f"All {len(modules)} Go modules are covered by dependabot.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,33 @@ jobs:
       - name: go vet
         working-directory: ${{ matrix.dir }}
         run: go vet ./...
-      - name: go test (race)
+      # -coverpkg=./... measures how much of the whole module each test binary
+      # reaches, not just the package under test, which is the honest number for
+      # a library whose tests deliberately drive it from the outside.
+      - name: go test (race, coverage)
         working-directory: ${{ matrix.dir }}
-        run: go test -race -count=1 ./...
+        run: go test -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+      # Each matrix job owns its own step summary, so this writes a complete
+      # fragment rather than a bare table row with no header.
+      - name: Coverage summary
+        working-directory: ${{ matrix.dir }}
+        run: |
+          total=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}')
+          {
+            echo "### Coverage: \`${{ matrix.dir }}\`"
+            echo
+            echo "**$total** of statements"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Total coverage for ${{ matrix.dir }}: $total"
+      - name: Name the coverage artifact
+        id: slug
+        run: echo "v=$(echo '${{ matrix.dir }}' | sed 's|^\./||; s|/|-|g; s|^\.$|core|')" >> "$GITHUB_OUTPUT"
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ steps.slug.outputs.v }}
+          path: ${{ matrix.dir }}/coverage.out
+          retention-days: 14
 
   lint:
     name: lint ${{ matrix.dir }}
@@ -74,6 +98,94 @@ jobs:
         with:
           version: v2.12.2
           working-directory: ${{ matrix.dir }}
+
+  # The Linux test matrix above cannot see a break in the platform-specific
+  # halves of this repo: peer-credential auth is implemented three times
+  # (authpeercred_{darwin,linux,other}.go), the config server listens on Unix
+  # sockets, and the CLI ships as a Homebrew formula. This job builds and
+  # type-checks those modules on macOS and Windows, and runs the full suite on
+  # macOS where the darwin peercred path is real code rather than the fallback.
+  # Windows stays at build+vet: the socket and uid/gid tests are POSIX-only.
+  cross-platform:
+    name: ${{ matrix.os }} ${{ matrix.dir }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+        dir: [".", "server", "cmd/mamori", "x/authjwt"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+          cache-dependency-path: ${{ matrix.dir }}/go.sum
+      - name: go build
+        working-directory: ${{ matrix.dir }}
+        run: go build ./...
+      # vet type-checks the _test.go files too, so a test that only compiles on
+      # Linux fails here rather than silently never running.
+      - name: go vet
+        working-directory: ${{ matrix.dir }}
+        run: go vet ./...
+      - name: go test (race)
+        if: runner.os == 'macOS'
+        working-directory: ${{ matrix.dir }}
+        run: go test -race -count=1 ./...
+
+  # A secrets library with a cloud SDK behind almost every provider needs a
+  # standing answer to "does anything we ship reach a known vulnerability?".
+  # govulncheck is call-graph aware, so an advisory in a module we require but
+  # never call does not fail the build. One job loops every module rather than
+  # fanning out, so a single log shows the whole picture and every module is
+  # reported even after the first failure.
+  govulncheck:
+    name: govulncheck
+    needs: discover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Scan every module
+        run: |
+          # Absolute path: the scan runs from inside each module directory.
+          govulncheck="$(go env GOPATH)/bin/govulncheck"
+          failed=""
+          for dir in $(echo '${{ needs.discover.outputs.dirs }}' | jq -r '.[]'); do
+            echo "::group::govulncheck $dir"
+            if (cd "$dir" && "$govulncheck" ./...); then
+              echo "OK $dir"
+            else
+              echo "::error::govulncheck found a reachable vulnerability in $dir"
+              failed="$failed $dir"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "Modules with reachable vulnerabilities:$failed"
+            exit 1
+          fi
+          echo "No reachable vulnerabilities in any module."
+
+  # dependabot.yml is hand-maintained while the matrix above is discovered, so
+  # the two drift apart silently and a new module never gets a dependency
+  # update. Fail instead.
+  dependabot-coverage:
+    name: Dependabot covers every module
+    needs: discover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+      - run: pip install --disable-pip-version-check pyyaml
+      - name: Every Go module must have a gomod entry
+        run: python3 .github/scripts/check_dependabot_coverage.py '${{ needs.discover.outputs.dirs }}'
 
   gofmt:
     name: gofmt

--- a/README.md
+++ b/README.md
@@ -126,12 +126,13 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 | `providers/growthbook` | `growthbook://` | poll | no (chain preserved) |
 | `providers/flipt` | `flipt://` | poll | ✅ |
 | `providers/goff` | `goff://` (GO Feature Flag) | poll | ✅ |
+| `providers/mamori` | `mamori://` ([config server](#config-server) client) | **native** (SSE stream) | ✅ |
 
 Every provider that passes the [`providertest`](providertest/) conformance kit earns a badge. See each module's README for auth and ref grammar.
 
-The error-classification sweep is complete: every one of the 35 providers now falls into exactly one of three honest states, and `not_found` itself is detected by every provider regardless of which one.
+The error-classification sweep is complete: every one of the 36 providers now falls into exactly one of three honest states, and `not_found` itself is detected by every provider regardless of which one.
 
-- **✅ classifies** - the provider maps real backend errors onto `mamori.ErrorKind` values beyond `not_found` (`permission_denied`, `unauthenticated`, `unavailable`, `rate_limited`, `invalid`, as the backend's own vocabulary supports): twenty-nine providers across twenty-six module rows, since core's single row covers four built-in providers (`env:`, `dotenv://`, `file://`, `exec:`).
+- **✅ classifies** - the provider maps real backend errors onto `mamori.ErrorKind` values beyond `not_found` (`permission_denied`, `unauthenticated`, `unavailable`, `rate_limited`, `invalid`, as the backend's own vocabulary supports): thirty providers across twenty-seven module rows, since core's single row covers four built-in providers (`env:`, `dotenv://`, `file://`, `exec:`).
 - **no (chain preserved)** - `providers/firebase-rtdb`, `providers/growthbook`, and `providers/flagsmith` have no backend-specific error vocabulary to map, so a non-not-found failure still reports `unknown`. Their `Resolve` wraps the underlying error with `%w` rather than flattening it, so `errors.Is`/`errors.As` and any mamori sentinel injected by a caller's own middleware still reach it - the chain is preserved even though nothing here narrows it to a more specific kind. Do not read this as classifying permission or availability errors these providers cannot see.
 - **n/a (no error surface)** - `providers/unleash`, `providers/configcat`, and `providers/split` wrap SDK client surfaces that return only `bool`/`string` values, with no per-key error at all; their `Resolve` can only ever produce `mamori.ErrNotFound` or a client-construction error, so there is nothing to classify or preserve a chain for. Each is explicitly exempted from the `providertest` conformance kit's `ErrorClassification` case via `providertest.Config.NoResolveErrors`, a deliberate, greppable declaration rather than a silent gap.
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,182 @@
+package mamori_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/mamoritest"
+	"github.com/xavidop/mamori/secret"
+)
+
+// benchConfig is representative of a real service config: a couple of secrets,
+// a couple of plain scalars, and a nested struct.
+type benchConfig struct {
+	DBPassword secret.String `source:"mem://db-password"`
+	APIKey     secret.String `source:"mem://api-key"`
+	LogLevel   string        `source:"mem://log-level" validate:"oneof=debug info warn error"`
+	Workers    int           `source:"mem://workers"   validate:"gte=1,lte=256"`
+	Redis      benchRedis
+}
+
+type benchRedis struct {
+	Addr string `source:"mem://redis-addr"`
+	DB   int    `source:"mem://redis-db"`
+}
+
+func benchProvider() *mamoritest.Provider {
+	p := mamoritest.NewProvider("mem")
+	p.Set("db-password", "s3cret")
+	p.Set("api-key", "sk-live-abc123")
+	p.Set("log-level", "info")
+	p.Set("workers", "8")
+	p.Set("redis-addr", "127.0.0.1:6379")
+	p.Set("redis-db", "0")
+	return p
+}
+
+func benchWatcher(tb testing.TB) *mamori.Watcher[benchConfig] {
+	tb.Helper()
+	w, err := mamori.Watch[benchConfig](context.Background(), mamori.WithProvider(benchProvider()))
+	if err != nil {
+		tb.Fatalf("Watch: %v", err)
+	}
+	tb.Cleanup(func() { _ = w.Close() })
+	return w
+}
+
+// BenchmarkWatcherGet guards the central performance claim: Get is a lock-free
+// read of the last valid snapshot, so it must stay allocation-free and cheap
+// enough to call on every request rather than being hoisted and cached by
+// callers (which is what reintroduces the staleness mamori exists to remove).
+func BenchmarkWatcherGet(b *testing.B) {
+	w := benchWatcher(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = w.Get()
+	}
+}
+
+// BenchmarkWatcherGetParallel is the one that matters for the lock-free claim:
+// with a mutex, throughput per goroutine collapses as GOMAXPROCS rises. It
+// should stay roughly flat instead.
+func BenchmarkWatcherGetParallel(b *testing.B) {
+	w := benchWatcher(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = w.Get()
+		}
+	})
+}
+
+// BenchmarkWatcherGetContended measures Get while the reconciler is publishing
+// new snapshots underneath it. A reader must not be slowed by a concurrent
+// writer, which is the practical difference between an atomic pointer swap and
+// a read-write lock.
+func BenchmarkWatcherGetContended(b *testing.B) {
+	prov := benchProvider()
+	w, err := mamori.Watch[benchConfig](context.Background(), mamori.WithProvider(prov))
+	if err != nil {
+		b.Fatalf("Watch: %v", err)
+	}
+	b.Cleanup(func() { _ = w.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				prov.Set("workers", fmt.Sprint(i%256+1))
+			}
+		}
+	}()
+	b.Cleanup(func() { close(done) })
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = w.Get()
+	}
+}
+
+// BenchmarkWatcherStatus covers the readiness-probe path: Status builds a
+// per-field report on every call, and a Kubernetes probe calls it on a timer
+// for the life of the pod.
+func BenchmarkWatcherStatus(b *testing.B) {
+	w := benchWatcher(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = w.Status()
+	}
+}
+
+// BenchmarkWatcherHealth is the same path reduced to the single boolean a
+// liveness or readiness endpoint actually needs.
+func BenchmarkWatcherHealth(b *testing.B) {
+	w := benchWatcher(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = w.Health()
+	}
+}
+
+// BenchmarkLoad measures the one-shot path: resolve every field, decode, and
+// validate. This is startup cost, paid once, but it gates how fast a process
+// becomes ready.
+func BenchmarkLoad(b *testing.B) {
+	prov := benchProvider()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := mamori.Load[benchConfig](context.Background(), mamori.WithProvider(prov)); err != nil {
+			b.Fatalf("Load: %v", err)
+		}
+	}
+}
+
+// BenchmarkParseRef and BenchmarkParseRefs cover tag parsing, which runs once
+// per field per Load and is the only regexp on that path.
+func BenchmarkParseRef(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mamori.ParseRef("aws-sm://prod/db#password?version=3"); err != nil {
+			b.Fatalf("ParseRef: %v", err)
+		}
+	}
+}
+
+func BenchmarkParseRefs(b *testing.B) {
+	cases := []struct {
+		name string
+		tag  string
+	}{
+		{"single", "env:PORT"},
+		{"chain2", "env:PORT,aws-ps://svc/port"},
+		{"chain2Spaced", "env:PORT, aws-ps://svc/port"},
+		{"chain3", "env:A,env:B,aws-sm://c#k?version=2"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := mamori.ParseRefs(tc.tag); err != nil {
+					b.Fatalf("ParseRefs: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,283 @@
+package mamori_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/mamoritest"
+	"github.com/xavidop/mamori/secret"
+)
+
+// Load reads every field of a struct from the source named in its `source`
+// tag, applies `default` for anything the source does not provide, and
+// validates the whole result before returning it. A field typed
+// [secret.String] is redacted everywhere except an explicit Reveal.
+func Example() {
+	type Config struct {
+		LogLevel string        `source:"env:EXAMPLE_LOG_LEVEL" default:"info" validate:"oneof=debug info warn error"`
+		Workers  int           `source:"env:EXAMPLE_WORKERS"   default:"4"    validate:"gte=1,lte=256"`
+		APIKey   secret.String `source:"env:EXAMPLE_API_KEY"`
+	}
+
+	_ = os.Setenv("EXAMPLE_LOG_LEVEL", "debug")
+	_ = os.Setenv("EXAMPLE_API_KEY", "sk-live-abc123")
+	defer func() { _ = os.Unsetenv("EXAMPLE_LOG_LEVEL") }()
+	defer func() { _ = os.Unsetenv("EXAMPLE_API_KEY") }()
+
+	cfg, err := mamori.Load[Config](context.Background())
+	if err != nil {
+		fmt.Println("load failed:", err)
+		return
+	}
+
+	fmt.Println("log level:", cfg.LogLevel)
+	fmt.Println("workers:  ", cfg.Workers) // EXAMPLE_WORKERS is unset, so the default applies
+	fmt.Println("api key:  ", cfg.APIKey)  // redacted by default
+	fmt.Println("revealed: ", cfg.APIKey.Reveal())
+
+	// Output:
+	// log level: debug
+	// workers:   4
+	// api key:   [REDACTED]
+	// revealed:  sk-live-abc123
+}
+
+// A comma-separated `source` tag is a precedence chain: sources are tried in
+// order and the first to yield a value wins, so an operator override can sit in
+// front of a centrally managed value without the caller writing that fallback
+// by hand. Whitespace around the separator is ignored.
+func ExampleLoad_precedenceChain() {
+	type Config struct {
+		// Prefer an explicit override, fall back to the deploy-wide value,
+		// fall back to the default.
+		Port string `source:"env:EXAMPLE_PORT_OVERRIDE, env:EXAMPLE_PORT" default:"8080"`
+	}
+
+	// Nothing set: the chain falls through to the default.
+	cfg, _ := mamori.Load[Config](context.Background())
+	fmt.Println("neither set:  ", cfg.Port)
+
+	// The lower-priority source answers.
+	_ = os.Setenv("EXAMPLE_PORT", "9090")
+	defer func() { _ = os.Unsetenv("EXAMPLE_PORT") }()
+	cfg, _ = mamori.Load[Config](context.Background())
+	fmt.Println("deploy value: ", cfg.Port)
+
+	// The override wins wherever it is set.
+	_ = os.Setenv("EXAMPLE_PORT_OVERRIDE", "3000")
+	defer func() { _ = os.Unsetenv("EXAMPLE_PORT_OVERRIDE") }()
+	cfg, _ = mamori.Load[Config](context.Background())
+	fmt.Println("override wins:", cfg.Port)
+
+	// Output:
+	// neither set:   8080
+	// deploy value:  9090
+	// override wins: 3000
+}
+
+// A snapshot that fails validation is rejected whole: Load returns a
+// *ValidationError rather than handing back a half-valid config.
+func ExampleLoad_validationFailure() {
+	type Config struct {
+		Workers int `source:"env:EXAMPLE_BAD_WORKERS" default:"4" validate:"gte=1,lte=256"`
+	}
+
+	_ = os.Setenv("EXAMPLE_BAD_WORKERS", "9000")
+	defer func() { _ = os.Unsetenv("EXAMPLE_BAD_WORKERS") }()
+
+	_, err := mamori.Load[Config](context.Background())
+
+	var verr *mamori.ValidationError
+	fmt.Println("rejected as invalid:", errors.As(err, &verr))
+
+	// Output:
+	// rejected as invalid: true
+}
+
+// Watch keeps the configuration reconciled at runtime. When a source value
+// changes, mamori re-resolves, re-validates, atomically swaps the snapshot, and
+// calls OnChange with both the old and new value so the application can react
+// without restarting.
+func ExampleWatch() {
+	type Config struct {
+		DBPassword secret.String `source:"mem://db-password"`
+	}
+
+	// A scriptable in-memory provider stands in for a real secret store.
+	prov := mamoritest.NewProvider("mem")
+	prov.Set("db-password", "old-password")
+
+	rotated := make(chan string, 1)
+
+	w, err := mamori.Watch[Config](context.Background(),
+		mamori.WithProvider(prov),
+		mamori.WithDebounce(time.Millisecond),
+		mamori.OnChange(func(ev mamori.Change[Config]) {
+			if ev.Changed("DBPassword") {
+				rotated <- ev.New.DBPassword.Reveal()
+			}
+		}),
+	)
+	if err != nil {
+		fmt.Println("watch failed:", err)
+		return
+	}
+	defer func() { _ = w.Close() }()
+
+	fmt.Println("before rotation:", w.Get().DBPassword.Reveal())
+
+	prov.Set("db-password", "new-password")
+
+	fmt.Println("OnChange saw:  ", <-rotated)
+	fmt.Println("after rotation: ", w.Get().DBPassword.Reveal())
+
+	// Output:
+	// before rotation: old-password
+	// OnChange saw:   new-password
+	// after rotation:  new-password
+}
+
+// An update that fails validation is rejected atomically: OnError is notified
+// and Get keeps returning the last valid configuration rather than entering a
+// broken state mid-flight.
+func ExampleWatch_rejectsInvalidUpdate() {
+	type Config struct {
+		Workers int `source:"mem://workers" validate:"gte=1,lte=256"`
+	}
+
+	prov := mamoritest.NewProvider("mem")
+	prov.Set("workers", "8")
+
+	rejected := make(chan error, 1)
+
+	w, err := mamori.Watch[Config](context.Background(),
+		mamori.WithProvider(prov),
+		mamori.WithDebounce(time.Millisecond),
+		mamori.OnError(func(err error) {
+			var verr *mamori.ValidationError
+			if errors.As(err, &verr) {
+				select {
+				case rejected <- err:
+				default:
+				}
+			}
+		}),
+	)
+	if err != nil {
+		fmt.Println("watch failed:", err)
+		return
+	}
+	defer func() { _ = w.Close() }()
+
+	fmt.Println("valid config:", w.Get().Workers)
+
+	prov.Set("workers", "9000") // out of range
+
+	<-rejected
+	fmt.Println("after rejected update:", w.Get().Workers)
+
+	// Output:
+	// valid config: 8
+	// after rejected update: 8
+}
+
+// Status reports live per-field health without ever exposing a value, which
+// makes it safe to log or serve. Health reduces the same report to a single
+// readiness answer suitable for a Kubernetes probe.
+func ExampleWatcher_Status() {
+	type Config struct {
+		Token secret.String `source:"mem://token"`
+	}
+
+	prov := mamoritest.NewProvider("mem")
+	prov.Set("token", "s3cret")
+
+	w, err := mamori.Watch[Config](context.Background(), mamori.WithProvider(prov))
+	if err != nil {
+		fmt.Println("watch failed:", err)
+		return
+	}
+	defer func() { _ = w.Close() }()
+
+	report := w.Status()
+	for _, f := range report.Fields {
+		fmt.Printf("%s ref=%s sensitive=%t error=%q\n", f.Path, f.Ref, f.Sensitive, f.LastError)
+	}
+	fmt.Println("healthy:", report.Healthy)
+	fmt.Println("ready:  ", w.Health() == nil)
+
+	// Output:
+	// Token ref=mem://token sensitive=true error=""
+	// healthy: true
+	// ready:   true
+}
+
+// Doctor resolves every field once, without starting a watcher, and reports
+// every failure rather than stopping at the first. Run it as a pre-deploy check
+// to catch a typo'd ref or a rotated-away secret before it ships.
+func ExampleDoctor() {
+	type Config struct {
+		Present string `source:"mem://present"`
+		Missing string `source:"mem://missing"`
+	}
+
+	prov := mamoritest.NewProvider("mem")
+	prov.Set("present", "value")
+	// "missing" is deliberately never Set.
+
+	// err is non-nil only when Config itself cannot be walked as a config
+	// struct. A field that fails to resolve is reported, not returned, so one
+	// call surfaces every problem instead of just the first.
+	report, err := mamori.Doctor[Config](context.Background(), mamori.WithProvider(prov))
+	if err != nil {
+		fmt.Println("not a usable config struct:", err)
+		return
+	}
+
+	for _, f := range report.Fields {
+		if f.LastKind == "" {
+			fmt.Printf("%s: ok\n", f.Path)
+			continue
+		}
+		fmt.Printf("%s: %s\n", f.Path, f.LastKind)
+	}
+	fmt.Println("all refs reachable:", report.Healthy)
+
+	// Output:
+	// Present: ok
+	// Missing: not_found
+	// all refs reachable: false
+}
+
+// ParseRefs turns a `source` tag into the chain of refs it denotes. A comma is
+// a separator only when what follows it looks like a scheme, so a comma inside
+// an opaque path or a query option is preserved.
+func ExampleParseRefs() {
+	for _, tag := range []string{
+		"env:PORT,aws-ps://svc/port",  // compact chain
+		"env:PORT, aws-ps://svc/port", // same chain, written with a space
+		"exec:echo a, b",              // one opaque command, not a chain
+		"vault://kv?tags=a,b",         // comma inside a query option
+	} {
+		refs, err := mamori.ParseRefs(tag)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		fmt.Printf("%d ref(s) from %q:", len(refs), tag)
+		for _, r := range refs {
+			fmt.Printf(" [%s %s]", r.Scheme, r.Path)
+		}
+		fmt.Println()
+	}
+
+	// Output:
+	// 2 ref(s) from "env:PORT,aws-ps://svc/port": [env PORT] [aws-ps svc/port]
+	// 2 ref(s) from "env:PORT, aws-ps://svc/port": [env PORT] [aws-ps svc/port]
+	// 1 ref(s) from "exec:echo a, b": [exec echo a, b]
+	// 1 ref(s) from "vault://kv?tags=a,b": [vault kv]
+}

--- a/ref.go
+++ b/ref.go
@@ -108,7 +108,15 @@ func ParseRef(tag string) (Ref, error) {
 // schemeStart matches a scheme-like token at the start of a string, e.g.
 // "aws-sm:" or "env:". It is how ParseRefs decides a comma is a chain
 // separator rather than a comma inside a path or query.
-var schemeStart = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
+//
+// Leading whitespace is skipped so that a chain written the way a human writes
+// a list - `env:PORT, aws-ps://svc/port` - splits identically to its compact
+// form. Without that, the space would stop the scheme from matching, the whole
+// tail would collapse into the first ref's path, and the resulting broken ref
+// would fail silently at resolve time rather than at parse time. Whitespace
+// alone is never enough: what follows it must still look like a scheme, so
+// `exec:echo a, b` stays the single ref it has always been.
+var schemeStart = regexp.MustCompile(`^\s*[a-zA-Z][a-zA-Z0-9+.\-]*:`)
 
 // ParseRefs parses a `source` tag that may hold a comma-separated precedence
 // chain of refs, e.g. "env:PORT,aws-ps://svc/port". This is the entry point
@@ -122,6 +130,12 @@ var schemeStart = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
 // or an opaque exec: path (exec:echo a,b) is preserved as part of that ref. To
 // force a literal comma that would otherwise be read as a separator,
 // percent-encode it as %2C.
+//
+// Whitespace around a separator is ignored, so the spaced form
+// "env:PORT, aws-ps://svc/port" yields exactly the same chain as the compact
+// "env:PORT,aws-ps://svc/port". A space does not by itself make a comma a
+// separator: what follows it must still look like a scheme, so
+// "exec:echo a, b" remains one ref.
 //
 // Because of that rule, a doubled or trailing comma is not a split point (no
 // scheme token follows it) and is instead kept as part of the adjacent ref's

--- a/ref_test.go
+++ b/ref_test.go
@@ -96,6 +96,21 @@ func TestParseRefs(t *testing.T) {
 			wantSchemes: []string{"env", "env", "aws-sm"},
 		},
 		{
+			name:        "space after the separator still splits",
+			in:          "env:PORT, aws-ps://svc/port",
+			wantSchemes: []string{"env", "aws-ps"},
+		},
+		{
+			name:        "space on both sides of the separator still splits",
+			in:          "env:PORT , aws-ps://svc/port",
+			wantSchemes: []string{"env", "aws-ps"},
+		},
+		{
+			name:        "spaces around every separator in a three-ref chain",
+			in:          "env:A, env:B, aws-sm://c",
+			wantSchemes: []string{"env", "env", "aws-sm"},
+		},
+		{
 			name:    "empty",
 			in:      "",
 			wantErr: true,
@@ -123,6 +138,66 @@ func TestParseRefs(t *testing.T) {
 			}
 		})
 	}
+
+	// A chain written the way a human writes a list - with a space after each
+	// comma - must produce the same refs as the compact form. Getting this
+	// wrong is silent: the whole tail collapses into the first ref's path, that
+	// ref resolves not-found, and the field quietly takes its onfail policy
+	// instead of consulting the rest of the chain.
+	t.Run("spaced separator yields the same refs as the compact form", func(t *testing.T) {
+		compact, err := ParseRefs("env:PORT,aws-ps://svc/port")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		spaced, err := ParseRefs("env:PORT, aws-ps://svc/port")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(spaced) != len(compact) {
+			t.Fatalf("spaced form got %d refs %+v, compact form got %d", len(spaced), spaced, len(compact))
+		}
+		for i := range compact {
+			if spaced[i].Scheme != compact[i].Scheme || spaced[i].Path != compact[i].Path {
+				t.Errorf("refs[%d] = scheme %q path %q, want scheme %q path %q",
+					i, spaced[i].Scheme, spaced[i].Path, compact[i].Scheme, compact[i].Path)
+			}
+		}
+	})
+
+	t.Run("spaced separator does not leak whitespace into the path", func(t *testing.T) {
+		refs, err := ParseRefs("env:PORT , aws-ps://svc/port")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(refs) != 2 {
+			t.Fatalf("got %d refs %+v, want 2", len(refs), refs)
+		}
+		if refs[0].Path != "PORT" {
+			t.Errorf("refs[0].Path = %q, want %q", refs[0].Path, "PORT")
+		}
+		if refs[1].Path != "svc/port" {
+			t.Errorf("refs[1].Path = %q, want %q", refs[1].Path, "svc/port")
+		}
+		if refs[1].Raw != "aws-ps://svc/port" {
+			t.Errorf("refs[1].Raw = %q, want %q", refs[1].Raw, "aws-ps://svc/port")
+		}
+	})
+
+	t.Run("space before a non-scheme word is still not a separator", func(t *testing.T) {
+		// "exec:echo a, b" is one command whose argument list happens to contain
+		// a comma and a space. Nothing after the comma looks like a scheme, so
+		// it must stay a single ref exactly as "exec:echo a,b" does.
+		refs, err := ParseRefs("exec:echo a, b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(refs) != 1 {
+			t.Fatalf("got %d refs %+v, want 1", len(refs), refs)
+		}
+		if refs[0].Path != "echo a, b" {
+			t.Errorf("Path = %q, want %q", refs[0].Path, "echo a, b")
+		}
+	})
 
 	t.Run("query comma preserved in tags opt", func(t *testing.T) {
 		refs, err := ParseRefs("vault://kv?tags=a,b")

--- a/secret/example_test.go
+++ b/secret/example_test.go
@@ -1,0 +1,97 @@
+package secret_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/xavidop/mamori/secret"
+)
+
+// String redacts itself everywhere a value is normally printed. Nothing short
+// of an explicit Reveal produces the plaintext, so an accidental log line or
+// error message cannot leak a credential.
+func ExampleString() {
+	pw := secret.NewString("hunter2")
+
+	fmt.Println(pw)          // Stringer
+	fmt.Printf("%v\n", pw)   // default verb
+	fmt.Printf("%s\n", pw)   // string verb
+	fmt.Printf("%q\n", pw)   // quoted
+	fmt.Println(pw.Reveal()) // the one explicit, greppable escape hatch
+
+	// Output:
+	// [REDACTED]
+	// [REDACTED]
+	// [REDACTED]
+	// "[REDACTED]"
+	// hunter2
+}
+
+// Marshaling a struct that carries a String emits the redaction, not the
+// secret, so a config dump or an API response is safe by construction.
+func ExampleString_MarshalJSON() {
+	type Config struct {
+		User     string        `json:"user"`
+		Password secret.String `json:"password"`
+	}
+
+	out, err := json.Marshal(Config{User: "svc-api", Password: secret.NewString("hunter2")})
+	if err != nil {
+		fmt.Println("marshal failed:", err)
+		return
+	}
+	fmt.Println(string(out))
+
+	// Output:
+	// {"user":"svc-api","password":"[REDACTED]"}
+}
+
+// String implements slog.LogValuer, so structured logging redacts it too, even
+// when it is passed straight to a log call.
+func ExampleString_LogValue() {
+	// A handler with time and level stripped, so the example output is stable.
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
+
+	logger.Info("connecting", "user", "svc-api", "password", secret.NewString("hunter2"))
+
+	// Output:
+	// msg=connecting user=svc-api password=[REDACTED]
+}
+
+// Reveal is deliberately the only way out. Keeping it explicit makes every
+// place a secret becomes plaintext a one-line grep away in code review.
+func ExampleString_Reveal() {
+	token := secret.NewString("sk-live-abc123")
+
+	// Pass the plaintext at the exact point it is needed, not before.
+	authHeader := "Bearer " + token.Reveal()
+
+	fmt.Println("stored: ", token)
+	fmt.Println("on wire:", authHeader)
+
+	// Output:
+	// stored:  [REDACTED]
+	// on wire: Bearer sk-live-abc123
+}
+
+// Bytes is the same guarantee for binary secrets such as a private key or a
+// certificate, and Zero scrubs the backing memory when the value is done.
+func ExampleBytes() {
+	key := secret.NewBytes([]byte("-----BEGIN PRIVATE KEY-----"))
+
+	fmt.Println(key)
+	fmt.Println(len(key.Reveal()), "bytes revealed")
+
+	// Output:
+	// [REDACTED]
+	// 27 bytes revealed
+}

--- a/site/src/pages/docs/concepts/source-chains.md
+++ b/site/src/pages/docs/concepts/source-chains.md
@@ -77,20 +77,29 @@ The rule to hold onto: **`default:` applies only to genuine absence**, never to 
 
 ## The comma-split rule
 
-A comma splits the chain only when the text right after it looks like a new scheme (matches `^[a-zA-Z][a-zA-Z0-9+.-]*:`). A comma anywhere else, inside a query string or an opaque path, stays part of that ref's value:
+A comma splits the chain only when the text right after it looks like a new scheme (matches `^\s*[a-zA-Z][a-zA-Z0-9+.-]*:`). A comma anywhere else, inside a query string or an opaque path, stays part of that ref's value:
 
 ```go
 // Two refs: "env:PORT" and "aws-ps://svc/port"
 Port string `source:"env:PORT,aws-ps://svc/port"`
+
+// The same two refs: whitespace around the separator is ignored
+Port string `source:"env:PORT, aws-ps://svc/port"`
 
 // One ref: the comma in the query string is not a chain separator
 Tags string `source:"consul://kv/tags?filter=a,b"`
 
 // One ref: the comma in the exec: path is not a chain separator
 Report string `source:"exec:echo a,b"`
+
+// Still one ref: a space does not make a comma a separator on its own,
+// because "b" does not look like a scheme
+Report string `source:"exec:echo a, b"`
 ```
 
-Because of that rule, a doubled or trailing comma is not a split point (no scheme follows it) and is kept as part of the adjacent ref's value: `env:A,,env:B` yields a first ref with path `A,`, which resolves not-found and falls through.
+Whitespace around a separator is ignored, so the spaced form yields exactly the same chain as the compact one and neither leaks a stray space into a ref's path. That tolerance is deliberate: writing a list with a space after each comma is the natural thing to do, and a chain that silently collapsed into a single unresolvable ref would fail at resolve time rather than at parse time.
+
+Because of the scheme rule, a doubled or trailing comma is not a split point (no scheme follows it) and is kept as part of the adjacent ref's value: `env:A,,env:B` yields a first ref with path `A,`, which resolves not-found and falls through.
 
 To force a literal comma where it would otherwise split, percent-encode it as `%2C`. mamori does not decode it back; the parsed path keeps the literal `%2C`:
 


### PR DESCRIPTION
<!-- Thanks for contributing to mamori! Please fill this out so reviewers have context. -->

## What & why

<!-- What does this change do, and why is it needed? Link any related issue. -->

Closes #

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] New provider module
- [ ] Middleware
- [ ] Docs / examples
- [ ] CI / release / tooling

## Checklist

- [ ] `go test ./...` passes for every affected module (`make test`)
- [ ] `go vet ./...` and `golangci-lint run` are clean (`make lint`)
- [ ] New/changed behavior is covered by tests
- [ ] Public API changes have doc comments
- [ ] Secret values are never logged or rendered unredacted

## For new or changed providers

- [ ] The provider passes the `providertest` conformance kit (`providertest.Run`)
- [ ] `Resolve` returns an error satisfying `errors.Is(err, mamori.ErrNotFound)` for missing values
- [ ] `Value.Version` is set from a native revision (or `mamori.VersionHash`) and changes when the value changes
- [ ] Secret-bearing schemes set `Value.Sensitive = true`
- [ ] `Watch` is implemented only if the backend has native change notification
- [ ] README documents schemes, ref grammar, auth, and what is verified vs needs a live backend

## Notes for reviewers

<!-- Anything else worth calling out. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Mamori configuration provider, including native server-sent event updates.
  * Added examples covering configuration loading, watching, validation, health checks, secret handling, and reference parsing.

* **Improvements**
  * Source chains now tolerate whitespace around comma separators while preserving commas in command arguments and query values.
  * Expanded cross-platform validation, security checks, coverage reporting, and performance benchmarks.

* **Documentation**
  * Updated provider listings and clarified source-chain parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->