### PR TITLE
feat: RFC 6901 JSON Pointer nested key selection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,14 @@ Read the [Write a provider guide](https://mamorigo.dev/docs/writing-a-provider) 
    backend, also set `NoResolveErrors: true` (the unit-test run against the
    fake already covers classification).
 
+   If your `#key` fragment selects into a JSON payload via `mamori.SelectKey`,
+   also supply `providertest.Config.PointerRef` so the `JSONPointerSelection`
+   case exercises RFC 6901 JSON Pointer selection (`#/credentials/password`,
+   `#/replicas/5/host`) against your provider. Leave `PointerRef` `nil`, with a
+   comment naming why, when the fragment is a backend-native key, a facet
+   selector on an evaluated result, or unused - the case skips rather than
+   failing.
+
 6. Add a `README.md` documenting schemes, ref grammar, auth, and what is verified vs needs a live backend. A provider that passes `providertest` gets listed in the root README with a badge.
 7. If you classified errors beyond not-found (step 3), also: add an `## Error classification` section to the module's `README.md`, mirror it onto the module's docs-site page, and flip that module's row in both coverage tables (the root `README.md` and `site/src/pages/docs/providers/index.md`).
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ type Config struct {
     // centrally managed Parameter Store value, otherwise the default.
     Port       string        `source:"env:PORT,aws-ps://svc/port" default:"8080"`
 
+    // A nested field, selected with an RFC 6901 JSON Pointer fragment
+    DBUser     string        `source:"aws-sm://prod/db#/credentials/user"`
+
     // A file-backed value, hot-reloaded via fsnotify
     TLSCert    []byte        `source:"file:///etc/tls/tls.crt"`
 
@@ -80,6 +83,7 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 ## What makes it different
 
 - **Typed & tag-driven** - one struct, multiple sources, generics API (`Load[T]` / `Watch[T]`).
+- **Nested selection** - `#/credentials/password` is an RFC 6901 JSON Pointer, addressing a value at any depth through objects and array elements; any other fragment (`#ca.crt`, `#tls.key`) stays a literal top-level key, exactly as before.
 - **Precedence chains** - `source:"env:PORT,aws-ps://svc/port"` tries sources in priority order: the first to yield a value wins, not-found falls through to the next, and a real error stops the walk and applies the field's `onfail` policy instead of silently sliding to a lower-priority source. Every position is watched, so precedence is live.
 - **Reconciled at runtime** - native watch where the backend supports it (Kubernetes informers, Consul blocking queries, fsnotify), polling with jitter everywhere else, and lease-aware pre-expiry refresh for Vault.
 - **Atomic & validated** - an update that fails validation is *rejected*; `Get()` keeps returning the last good config. Config never enters a broken state mid-flight.

--- a/doc.go
+++ b/doc.go
@@ -20,6 +20,12 @@
 //
 //	cfg, err := mamori.Load[Config](ctx)
 //
+// A source tag's optional #key fragment selects one field from a structured
+// payload: a fragment beginning with '/' is an RFC 6901 JSON Pointer
+// addressing a value at any depth ("#/credentials/password"), and any other
+// fragment is a literal top-level key ("#ca.crt"), exactly as before. See
+// [ParseRef] and [SelectKey].
+//
 // # Watching
 //
 // [Watch] performs an initial fail-fast load and then keeps the configuration

--- a/docs/superpowers/plans/2026-07-27-ref-grammar.md
+++ b/docs/superpowers/plans/2026-07-27-ref-grammar.md
@@ -232,6 +232,8 @@ func TestSelectPointerErrors(t *testing.T) {
 		{"descend into scalar", "/replicas/0/host/nope", ErrInvalid},
 		{"non-numeric array token", "/replicas/five", ErrInvalid},
 		{"leading zero index", "/replicas/05", ErrInvalid},
+		{"plus-signed index", "/replicas/+1", ErrInvalid},
+		{"negative zero index", "/replicas/-0", ErrInvalid},
 		{"dash token", "/replicas/-", ErrInvalid},
 		{"bad escape", "/replicas/0/a~2b", ErrInvalid},
 		{"trailing tilde", "/replicas/0/a~", ErrInvalid},
@@ -389,22 +391,39 @@ func unescapeToken(tok string) (string, error) {
 	return b.String(), nil
 }
 
-// arrayIndex parses an RFC 6901 array index: either "0", or a non-zero digit
-// followed by digits. A leading zero is rejected rather than silently accepted
-// so that "/05" fails loudly instead of aliasing "/5". The "-" token, which
-// RFC 6901 defines as one-past-the-end for JSON Patch's add operation, can
-// never address an existing value and is rejected for the same reason.
+// arrayIndex parses an RFC 6901 array index. The grammar is digits only,
+// "0" / (%x31-39 *DIGIT): no sign character is permitted at all, so a leading
+// zero is rejected rather than silently accepted (so that "/05" fails loudly
+// instead of aliasing "/5"), and this validates that every byte of tok is an
+// ASCII digit before calling strconv.Atoi, rather than leaning on Atoi's sign
+// tolerance plus post-hoc guards. Atoi alone would accept "+1" as 1 and "-0"
+// as 0 (Go's int has no negative zero for an i < 0 check to catch), letting a
+// pointer like "/replicas/+1" silently address a real element instead of
+// failing loudly. The "-" token, which RFC 6901 defines as one-past-the-end
+// for JSON Patch's add operation, can never address an existing value and is
+// rejected for the same reason.
+//
+// The byte-range check is deliberate rather than unicode.IsDigit: the latter
+// accepts non-ASCII digits such as the Arabic-Indic set, which strconv.Atoi
+// would then reject anyway, turning a clear "not an array index" into a
+// confusing parse failure.
 func arrayIndex(tok string) (int, error) {
-	switch {
-	case tok == "-":
+	switch tok {
+	case "-":
 		return 0, fmt.Errorf("token %q addresses one past the end of the array and can never select a value: %w", tok, ErrInvalid)
-	case tok == "":
+	case "":
 		return 0, fmt.Errorf("empty array index token: %w", ErrInvalid)
-	case len(tok) > 1 && tok[0] == '0':
+	}
+	for i := 0; i < len(tok); i++ {
+		if tok[i] < '0' || tok[i] > '9' {
+			return 0, fmt.Errorf("token %q is not an array index: %w", tok, ErrInvalid)
+		}
+	}
+	if len(tok) > 1 && tok[0] == '0' {
 		return 0, fmt.Errorf("array index %q has a leading zero: %w", tok, ErrInvalid)
 	}
 	i, err := strconv.Atoi(tok)
-	if err != nil || i < 0 {
+	if err != nil {
 		return 0, fmt.Errorf("token %q is not an array index: %w", tok, ErrInvalid)
 	}
 	return i, nil

--- a/docs/superpowers/plans/2026-07-27-ref-grammar.md
+++ b/docs/superpowers/plans/2026-07-27-ref-grammar.md
@@ -549,23 +549,59 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 
 **Interfaces:**
 - Consumes: `mamori.SelectKey` behavior from Task 1.
-- Produces: `providertest.Config.NoStructuredPayload bool`, and a `JSONPointerSelection` subtest registered in `Run`.
+- Produces: `providertest.Config.PointerRef func(key, fragment string) string`, and a `JSONPointerSelection` subtest registered in `Run`.
 
-- [ ] **Step 1: Add the opt-out field to `Config`**
+**Design correction, read this before starting.** An earlier draft of this task
+made the case unconditional and appended a fragment to `c.Ref(key)`'s output.
+Both were wrong:
+
+- `Config.Ref` is **not** fragment-free by convention. `vault`
+  (`providers/vault/vault_test.go:137`), `mongodb`
+  (`providers/mongodb/mongodb_test.go:205`), `firestore`
+  (`providers/firestore/firestore_test.go:166`), and `k8s`
+  (`providers/k8s/k8s_test.go:166,206`) all bake `#value` into it, and `doppler`
+  (`providers/doppler/doppler_test.go:346`) bakes `#<key>`. Appending would
+  produce `vault://secret/x#value#/outer/inner`.
+- A fragment does not mean a JSON selector in every provider. See spec section
+  5.5: it is a backend-native key in `k8s` and `doppler`, and means nothing at
+  all in `providers/mamori` (decision D9) or in flag providers returning a bare
+  `bool`. Those providers are **not defective** for lacking pointer support.
+
+Hence: a ref *builder*, and an opt-in case.
+
+- [ ] **Step 1: Add the opt-in field to `Config`**
 
 Insert after the `NoResolveErrors` field in `providertest/providertest.go`:
 
 ```go
-	// NoStructuredPayload declares that this provider's values are never JSON
-	// documents, so fragment selection cannot be exercised against it. A
-	// feature-flag provider returning a bare bool, or a backend whose values are
-	// opaque binary, is the usual case.
+	// PointerRef builds a ref whose #fragment selects a value out of a JSON
+	// payload, given a logical key and the fragment to use (including its
+	// leading '#'). Supply it only when this provider's fragment slot IS a JSON
+	// selector routed through mamori.SelectKey; leave it nil otherwise, and the
+	// JSONPointerSelection case skips.
 	//
-	// Like NoResolveErrors, this is a deliberate, greppable declaration rather
-	// than a silent gap: a provider that stores JSON and does not call
-	// mamori.SelectKey has a real bug, and the JSONPointerSelection case exists
-	// to catch exactly that.
-	NoStructuredPayload bool
+	// It is a builder rather than a bool because Config.Ref is not fragment-free
+	// by convention: several providers bake a fixed fragment into it (vault,
+	// mongodb, firestore, and k8s all produce "...#value"), so the case cannot
+	// simply append its own fragment to Ref's output. A builder lets each
+	// provider say where its selector goes:
+	//
+	//	PointerRef: func(key, frag string) string {
+	//	    return "vault://secret/" + key + frag
+	//	}
+	//
+	// Leaving it nil is not a confession of a gap. A fragment means three
+	// different things across this ecosystem: a JSON selector (most providers),
+	// a backend-native key (a Kubernetes Secret data key, a Doppler secret
+	// name), or nothing at all (providers/mamori never reads ref.Key by design;
+	// a flag provider returning a bare bool has no payload to select from).
+	// Only the first can be tested for pointer support, and the other two are
+	// not defective for failing such a test.
+	//
+	// What this case DOES catch, for a provider that supplies it: hand-rolling a
+	// top-level-only key lookup instead of calling mamori.SelectKey, which
+	// passes every other case in this kit and fails only this one.
+	PointerRef func(key, fragment string) string
 ```
 
 - [ ] **Step 2: Write the conformance case**
@@ -573,14 +609,18 @@ Insert after the `NoResolveErrors` field in `providertest/providertest.go`:
 Add to `providertest/providertest.go`:
 
 ```go
-// testJSONPointerSelection verifies the provider routes its #fragment through
-// mamori.SelectKey, so nested selection works identically everywhere. A
-// provider that hand-rolls a top-level-only key lookup passes every other case
-// in this kit and fails this one.
+// testJSONPointerSelection verifies a provider whose #fragment is a JSON
+// selector routes it through mamori.SelectKey, so nested selection behaves
+// identically everywhere. A provider that hand-rolls a top-level-only key
+// lookup passes every other case in this kit and fails only this one.
+//
+// It skips when Config.PointerRef is nil, because a fragment is not a JSON
+// selector in every provider: it is a backend-native key in some and means
+// nothing in others. See PointerRef's doc comment.
 func testJSONPointerSelection(t *testing.T, c Config) {
 	t.Helper()
-	if c.NoStructuredPayload {
-		t.Skip("providertest: provider declares NoStructuredPayload; values are never JSON documents")
+	if c.PointerRef == nil {
+		t.Skip("providertest: provider supplies no PointerRef; its #fragment is not a JSON selector")
 		return
 	}
 	ctx := context.Background()
@@ -592,13 +632,13 @@ func testJSONPointerSelection(t *testing.T, c Config) {
 		t.Fatalf("Seed: %v", err)
 	}
 
-	cases := []struct{ frag, want string }{
+	ok := []struct{ frag, want string }{
 		{"#/outer/inner", "deep"},
 		{"#/list/1/n", "one"},
 		{"#dotted.key", "literal"}, // literal fragment, not a path
 	}
-	for _, tc := range cases {
-		ref, err := mamori.ParseRef(c.Ref(key) + tc.frag)
+	for _, tc := range ok {
+		ref, err := mamori.ParseRef(c.PointerRef(key, tc.frag))
 		if err != nil {
 			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
 		}
@@ -611,20 +651,22 @@ func testJSONPointerSelection(t *testing.T, c Config) {
 		}
 	}
 
-	ref, err := mamori.ParseRef(c.Ref(key) + "#/outer/absent")
-	if err != nil {
-		t.Fatalf("ParseRef: %v", err)
+	bad := []struct {
+		frag string
+		want error
+	}{
+		{"#/outer/absent", mamori.ErrNotFound},
+		{"#/list/9", mamori.ErrNotFound},
+		{"#/outer/inner/deeper", mamori.ErrInvalid},
 	}
-	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrNotFound) {
-		t.Errorf("absent pointer err = %v, want ErrNotFound", err)
-	}
-
-	ref, err = mamori.ParseRef(c.Ref(key) + "#/outer/inner/deeper")
-	if err != nil {
-		t.Fatalf("ParseRef: %v", err)
-	}
-	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrInvalid) {
-		t.Errorf("descend-into-scalar err = %v, want ErrInvalid", err)
+	for _, tc := range bad {
+		ref, err := mamori.ParseRef(c.PointerRef(key, tc.frag))
+		if err != nil {
+			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
+		}
+		if _, err := p.Resolve(ctx, ref); !errors.Is(err, tc.want) {
+			t.Errorf("Resolve(%q) err = %v, want %v", tc.frag, err, tc.want)
+		}
 	}
 }
 ```
@@ -639,14 +681,33 @@ In `Run`, after the `NotFoundTyped` line:
 	t.Run("JSONPointerSelection", func(t *testing.T) { testJSONPointerSelection(t, c) })
 ```
 
-- [ ] **Step 4: Run the conformance kit across every provider module**
+- [ ] **Step 4: Wire `PointerRef` into the providers whose fragment IS a JSON selector**
 
-Run:
+The case is inert until providers opt in, so opting in the eligible ones is
+part of this task. For each provider module, read how its `Resolve` treats
+`ref.Key`:
+
+- **Calls `mamori.SelectKey`** → add a `PointerRef` to its `providertest.Config`,
+  built from the same shape as its existing `Ref` but with the caller's fragment
+  in place of any baked-in one. For `vault`, whose `Ref` is
+  `"vault://secret/" + key + "#value"`, that is
+  `func(key, frag string) string { return "vault://secret/" + key + frag }`.
+- **Does its own backend-native lookup, or ignores `ref.Key`** → leave
+  `PointerRef` nil. Do not add one to force coverage.
+
+Then run:
 ```bash
 go test -race ./providertest/...
 for d in providers/*/; do (cd "$d" && go test -race ./... 2>&1 | tail -3); done
 ```
-Expected: PASS everywhere, or a clear `NoStructuredPayload` skip. Any provider that fails here stores JSON but does not call `mamori.SelectKey`. Fix by setting `NoStructuredPayload` only if its values genuinely are never JSON; otherwise the provider has a real bug and this case just found it. **Report any such provider rather than silently setting the flag.**
+
+Expected: PASS everywhere, with `JSONPointerSelection` either passing or
+skipping. **A provider that supplies a `PointerRef` and then fails the case has
+a real bug.** Report it; do not remove the `PointerRef` to make the suite green.
+Known suspects from an earlier sweep, to check specifically: `dynamodb` and
+`onepassword`. If either is genuinely broken, leave it failing, report it, and
+stop; those are pre-existing bugs that will be fixed in their own PR outside
+this stack, not folded in here.
 
 - [ ] **Step 5: Commit**
 
@@ -654,15 +715,19 @@ Expected: PASS everywhere, or a clear `NoStructuredPayload` skip. Any provider t
 git add providertest/providertest.go providers/
 git commit -m "test: conformance case for JSON Pointer fragment selection
 
-JSONPointerSelection verifies every provider routes its #fragment through
-mamori.SelectKey, so nested selection, literal dotted keys, and the
-ErrNotFound/ErrInvalid split behave identically across the ecosystem. A
-provider that hand-rolls a top-level-only lookup passes every other case in
-the kit and fails this one.
+JSONPointerSelection verifies a provider whose #fragment is a JSON selector
+routes it through mamori.SelectKey, so nested selection, literal dotted keys,
+and the ErrNotFound/ErrInvalid split behave identically across the ecosystem.
+A provider that hand-rolls a top-level-only lookup passes every other case in
+the kit and fails only this one.
 
-Config.NoStructuredPayload opts out providers whose values are never JSON
-documents, following the NoResolveErrors precedent of an explicit, greppable
-declaration rather than a silent skip.
+The case is opt-in via Config.PointerRef, a ref builder rather than a bool, for
+two reasons. Config.Ref is not fragment-free by convention: vault, mongodb,
+firestore, and k8s all bake #value into it, so the case cannot append its own
+fragment. And a fragment is not a JSON selector everywhere: it is a
+backend-native key in k8s and doppler, and means nothing in providers/mamori,
+which never reads ref.Key by design. Those providers are not defective for
+lacking pointer support, so they supply no PointerRef and the case skips.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 ```

--- a/docs/superpowers/specs/2026-07-27-ref-grammar-design.md
+++ b/docs/superpowers/specs/2026-07-27-ref-grammar-design.md
@@ -169,12 +169,23 @@ conformance case depends on it. Three distinct meanings exist today:
    These gain pointer support.
 2. **A backend-native key.** The Kubernetes provider reads `Secret.Data`, a Go
    map, so `#ca.crt` names a map entry, not a JSON path. Doppler's fragment
-   names the secret itself. These correctly do their own lookup and gain
-   nothing, because there is no document to point into.
+   names the secret itself. `flipt` and `unleash` belong here too: their
+   fragment is a **facet selector** on an already-evaluated result rather than
+   a path into a document (`flipt`: empty or `#attachment`; `unleash`: empty,
+   `#variant`, or `#payload`). All of these correctly do their own lookup and
+   gain nothing from pointer support, because there is no document to point
+   into.
 3. **Nothing.** `providers/mamori`'s client never reads `ref.Key` at all;
    per decision D9 of the operational-layer spec, field selection is
-   server-side only. Feature-flag providers returning a bare `bool` or `string`
-   (`unleash`, `split`, `flipt`) have no payload to select from either.
+   server-side only. `providers/split` is the same: its `Resolve` consults
+   only `ref.Path` and the `?key=` query option, never `ref.Key`, so a split
+   ref carries no fragment grammar at all - not even a facet selector.
+
+A genuine gap, out of scope here: `flipt`'s `#attachment` and `unleash`'s
+`#payload` can themselves be a JSON string, and there is no second-level
+selector to reach into it once the facet is chosen - a caller who needs one
+field out of an attachment or payload must decode the whole string
+(`flatten:"json"`) rather than compose a pointer onto the facet fragment.
 
 Only category 1 can be conformance-tested for pointer support, and a provider
 in category 2 or 3 is not defective for failing such a test. The conformance

--- a/docs/superpowers/specs/2026-07-27-ref-grammar-design.md
+++ b/docs/superpowers/specs/2026-07-27-ref-grammar-design.md
@@ -158,11 +158,37 @@ struct field without a second rule.
 
 ### 5.5 Blast radius
 
-All 26 provider files calling `mamori.SelectKey` inherit this with no change. Providers
-that do their own key lookup because their backend is natively keyed (the
-Kubernetes provider reads `Secret.Data`, a Go map) are unaffected and keep
-literal-key semantics, which is correct for them: a Kubernetes Secret has no
-nesting to point into.
+All 26 provider files calling `mamori.SelectKey` inherit this with no change.
+
+**The fragment slot does not mean the same thing in every provider.** This was
+underestimated in the first draft of this spec and is recorded here because the
+conformance case depends on it. Three distinct meanings exist today:
+
+1. **A JSON selector.** `aws-sm`, `s3`, `consul`, `redis`, and most others treat
+   the fragment as a key into a JSON payload and route it through `SelectKey`.
+   These gain pointer support.
+2. **A backend-native key.** The Kubernetes provider reads `Secret.Data`, a Go
+   map, so `#ca.crt` names a map entry, not a JSON path. Doppler's fragment
+   names the secret itself. These correctly do their own lookup and gain
+   nothing, because there is no document to point into.
+3. **Nothing.** `providers/mamori`'s client never reads `ref.Key` at all;
+   per decision D9 of the operational-layer spec, field selection is
+   server-side only. Feature-flag providers returning a bare `bool` or `string`
+   (`unleash`, `split`, `flipt`) have no payload to select from either.
+
+Only category 1 can be conformance-tested for pointer support, and a provider
+in category 2 or 3 is not defective for failing such a test. The conformance
+case is therefore **opt-in**: `providertest.Config.PointerRef` is supplied only
+by a provider whose fragment slot is a JSON selector, and the case skips when it
+is nil.
+
+`PointerRef` is a ref *builder* rather than a boolean because
+`providertest.Config.Ref` is not fragment-free by convention. Several providers
+bake a fixed fragment into it (`vault://secret/<key>#value` at
+`providers/vault/vault_test.go:137`; the same shape in `mongodb`, `firestore`,
+and `k8s`), so appending a second fragment to `Ref`'s output would produce
+`vault://secret/x#value#/outer/inner`. A builder lets each provider say where
+its selector goes.
 
 ## 6. Feature 2: `?decode=` value transforms
 
@@ -334,11 +360,14 @@ error rather than an injection vector, and it is documented alongside
 - **Interpolation tests**: expansion in scheme, path, fragment, and query
   position; `$$` escaping; unset-variable error text; merge order across two
   `WithRefVars` calls; expansion inside a chain.
-- **Two new `providertest` cases**: `JSONPointerSelection` and
-  `DecodeOption`, with a `providertest.Config.NoStructuredPayload bool` opt-out
-  for providers whose values are never JSON documents, following the existing
-  `NoResolveErrors` precedent (`providertest/providertest.go:97`) of an explicit,
-  greppable declaration rather than a silent skip.
+- **Two new `providertest` cases**: `JSONPointerSelection` and `DecodeOption`.
+  `JSONPointerSelection` is opt-in via `providertest.Config.PointerRef`
+  (see 5.5): a provider supplies a builder saying how to construct a ref whose
+  fragment is a JSON selector, and the case skips when it is nil, because a
+  provider whose fragment slot is a backend-native key is not defective for
+  lacking pointer support. `DecodeOption` needs no opt-out: `?decode=` is a
+  query option every provider must pass through untouched regardless of what
+  its fragment means.
 - **A fuzz target over `ParseRef` + `SelectKey`.** The repo has no fuzzing
   today; a grammar this size with hand-rolled parsing warrants one, and it costs
   a single `FuzzRefGrammar` function.

--- a/helpers.go
+++ b/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
+	"strings"
 )
 
 // VersionHash produces a stable version string from bytes. Provider authors can
@@ -16,30 +17,48 @@ func VersionHash(b []byte) string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
-// SelectKey extracts a single field named key from a JSON object payload, for
-// refs of the form scheme://path#key. If key is empty, data is returned
-// unchanged. String values are returned unquoted; objects, arrays, numbers, and
-// booleans are returned as their JSON encoding. If the key is absent, SelectKey
-// returns an error wrapping ErrNotFound.
+// SelectKey extracts a single value from a structured payload, for refs of the
+// form scheme://path#key.
+//
+// The fragment is interpreted one of two ways, chosen by its first character:
+//
+//   - A fragment beginning with '/' is an RFC 6901 JSON Pointer, addressing a
+//     value at any depth, through objects and array elements alike:
+//     "#/credentials/password", "#/replicas/5/host". Escapes are RFC 6901's:
+//     "~1" for a literal '/', "~0" for a literal '~'.
+//   - Any other fragment is a literal top-level key, exactly as it has always
+//     been. This is what keeps "#ca.crt" addressing the key named "ca.crt"
+//     rather than a path, which matters because "tls.crt"/"tls.key"/"ca.crt"
+//     are the canonical Kubernetes TLS secret keys and dotted keys are the norm
+//     in ConfigMaps and Java properties files.
+//
+// If key is empty, data is returned unchanged. String values are returned
+// unquoted; objects, arrays, numbers, and booleans are returned as their JSON
+// encoding, byte-for-byte as they appeared in the payload.
+//
+// An absent key or an out-of-range index wraps ErrNotFound, so the field's
+// default: or optional handling applies. A structural mismatch (a pointer
+// descending into a scalar, a non-numeric token against an array, a malformed
+// escape, or a payload that is not JSON) wraps ErrInvalid instead, because it
+// is a malformed request against this payload rather than an absence and must
+// not be silently masked by a default.
 //
 // Provider authors should call SelectKey with ref.Key after fetching the raw
-// payload, so that `#key` selection behaves identically across all providers.
+// payload, so that fragment selection behaves identically across all providers.
 func SelectKey(data []byte, key string) ([]byte, error) {
 	if key == "" {
 		return data, nil
 	}
+	if strings.HasPrefix(key, "/") {
+		return selectPointer(data, key)
+	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, fmt.Errorf("mamori: cannot select key %q: payload is not a JSON object: %w", key, err)
+		return nil, fmt.Errorf("mamori: cannot select key %q: payload is not a JSON object: %w: %w", key, ErrInvalid, err)
 	}
 	raw, ok := obj[key]
 	if !ok {
 		return nil, fmt.Errorf("mamori: key %q not present in payload: %w", key, ErrNotFound)
 	}
-	// If the value is a JSON string, return the unquoted contents.
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		return []byte(s), nil
-	}
-	return raw, nil
+	return unquoteJSON(raw), nil
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -41,3 +41,31 @@ func TestSelectKey(t *testing.T) {
 		t.Errorf("empty key should return payload unchanged")
 	}
 }
+
+func TestSelectKeyLiteralDottedKeysUnchanged(t *testing.T) {
+	// Guards spec decision D1. tls.crt / tls.key / ca.crt are the canonical
+	// Kubernetes TLS secret keys and appear in shipped docs; a dotted key must
+	// never be reinterpreted as a path.
+	payload := []byte(`{"tls.crt":"CERT","tls.key":"KEY","ca.crt":"CA","application.properties":"a=1"}`)
+	want := map[string]string{
+		"tls.crt":                "CERT",
+		"tls.key":                "KEY",
+		"ca.crt":                 "CA",
+		"application.properties": "a=1",
+	}
+	for key, wantVal := range want {
+		got, err := SelectKey(payload, key)
+		if err != nil {
+			t.Fatalf("SelectKey(%q) unexpected error: %v", key, err)
+		}
+		if string(got) != wantVal {
+			t.Errorf("SelectKey(%q) = %q, want %q", key, got, wantVal)
+		}
+	}
+}
+
+func TestSelectKeyNonObjectPayloadIsInvalid(t *testing.T) {
+	if _, err := SelectKey([]byte(`not json`), "k"); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
+	}
+}

--- a/jsonpointer.go
+++ b/jsonpointer.go
@@ -119,22 +119,34 @@ func unescapeToken(tok string) (string, error) {
 	return b.String(), nil
 }
 
-// arrayIndex parses an RFC 6901 array index: either "0", or a non-zero digit
-// followed by digits. A leading zero is rejected rather than silently accepted
-// so that "/05" fails loudly instead of aliasing "/5". The "-" token, which
-// RFC 6901 defines as one-past-the-end for JSON Patch's add operation, can
-// never address an existing value and is rejected for the same reason.
+// arrayIndex parses an RFC 6901 array index. The grammar is digits only,
+// "0" / (%x31-39 *DIGIT): no sign character is permitted at all, so a leading
+// zero is rejected rather than silently accepted (so that "/05" fails loudly
+// instead of aliasing "/5"), and this validates that every byte of tok is an
+// ASCII digit before calling strconv.Atoi, rather than leaning on Atoi's sign
+// tolerance plus post-hoc guards. Atoi alone would accept "+1" as 1 and "-0"
+// as 0 (Go's int has no negative zero for an i < 0 check to catch), letting a
+// pointer like "/replicas/+1" silently address a real element instead of
+// failing loudly. The "-" token, which RFC 6901 defines as one-past-the-end
+// for JSON Patch's add operation, can never address an existing value and is
+// rejected for the same reason.
 func arrayIndex(tok string) (int, error) {
-	switch {
-	case tok == "-":
+	switch tok {
+	case "-":
 		return 0, fmt.Errorf("token %q addresses one past the end of the array and can never select a value: %w", tok, ErrInvalid)
-	case tok == "":
+	case "":
 		return 0, fmt.Errorf("empty array index token: %w", ErrInvalid)
-	case len(tok) > 1 && tok[0] == '0':
+	}
+	for i := 0; i < len(tok); i++ {
+		if tok[i] < '0' || tok[i] > '9' {
+			return 0, fmt.Errorf("token %q is not an array index: %w", tok, ErrInvalid)
+		}
+	}
+	if len(tok) > 1 && tok[0] == '0' {
 		return 0, fmt.Errorf("array index %q has a leading zero: %w", tok, ErrInvalid)
 	}
 	i, err := strconv.Atoi(tok)
-	if err != nil || i < 0 {
+	if err != nil {
 		return 0, fmt.Errorf("token %q is not an array index: %w", tok, ErrInvalid)
 	}
 	return i, nil

--- a/jsonpointer.go
+++ b/jsonpointer.go
@@ -1,0 +1,152 @@
+package mamori
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// selectPointer resolves an RFC 6901 JSON Pointer against a JSON document and
+// returns the addressed value, using the same encoding rule SelectKey applies
+// to a literal key: a JSON string yields its unquoted contents, anything else
+// yields its JSON encoding.
+//
+// The walk descends one level at a time over json.RawMessage rather than
+// unmarshalling the whole document into an any tree. That preserves the exact
+// bytes of a selected object or array: a marshal round trip would sort object
+// keys and drop original whitespace, which would make a pointer-selected value
+// differ byte-for-byte from a literally-selected one and perturb
+// Value.changed's byte comparison for providers that supply no Version.
+//
+// ptr is guaranteed by the caller to begin with '/'.
+func selectPointer(data []byte, ptr string) ([]byte, error) {
+	cur := json.RawMessage(data)
+	// A pointer's leading '/' produces an empty first token that is not a
+	// reference token, so it is dropped.
+	for _, raw := range strings.Split(ptr, "/")[1:] {
+		tok, err := unescapeToken(raw)
+		if err != nil {
+			return nil, fmt.Errorf("mamori: pointer %q: %w", ptr, err)
+		}
+		next, err := descend(cur, tok, ptr)
+		if err != nil {
+			return nil, err
+		}
+		cur = next
+	}
+	return unquoteJSON(cur), nil
+}
+
+// descend resolves one reference token against one node.
+func descend(node json.RawMessage, tok, ptr string) (json.RawMessage, error) {
+	switch containerKind(node) {
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(node, &obj); err != nil {
+			return nil, fmt.Errorf("mamori: pointer %q: malformed object at token %q: %w: %w", ptr, tok, ErrInvalid, err)
+		}
+		v, ok := obj[tok]
+		if !ok {
+			return nil, fmt.Errorf("mamori: pointer %q: key %q not present: %w", ptr, tok, ErrNotFound)
+		}
+		return v, nil
+	case '[':
+		var arr []json.RawMessage
+		if err := json.Unmarshal(node, &arr); err != nil {
+			return nil, fmt.Errorf("mamori: pointer %q: malformed array at token %q: %w: %w", ptr, tok, ErrInvalid, err)
+		}
+		i, err := arrayIndex(tok)
+		if err != nil {
+			return nil, fmt.Errorf("mamori: pointer %q: %w", ptr, err)
+		}
+		if i >= len(arr) {
+			return nil, fmt.Errorf("mamori: pointer %q: index %d out of range (array has %d elements): %w", ptr, i, len(arr), ErrNotFound)
+		}
+		return arr[i], nil
+	default:
+		// A scalar, or a payload that is not JSON at all. Either way the
+		// pointer asks for something this document cannot contain: a
+		// structural mismatch, not an absence, so default:/optional must not
+		// mask it.
+		return nil, fmt.Errorf("mamori: pointer %q: cannot descend into a non-container value at token %q: %w", ptr, tok, ErrInvalid)
+	}
+}
+
+// containerKind reports the first significant byte of raw, which is '{' for an
+// object, '[' for an array, and anything else (or 0 when empty) for a scalar or
+// non-JSON payload.
+func containerKind(raw json.RawMessage) byte {
+	for _, c := range raw {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return c
+		}
+	}
+	return 0
+}
+
+// unescapeToken applies RFC 6901's escaping: "~1" is '/', "~0" is '~'. The
+// order matters and is why this is a single left-to-right pass rather than two
+// strings.ReplaceAll calls: replacing "~0" first would turn the literal "~01"
+// into "~1" and then into "/", which is wrong.
+func unescapeToken(tok string) (string, error) {
+	if !strings.ContainsRune(tok, '~') {
+		return tok, nil
+	}
+	var b strings.Builder
+	b.Grow(len(tok))
+	for i := 0; i < len(tok); i++ {
+		if tok[i] != '~' {
+			b.WriteByte(tok[i])
+			continue
+		}
+		if i+1 >= len(tok) {
+			return "", fmt.Errorf("token %q ends with an unescaped %q: %w", tok, "~", ErrInvalid)
+		}
+		switch tok[i+1] {
+		case '0':
+			b.WriteByte('~')
+		case '1':
+			b.WriteByte('/')
+		default:
+			return "", fmt.Errorf("token %q contains invalid escape %q (want ~0 or ~1): %w", tok, tok[i:i+2], ErrInvalid)
+		}
+		i++
+	}
+	return b.String(), nil
+}
+
+// arrayIndex parses an RFC 6901 array index: either "0", or a non-zero digit
+// followed by digits. A leading zero is rejected rather than silently accepted
+// so that "/05" fails loudly instead of aliasing "/5". The "-" token, which
+// RFC 6901 defines as one-past-the-end for JSON Patch's add operation, can
+// never address an existing value and is rejected for the same reason.
+func arrayIndex(tok string) (int, error) {
+	switch {
+	case tok == "-":
+		return 0, fmt.Errorf("token %q addresses one past the end of the array and can never select a value: %w", tok, ErrInvalid)
+	case tok == "":
+		return 0, fmt.Errorf("empty array index token: %w", ErrInvalid)
+	case len(tok) > 1 && tok[0] == '0':
+		return 0, fmt.Errorf("array index %q has a leading zero: %w", tok, ErrInvalid)
+	}
+	i, err := strconv.Atoi(tok)
+	if err != nil || i < 0 {
+		return 0, fmt.Errorf("token %q is not an array index: %w", tok, ErrInvalid)
+	}
+	return i, nil
+}
+
+// unquoteJSON returns a JSON string's unquoted contents, or raw unchanged for
+// any other JSON value. It is the shared final step of both SelectKey's literal
+// path and selectPointer, so both encode a selected value identically.
+func unquoteJSON(raw json.RawMessage) []byte {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []byte(s)
+	}
+	return raw
+}

--- a/jsonpointer_test.go
+++ b/jsonpointer_test.go
@@ -1,0 +1,110 @@
+package mamori
+
+import (
+	"errors"
+	"testing"
+)
+
+// rfc6901Doc is the example document from RFC 6901 section 5.
+var rfc6901Doc = []byte(`{
+   "foo": ["bar", "baz"],
+   "": 0,
+   "a/b": 1,
+   "c%d": 2,
+   "e^f": 3,
+   "g|h": 4,
+   "i\\j": 5,
+   "k\"l": 6,
+   " ": 7,
+   "m~n": 8
+}`)
+
+func TestSelectPointerRFC6901(t *testing.T) {
+	tests := []struct{ ptr, want string }{
+		{"/foo", `["bar", "baz"]`},
+		{"/foo/0", "bar"},
+		{"/foo/1", "baz"},
+		{"/", "0"},
+		{"/a~1b", "1"},
+		{"/c%d", "2"},
+		{"/e^f", "3"},
+		{"/g|h", "4"},
+		{"/i\\j", "5"},
+		{"/k\"l", "6"},
+		{"/ ", "7"},
+		{"/m~0n", "8"},
+	}
+	for _, tt := range tests {
+		got, err := SelectKey(rfc6901Doc, tt.ptr)
+		if err != nil {
+			t.Fatalf("SelectKey(%q) error: %v", tt.ptr, err)
+		}
+		if string(got) != tt.want {
+			t.Errorf("SelectKey(%q) = %q, want %q", tt.ptr, got, tt.want)
+		}
+	}
+}
+
+// replicaDoc is the array-of-objects shape from spec section 5.2.
+var replicaDoc = []byte(`{"replicas":[` +
+	`{"host":"r0.db","creds":{"user":"app","password":"p0"}},` +
+	`{"host":"r1.db","creds":{"user":"app","password":"p1"}},` +
+	`{"host":"r2.db","creds":{"user":"app","password":"p2"}},` +
+	`{"host":"r3.db","creds":{"user":"app","password":"p3"}},` +
+	`{"host":"r4.db","creds":{"user":"app","password":"p4"}},` +
+	`{"host":"r5.db","creds":{"user":"app","password":"p5"}}]}`)
+
+func TestSelectPointerArrayOfObjects(t *testing.T) {
+	got, err := SelectKey(replicaDoc, "/replicas/5/creds/password")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != "p5" {
+		t.Errorf("= %q, want p5", got)
+	}
+	got, err = SelectKey(replicaDoc, "/replicas/0/host")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if string(got) != "r0.db" {
+		t.Errorf("= %q, want r0.db", got)
+	}
+}
+
+func TestSelectPointerErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		ptr  string
+		want error
+	}{
+		{"absent key", "/replicas/0/missing", ErrNotFound},
+		{"index out of range", "/replicas/99", ErrNotFound},
+		{"descend into scalar", "/replicas/0/host/nope", ErrInvalid},
+		{"non-numeric array token", "/replicas/five", ErrInvalid},
+		{"leading zero index", "/replicas/05", ErrInvalid},
+		{"dash token", "/replicas/-", ErrInvalid},
+		{"bad escape", "/replicas/0/a~2b", ErrInvalid},
+		{"trailing tilde", "/replicas/0/a~", ErrInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SelectKey(replicaDoc, tt.ptr)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("err = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectPointerPreservesBytes(t *testing.T) {
+	// A pointer-selected object must come back byte-identical, not
+	// key-reordered by a marshal round trip.
+	doc := []byte(`{"outer":{"z":1,"a":2,"m":3}}`)
+	got, err := SelectKey(doc, "/outer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"z":1,"a":2,"m":3}` {
+		t.Errorf("= %q, want byte-preserved object", got)
+	}
+}

--- a/jsonpointer_test.go
+++ b/jsonpointer_test.go
@@ -71,28 +71,63 @@ func TestSelectPointerArrayOfObjects(t *testing.T) {
 	}
 }
 
+// scalarKindsDoc exercises each JSON scalar kind (string, number, boolean,
+// null) as the thing a pointer wrongly tries to descend through.
+var scalarKindsDoc = []byte(`{"str":"s","num":42,"bool":true,"null":null}`)
+
 func TestSelectPointerErrors(t *testing.T) {
 	tests := []struct {
 		name string
+		doc  []byte
 		ptr  string
 		want error
 	}{
-		{"absent key", "/replicas/0/missing", ErrNotFound},
-		{"index out of range", "/replicas/99", ErrNotFound},
-		{"descend into scalar", "/replicas/0/host/nope", ErrInvalid},
-		{"non-numeric array token", "/replicas/five", ErrInvalid},
-		{"leading zero index", "/replicas/05", ErrInvalid},
-		{"dash token", "/replicas/-", ErrInvalid},
-		{"bad escape", "/replicas/0/a~2b", ErrInvalid},
-		{"trailing tilde", "/replicas/0/a~", ErrInvalid},
+		{"absent key", replicaDoc, "/replicas/0/missing", ErrNotFound},
+		{"index out of range", replicaDoc, "/replicas/99", ErrNotFound},
+		{"descend into scalar (string)", replicaDoc, "/replicas/0/host/nope", ErrInvalid},
+		{"descend into scalar (number)", scalarKindsDoc, "/num/nope", ErrInvalid},
+		{"descend into scalar (boolean)", scalarKindsDoc, "/bool/nope", ErrInvalid},
+		{"descend into scalar (null)", scalarKindsDoc, "/null/nope", ErrInvalid},
+		{"non-numeric array token", replicaDoc, "/replicas/five", ErrInvalid},
+		{"leading zero index", replicaDoc, "/replicas/05", ErrInvalid},
+		{"dash token", replicaDoc, "/replicas/-", ErrInvalid},
+		{"plus-signed index", replicaDoc, "/replicas/+1", ErrInvalid},
+		{"negative zero index", replicaDoc, "/replicas/-0", ErrInvalid},
+		{"bad escape", replicaDoc, "/replicas/0/a~2b", ErrInvalid},
+		{"trailing tilde", replicaDoc, "/replicas/0/a~", ErrInvalid},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := SelectKey(replicaDoc, tt.ptr)
+			_, err := SelectKey(tt.doc, tt.ptr)
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("err = %v, want %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestSelectPointerDoubleEscape(t *testing.T) {
+	// unescapeToken's doc comment explains why decoding must be a single
+	// left-to-right pass rather than two strings.ReplaceAll calls:
+	// replacing "~0" before "~1" would turn the literal token "~01" into
+	// "~1" and then into "/", which is wrong. "~01" must decode to the two
+	// characters '~' '1', addressing a key literally named "~1".
+	doc := []byte(`{"~1":"tilde-one"}`)
+	got, err := SelectKey(doc, "/~01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "tilde-one" {
+		t.Errorf("= %q, want tilde-one", got)
+	}
+}
+
+func TestSelectPointerAgainstNonJSONRoot(t *testing.T) {
+	// A pointer against a payload that is not JSON at all is a structural
+	// mismatch, not an absence: it must wrap ErrInvalid, the same as
+	// SelectKey's literal path does for a non-object payload.
+	if _, err := SelectKey([]byte("not json"), "/foo"); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
 	}
 }
 

--- a/providers/aws/aws_test.go
+++ b/providers/aws/aws_test.go
@@ -262,24 +262,26 @@ func mustParse(t *testing.T, raw string) mamori.Ref {
 func TestConformanceSecretsManager(t *testing.T) {
 	fake := newFakeSM()
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return newSMWithClient(fake) },
-		Ref:    func(key string) string { return schemeSM + "://" + key },
-		Seed:   func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
-		Mutate: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
-		Fail:   func(_ context.Context, key string, err error) error { fake.fail(key, err); return nil },
-		Clear:  func(_ context.Context, key string) error { fake.clear(key); return nil },
+		New:        func() mamori.Provider { return newSMWithClient(fake) },
+		Ref:        func(key string) string { return schemeSM + "://" + key },
+		PointerRef: func(key, frag string) string { return schemeSM + "://" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Mutate:     func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Fail:       func(_ context.Context, key string, err error) error { fake.fail(key, err); return nil },
+		Clear:      func(_ context.Context, key string) error { fake.clear(key); return nil },
 	})
 }
 
 func TestConformanceParameterStore(t *testing.T) {
 	fake := newFakeSSM()
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return newPSWithClient(fake) },
-		Ref:    func(key string) string { return schemePS + "://" + key },
-		Seed:   func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
-		Mutate: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
-		Fail:   func(_ context.Context, key string, err error) error { fake.fail(key, err); return nil },
-		Clear:  func(_ context.Context, key string) error { fake.clear(key); return nil },
+		New:        func() mamori.Provider { return newPSWithClient(fake) },
+		Ref:        func(key string) string { return schemePS + "://" + key },
+		PointerRef: func(key, frag string) string { return schemePS + "://" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Mutate:     func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Fail:       func(_ context.Context, key string, err error) error { fake.fail(key, err); return nil },
+		Clear:      func(_ context.Context, key string) error { fake.clear(key); return nil },
 	})
 }
 

--- a/providers/azblob/azblob_test.go
+++ b/providers/azblob/azblob_test.go
@@ -281,8 +281,9 @@ const confContainer = "conformance"
 func TestConformance(t *testing.T) {
 	fake := newFakeStore()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(WithClient(fake)) },
-		Ref: func(key string) string { return "azblob://" + confContainer + "/" + key },
+		New:        func() mamori.Provider { return New(WithClient(fake)) },
+		Ref:        func(key string) string { return "azblob://" + confContainer + "/" + key },
+		PointerRef: func(key, frag string) string { return "azblob://" + confContainer + "/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.put(confContainer, key, val)
 			return nil

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -209,8 +209,9 @@ func TestResolveContextCancelled(t *testing.T) {
 func TestConformance(t *testing.T) {
 	fake := newFakeVault()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(WithClient(fake)) },
-		Ref: func(key string) string { return "azure-kv://testvault/" + key },
+		New:        func() mamori.Provider { return New(WithClient(fake)) },
+		Ref:        func(key string) string { return "azure-kv://testvault/" + key },
+		PointerRef: func(key, frag string) string { return "azure-kv://testvault/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/configcat/configcat_test.go
+++ b/providers/configcat/configcat_test.go
@@ -218,8 +218,9 @@ func TestConformance(t *testing.T) {
 	f := newFake()
 
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return newWithClient(f) },
-		Ref: func(key string) string { return "configcat://" + key },
+		New:        func() mamori.Provider { return newWithClient(f) },
+		Ref:        func(key string) string { return "configcat://" + key },
+		PointerRef: func(key, frag string) string { return "configcat://" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(key, val)
 			return nil

--- a/providers/consul/consul_test.go
+++ b/providers/consul/consul_test.go
@@ -148,7 +148,8 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withKV(fake), WithWaitTime(500*time.Millisecond))
 		},
-		Ref: func(key string) string { return "consul://" + key },
+		Ref:        func(key string) string { return "consul://" + key },
+		PointerRef: func(key, frag string) string { return "consul://" + key + frag },
 		// consul.go: the first blocking query (lastIndex == 0) reads and emits
 		// the baseline, and the index it returns is the subscription position,
 		// so nothing written after it can be missed.

--- a/providers/cosmos/cosmos_test.go
+++ b/providers/cosmos/cosmos_test.go
@@ -336,6 +336,9 @@ func TestConformance(t *testing.T) {
 		Ref: func(k string) string {
 			return "cosmos://" + confDatabase + "/" + confContainer + "/" + k
 		},
+		PointerRef: func(k, frag string) string {
+			return "cosmos://" + confDatabase + "/" + confContainer + "/" + k + frag
+		},
 		Seed: func(_ context.Context, k, val string) error {
 			fake.put(confDatabase, confContainer, k, val)
 			return nil

--- a/providers/doppler/doppler_test.go
+++ b/providers/doppler/doppler_test.go
@@ -346,6 +346,8 @@ func TestConformance(t *testing.T) {
 		Ref: func(key string) string {
 			return "doppler://" + testProject + "/" + testConfig + "#" + key
 		},
+		// No PointerRef: #<name> is the secret's name, a required, backend-native
+		// identifier (see Resolve), not a path into a JSON document.
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(testProject, testConfig, key, val)
 			return nil

--- a/providers/dynamodb/dynamodb_test.go
+++ b/providers/dynamodb/dynamodb_test.go
@@ -142,8 +142,11 @@ func TestConformance(t *testing.T) {
 		return nil
 	}
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return newWithClient(fake) },
-		Ref:    func(key string) string { return "dynamodb://conf/" + key + "#value" },
+		New: func() mamori.Provider { return newWithClient(fake) },
+		Ref: func(key string) string { return "dynamodb://conf/" + key + "#value" },
+		// No PointerRef: #attr selects a DynamoDB attribute from the item's
+		// AttributeValue map, not a path into a JSON document. The item is only
+		// marshalled to JSON when the fragment is empty (see itemBytes).
 		Seed:   seed,
 		Mutate: seed, // put overwrites, so seed doubles as mutate
 		Fail: func(_ context.Context, key string, err error) error {

--- a/providers/etcd/etcd_test.go
+++ b/providers/etcd/etcd_test.go
@@ -201,8 +201,9 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withClient(fake))
 		},
-		Ref:  func(key string) string { return "etcd://" + key },
-		Seed: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Ref:        func(key string) string { return "etcd://" + key },
+		PointerRef: func(key, frag string) string { return "etcd://" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
 		Mutate: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/firebase-rc/firebaserc_test.go
+++ b/providers/firebase-rc/firebaserc_test.go
@@ -98,8 +98,9 @@ func parse(t *testing.T, raw string) mamori.Ref {
 func TestConformance(t *testing.T) {
 	fake := newFakeBackend()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(WithFetcher(fake)) },
-		Ref: func(key string) string { return "firebase-rc://" + key },
+		New:        func() mamori.Provider { return New(WithFetcher(fake)) },
+		Ref:        func(key string) string { return "firebase-rc://" + key },
+		PointerRef: func(key, frag string) string { return "firebase-rc://" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/firebase-rtdb/firebasertdb_test.go
+++ b/providers/firebase-rtdb/firebasertdb_test.go
@@ -189,7 +189,8 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withBackend(fake), WithReconnectBackoff(200*time.Millisecond))
 		},
-		Ref: func(key string) string { return "firebase-rtdb://" + key },
+		Ref:        func(key string) string { return "firebase-rtdb://" + key },
+		PointerRef: func(key, frag string) string { return "firebase-rtdb://" + key + frag },
 		// firebasertdb.go: the stream is opened first, then "Emit the current
 		// value as a baseline once, after the stream is open".
 		WatchDeliversBaseline: true,

--- a/providers/firestore/firestore_test.go
+++ b/providers/firestore/firestore_test.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -156,6 +157,20 @@ func (s *fakeStream) Stop() {}
 // compile-time check that the fake satisfies the backend interface.
 var _ backend = (*fakeStore)(nil)
 
+// conformanceDoc builds the document Seed/Mutate write for val. Most
+// conformance cases seed a plain scalar (e.g. "hello-world"), which is not
+// valid JSON, so it is wrapped under a "value" field and selected via Ref's
+// baked-in #value. JSONPointerSelection instead seeds a JSON object payload;
+// storing that unwrapped lets PointerRef's fragment select directly into it,
+// exactly as a real multi-field Firestore document would be addressed.
+func conformanceDoc(val string) map[string]interface{} {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(val), &m); err == nil {
+		return m
+	}
+	return map[string]interface{}{"value": val}
+}
+
 func TestConformance(t *testing.T) {
 	store := newFakeStore()
 	const collection = "conform"
@@ -164,15 +179,20 @@ func TestConformance(t *testing.T) {
 		// The document stores the value under a "value" field so a scalar can be
 		// round-tripped through a document-shaped backend.
 		Ref: func(key string) string { return "firestore://" + collection + "/" + key + "#value" },
+		// PointerRef drops the baked "#value" fragment in favor of the caller's
+		// own: #key is delegated to mamori.SelectKey (see valueFor), and a JSON
+		// Pointer fragment needs to address the document directly, not a value
+		// nested one field under it.
+		PointerRef: func(key, frag string) string { return "firestore://" + collection + "/" + key + frag },
 		// firestore.go: the snapshot stream is created before the goroutine
 		// runs, and its first event is the current document.
 		WatchDeliversBaseline: true,
 		Seed: func(_ context.Context, key, val string) error {
-			store.set(collection, key, map[string]interface{}{"value": val})
+			store.set(collection, key, conformanceDoc(val))
 			return nil
 		},
 		Mutate: func(_ context.Context, key, val string) error {
-			store.set(collection, key, map[string]interface{}{"value": val})
+			store.set(collection, key, conformanceDoc(val))
 			return nil
 		},
 		Fail: func(_ context.Context, key string, err error) error {

--- a/providers/flagsmith/flagsmith_test.go
+++ b/providers/flagsmith/flagsmith_test.go
@@ -230,8 +230,9 @@ func TestConformance(t *testing.T) {
 	f := newFake()
 
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return newWithSource(f) },
-		Ref: func(key string) string { return "flagsmith://" + key },
+		New:        func() mamori.Provider { return newWithSource(f) },
+		Ref:        func(key string) string { return "flagsmith://" + key },
+		PointerRef: func(key, frag string) string { return "flagsmith://" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(key, val)
 			return nil

--- a/providers/flipt/flipt_test.go
+++ b/providers/flipt/flipt_test.go
@@ -329,6 +329,8 @@ func TestConformance(t *testing.T) {
 		Ref: func(key string) string {
 			return "flipt://" + testNamespace + "/" + key
 		},
+		// No PointerRef: #attachment selects a variant's attachment facet of
+		// the evaluated result, not a path into a JSON document (see Resolve).
 		Seed: func(_ context.Context, key, val string) error {
 			// Model every seeded flag as a variant flag whose matched variant key
 			// is the seeded value, so Resolve returns the value verbatim.

--- a/providers/gcp/gcp_test.go
+++ b/providers/gcp/gcp_test.go
@@ -121,8 +121,9 @@ func TestConformance(t *testing.T) {
 	fake := newFakeSM()
 	const project = "test-project"
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(WithClient(fake)) },
-		Ref: func(key string) string { return "gcp-sm://" + project + "/" + key },
+		New:        func() mamori.Provider { return New(WithClient(fake)) },
+		Ref:        func(key string) string { return "gcp-sm://" + project + "/" + key },
+		PointerRef: func(key, frag string) string { return "gcp-sm://" + project + "/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.add(project, key, val)
 			return nil

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -110,8 +110,9 @@ func TestConformance(t *testing.T) {
 	fake := newFakeGCS()
 	const bucket = "test-bucket"
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(WithClient(fake)) },
-		Ref: func(key string) string { return "gcs://" + bucket + "/" + key },
+		New:        func() mamori.Provider { return New(WithClient(fake)) },
+		Ref:        func(key string) string { return "gcs://" + bucket + "/" + key },
+		PointerRef: func(key, frag string) string { return "gcs://" + bucket + "/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.put(bucket, key, val)
 			return nil

--- a/providers/goff/goff_test.go
+++ b/providers/goff/goff_test.go
@@ -79,8 +79,9 @@ func (f *fakeEvaluator) RawVariation(flagKey string, _ ffcontext.Context, _ any)
 func TestConformance(t *testing.T) {
 	fake := newFake()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(withEvaluator(fake)) },
-		Ref: func(key string) string { return "goff://" + key },
+		New:        func() mamori.Provider { return New(withEvaluator(fake)) },
+		Ref:        func(key string) string { return "goff://" + key },
+		PointerRef: func(key, frag string) string { return "goff://" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/growthbook/growthbook_test.go
+++ b/providers/growthbook/growthbook_test.go
@@ -77,8 +77,9 @@ func parse(t *testing.T, raw string) mamori.Ref {
 func TestConformance(t *testing.T) {
 	fake := newFakeEvaluator()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(withEvaluator(fake)) },
-		Ref: func(key string) string { return "growthbook://" + key },
+		New:        func() mamori.Provider { return New(withEvaluator(fake)) },
+		Ref:        func(key string) string { return "growthbook://" + key },
+		PointerRef: func(key, frag string) string { return "growthbook://" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			// Seed a string so encodeFeatureValue returns the raw value the
 			// conformance kit compares against.

--- a/providers/k8s/README.md
+++ b/providers/k8s/README.md
@@ -29,6 +29,8 @@ type Config struct {
 - Without `#key`, the whole data map is JSON-encoded as an object of string values.
 - `Value.Version` is the object's `ResourceVersion` - monotonic, native change detection.
 
+`ca.crt`, `tls.crt`, and `tls.key` are literal key names, not paths. A mamori fragment is only a JSON Pointer when it begins with `/`, so a dotted key addresses exactly the key it names. A Kubernetes Secret's `data` is a flat map with no nesting to point into, so this provider only ever does a literal lookup.
+
 ## Authentication
 
 In-cluster config when running in a Pod; otherwise the default kubeconfig resolution (`KUBECONFIG`, then `~/.kube/config`). Override explicitly:

--- a/providers/k8s/k8s_test.go
+++ b/providers/k8s/k8s_test.go
@@ -167,6 +167,8 @@ func TestConformanceSecret(t *testing.T) {
 			// key is a bare name; map it to default/<name>#value
 			return "k8s-secret://" + testNamespace + "/" + sanitize(key) + "#value"
 		},
+		// No PointerRef: #key selects an entry of Secret.Data, a Go map, not a
+		// path into a JSON document (see secretValue).
 		Seed:   func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		Mutate: func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		// k8s.go: "Emit the current snapshot after the watch is established so
@@ -205,8 +207,10 @@ func TestConformanceConfigMap(t *testing.T) {
 	}
 
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return k8sprov.NewConfigMap(k8sprov.WithClient(client)) },
-		Ref:    func(key string) string { return "k8s-cm://" + testNamespace + "/" + sanitize(key) + "#value" },
+		New: func() mamori.Provider { return k8sprov.NewConfigMap(k8sprov.WithClient(client)) },
+		Ref: func(key string) string { return "k8s-cm://" + testNamespace + "/" + sanitize(key) + "#value" },
+		// No PointerRef: #key selects an entry of ConfigMap.Data, a Go map, not a
+		// path into a JSON document (see configMapValue).
 		Seed:   func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		Mutate: func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		// Same Watch as the Secret case above: snapshot after the watch starts.

--- a/providers/launchdarkly/launchdarkly_test.go
+++ b/providers/launchdarkly/launchdarkly_test.go
@@ -173,9 +173,10 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withClient(fake))
 		},
-		Ref:    func(key string) string { return "launchdarkly://" + key },
-		Seed:   func(_ context.Context, key, val string) error { fake.setString(key, val); return nil },
-		Mutate: func(_ context.Context, key, val string) error { fake.setString(key, val); return nil },
+		Ref:        func(key string) string { return "launchdarkly://" + key },
+		PointerRef: func(key, frag string) string { return "launchdarkly://" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { fake.setString(key, val); return nil },
+		Mutate:     func(_ context.Context, key, val string) error { fake.setString(key, val); return nil },
 		Fail: func(_ context.Context, key string, err error) error {
 			fake.fail(key, err)
 			return nil

--- a/providers/mamori/conformance_test.go
+++ b/providers/mamori/conformance_test.go
@@ -298,6 +298,11 @@ func runConformance(t *testing.T, serverOpts []server.Option, endpointFor func(*
 	cfg := providertest.Config{
 		New: func() mamori.Provider { return newClient() },
 		Ref: func(key string) string { return "mamori://" + key },
+		// No PointerRef: ref.Key is never read by this client (see resolve.go).
+		// Field selection for a mamori:// ref is server-side only, decided by how
+		// the operator's Bind maps a name to its upstream ref (decision D9); the
+		// client only ever asks for a binding name, never a fragment within it.
+		//
 		// The server sends a snapshot per subscribed name at subscribe time
 		// (server/handler.go, sendWatchSnapshot), so the first Update the SSE
 		// watch delivers proves the subscription is registered upstream.

--- a/providers/mongodb/mongodb_test.go
+++ b/providers/mongodb/mongodb_test.go
@@ -2,6 +2,7 @@ package mongodb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -196,6 +197,22 @@ var _ backend = (*fakeBackend)(nil)
 
 // --- conformance ---------------------------------------------------------------
 
+// conformanceDoc builds the document Seed/Mutate write for val. Most
+// conformance cases seed a plain scalar (e.g. "hello-world"), which is not
+// valid JSON, so it is wrapped under a "value" field and selected via Ref's
+// baked-in #value. JSONPointerSelection instead seeds a JSON object payload;
+// merging its fields directly into the document (alongside _id) lets
+// PointerRef's fragment select directly into it, exactly as a real
+// multi-field MongoDB document would be addressed.
+func conformanceDoc(key, val string) bson.M {
+	var m bson.M
+	if err := json.Unmarshal([]byte(val), &m); err == nil {
+		m["_id"] = key
+		return m
+	}
+	return bson.M{"_id": key, "value": val}
+}
+
 func TestConformance(t *testing.T) {
 	fake := newFakeBackend()
 	providertest.Run(t, providertest.Config{
@@ -203,15 +220,20 @@ func TestConformance(t *testing.T) {
 		// The conformance kit stores each value as a document's "value" field and
 		// selects it with #value, so the resolved bytes equal the seeded string.
 		Ref: func(key string) string { return "mongodb://conformance/" + key + "#value" },
+		// PointerRef drops the baked "#value" fragment in favor of the caller's
+		// own: #key is delegated to mamori.SelectKey (see valueFor), and a JSON
+		// Pointer fragment needs to address the document directly, not a value
+		// nested one field under it.
+		PointerRef: func(key, frag string) string { return "mongodb://conformance/" + key + frag },
 		// mongodb.go: the change stream is opened before the goroutine runs and
 		// the baseline is read after it ("Emit the current value as a baseline").
 		WatchDeliversBaseline: true,
 		Seed: func(_ context.Context, key, val string) error {
-			fake.put("conformance", key, bson.M{"_id": key, "value": val})
+			fake.put("conformance", key, conformanceDoc(key, val))
 			return nil
 		},
 		Mutate: func(_ context.Context, key, val string) error {
-			fake.put("conformance", key, bson.M{"_id": key, "value": val})
+			fake.put("conformance", key, conformanceDoc(key, val))
 			return nil
 		},
 		Fail: func(_ context.Context, key string, err error) error {

--- a/providers/mysql/mysql_test.go
+++ b/providers/mysql/mysql_test.go
@@ -462,8 +462,9 @@ func TestConformance(t *testing.T) {
 	f := newFakeDB()
 
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(withQueryer(f)) },
-		Ref: func(key string) string { return "mysql://kv/" + key },
+		New:        func() mamori.Provider { return New(withQueryer(f)) },
+		Ref:        func(key string) string { return "mysql://kv/" + key },
+		PointerRef: func(key, frag string) string { return "mysql://kv/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(key, val)
 			return nil

--- a/providers/onepassword/onepassword_test.go
+++ b/providers/onepassword/onepassword_test.go
@@ -406,6 +406,9 @@ func TestConformance(t *testing.T) {
 		Ref: func(key string) string {
 			return "op://" + confVaultName + "/" + confItemTitle + "/" + key
 		},
+		// No PointerRef: the field name is the ref's third path segment (see
+		// parseOpRef), not a fragment. #key has no meaning to this provider at
+		// all; ref.Key is never referenced in Resolve.
 		Seed: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/postgres/postgres_test.go
+++ b/providers/postgres/postgres_test.go
@@ -223,8 +223,9 @@ func mustRef(t *testing.T, s string) mamori.Ref {
 func TestConformance(t *testing.T) {
 	fake := newFakeBackend()
 	providertest.Run(t, providertest.Config{
-		New: func() mamori.Provider { return New(withBackend(fake)) },
-		Ref: func(key string) string { return "postgres://app_config/" + key },
+		New:        func() mamori.Provider { return New(withBackend(fake)) },
+		Ref:        func(key string) string { return "postgres://app_config/" + key },
+		PointerRef: func(key, frag string) string { return "postgres://app_config/" + key + frag },
 		// postgres.go: LISTEN is issued before the baseline query, and the fake
 		// models the same queue-from-subscription semantics a real LISTEN has
 		// (see fakeBackend's doc comment).

--- a/providers/redis/redis_test.go
+++ b/providers/redis/redis_test.go
@@ -205,10 +205,11 @@ func TestWatchEmitsOnSet(t *testing.T) {
 func TestConformance(t *testing.T) {
 	f := newFakeRedis()
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return New(withRedisAPI(f)) },
-		Ref:    func(key string) string { return "redis://" + key },
-		Seed:   func(_ context.Context, key, val string) error { f.set(key, val); return nil },
-		Mutate: func(_ context.Context, key, val string) error { f.set(key, val); return nil },
+		New:        func() mamori.Provider { return New(withRedisAPI(f)) },
+		Ref:        func(key string) string { return "redis://" + key },
+		PointerRef: func(key, frag string) string { return "redis://" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { f.set(key, val); return nil },
+		Mutate:     func(_ context.Context, key, val string) error { f.set(key, val); return nil },
 		// redis.go: "Subscribe before emitting the baseline so no notification
 		// is missed between the baseline GET and the start of the read loop."
 		WatchDeliversBaseline: true,

--- a/providers/s3/s3_test.go
+++ b/providers/s3/s3_test.go
@@ -130,10 +130,11 @@ const testBucket = "mamori-test-bucket"
 func TestConformance(t *testing.T) {
 	fake := newFakeS3()
 	providertest.Run(t, providertest.Config{
-		New:    func() mamori.Provider { return newWithClient(fake) },
-		Ref:    func(key string) string { return scheme + "://" + testBucket + "/" + key },
-		Seed:   func(_ context.Context, key, val string) error { fake.put(testBucket, key, val); return nil },
-		Mutate: func(_ context.Context, key, val string) error { fake.put(testBucket, key, val); return nil },
+		New:        func() mamori.Provider { return newWithClient(fake) },
+		Ref:        func(key string) string { return scheme + "://" + testBucket + "/" + key },
+		PointerRef: func(key, frag string) string { return scheme + "://" + testBucket + "/" + key + frag },
+		Seed:       func(_ context.Context, key, val string) error { fake.put(testBucket, key, val); return nil },
+		Mutate:     func(_ context.Context, key, val string) error { fake.put(testBucket, key, val); return nil },
 		Fail: func(_ context.Context, key string, err error) error {
 			fake.fail(testBucket, key, err)
 			return nil

--- a/providers/sops/sops_test.go
+++ b/providers/sops/sops_test.go
@@ -206,7 +206,8 @@ func TestConformance(t *testing.T) {
 				return os.ReadFile(path)
 			}))
 		},
-		Ref: func(key string) string { return "sops://" + pathFor(key) },
+		Ref:        func(key string) string { return "sops://" + pathFor(key) },
+		PointerRef: func(key, frag string) string { return "sops://" + pathFor(key) + frag },
 		// sops.go: the fsnotify watcher is created and w.Add'd before the
 		// goroutine starts, and the baseline is emitted from inside it.
 		WatchDeliversBaseline: true,

--- a/providers/split/split_test.go
+++ b/providers/split/split_test.go
@@ -208,6 +208,8 @@ func TestConformance(t *testing.T) {
 	providertest.Run(t, providertest.Config{
 		New: func() mamori.Provider { return New(withClient(f)) },
 		Ref: func(key string) string { return "split://" + key },
+		// No PointerRef: split refs carry no fragment at all - the traffic key
+		// comes from ?key=, and Resolve never reads ref.Key (see Resolve).
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(defaultKey, key, val)
 			return nil

--- a/providers/sqlite/sqlite_test.go
+++ b/providers/sqlite/sqlite_test.go
@@ -160,7 +160,8 @@ func TestConformance(t *testing.T) {
 				return failQueryer{inner: q, reg: reg}
 			}))
 		},
-		Ref: func(key string) string { return "sqlite://cfg/" + key },
+		Ref:        func(key string) string { return "sqlite://cfg/" + key },
+		PointerRef: func(key, frag string) string { return "sqlite://cfg/" + key + frag },
 		// sqlite.go: the fsnotify watch is added before the goroutine starts,
 		// and the baseline emit happens inside it.
 		WatchDeliversBaseline: true,

--- a/providers/unleash/unleash_test.go
+++ b/providers/unleash/unleash_test.go
@@ -252,6 +252,8 @@ func TestConformance(t *testing.T) {
 	providertest.Run(t, providertest.Config{
 		New: func() mamori.Provider { return fakeProvider(f) },
 		Ref: func(key string) string { return "unleash://" + key + "#payload" },
+		// No PointerRef: #variant/#payload selects a facet of the evaluated
+		// toggle result, not a path into a JSON document (see Resolve).
 		Seed: func(_ context.Context, key, val string) error {
 			f.set(key, toggle{enabled: true, variantName: key, payloadValue: val})
 			return nil

--- a/providers/vault/vault_test.go
+++ b/providers/vault/vault_test.go
@@ -128,6 +128,21 @@ func (f *fakeVault) Renew(ctx context.Context, leaseID string, increment int) (*
 
 // --- conformance -----------------------------------------------------------
 
+// conformanceSecretData builds the secret.Data the conformance kit's Seed/
+// Mutate store for val. Most conformance cases seed a plain scalar (e.g.
+// "hello-world"), which is not valid JSON, so it is wrapped under a "value"
+// field and selected via Ref's baked-in #value. JSONPointerSelection instead
+// seeds a JSON object payload; storing that unwrapped lets PointerRef's
+// fragment select directly into it, exactly as a real multi-field Vault
+// secret would be addressed.
+func conformanceSecretData(val string) map[string]interface{} {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(val), &m); err == nil {
+		return m
+	}
+	return map[string]interface{}{"value": val}
+}
+
 func TestConformance(t *testing.T) {
 	fake := newFakeVault()
 	providertest.Run(t, providertest.Config{
@@ -135,12 +150,17 @@ func TestConformance(t *testing.T) {
 		// The conformance kit seeds a single scalar per key; we store it under the
 		// "value" field and select it with #value so Bytes is exactly that scalar.
 		Ref: func(key string) string { return "vault://secret/" + key + "#value" },
+		// PointerRef drops the baked "#value" fragment in favor of the caller's
+		// own, since #key is delegated to mamori.SelectKey (see Resolve) and a
+		// JSON Pointer fragment needs to address the secret's data map directly,
+		// not a value nested one level under it.
+		PointerRef: func(key, frag string) string { return "vault://secret/" + key + frag },
 		Seed: func(_ context.Context, key, val string) error {
-			fake.setSecret("secret", key, map[string]interface{}{"value": val})
+			fake.setSecret("secret", key, conformanceSecretData(val))
 			return nil
 		},
 		Mutate: func(_ context.Context, key, val string) error {
-			fake.setSecret("secret", key, map[string]interface{}{"value": val})
+			fake.setSecret("secret", key, conformanceSecretData(val))
 			return nil
 		},
 		Fail: func(_ context.Context, key string, err error) error {

--- a/providertest/providertest.go
+++ b/providertest/providertest.go
@@ -130,6 +130,35 @@ type Config struct {
 	// is a hard error, so this exemption is explicit and greppable, never a
 	// silent skip.
 	NoResolveErrors bool
+
+	// PointerRef builds a ref whose #fragment selects a value out of a JSON
+	// payload, given a logical key and the fragment to use (including its
+	// leading '#'). Supply it only when this provider's fragment slot IS a JSON
+	// selector routed through mamori.SelectKey; leave it nil otherwise, and the
+	// JSONPointerSelection case skips.
+	//
+	// It is a builder rather than a bool because Config.Ref is not fragment-free
+	// by convention: several providers bake a fixed fragment into it (vault,
+	// mongodb, firestore, and k8s all produce "...#value"), so the case cannot
+	// simply append its own fragment to Ref's output. A builder lets each
+	// provider say where its selector goes:
+	//
+	//	PointerRef: func(key, frag string) string {
+	//	    return "vault://secret/" + key + frag
+	//	}
+	//
+	// Leaving it nil is not a confession of a gap. A fragment means three
+	// different things across this ecosystem: a JSON selector (most providers),
+	// a backend-native key (a Kubernetes Secret data key, a Doppler secret
+	// name), or nothing at all (providers/mamori never reads ref.Key by design;
+	// a flag provider returning a bare bool has no payload to select from).
+	// Only the first can be tested for pointer support, and the other two are
+	// not defective for failing such a test.
+	//
+	// What this case DOES catch, for a provider that supplies it: hand-rolling a
+	// top-level-only key lookup instead of calling mamori.SelectKey, which
+	// passes every other case in this kit and fails only this one.
+	PointerRef func(key, fragment string) string
 }
 
 func (c Config) key(name string) string {
@@ -164,6 +193,7 @@ func Run(t *testing.T, c Config) {
 	t.Run("Scheme", func(t *testing.T) { testScheme(t, c) })
 	t.Run("ResolveSeeded", func(t *testing.T) { testResolveSeeded(t, c) })
 	t.Run("NotFoundTyped", func(t *testing.T) { testNotFound(t, c) })
+	t.Run("JSONPointerSelection", func(t *testing.T) { testJSONPointerSelection(t, c) })
 	t.Run("ErrorClassification", func(t *testing.T) { RunErrorClassification(t, c) })
 	t.Run("ContextCancel", func(t *testing.T) { testContextCancel(t, c) })
 	t.Run("ConcurrentResolve", func(t *testing.T) { testConcurrentResolve(t, c) })
@@ -268,6 +298,67 @@ func RunErrorClassification(tb testing.TB, c Config) {
 				"errors.Is chain. Underlying error: %v",
 				tc.name, got, tc.want, resolveErr)
 			return
+		}
+	}
+}
+
+// testJSONPointerSelection verifies a provider whose #fragment is a JSON
+// selector routes it through mamori.SelectKey, so nested selection behaves
+// identically everywhere. A provider that hand-rolls a top-level-only key
+// lookup passes every other case in this kit and fails only this one.
+//
+// It skips when Config.PointerRef is nil, because a fragment is not a JSON
+// selector in every provider: it is a backend-native key in some and means
+// nothing in others. See PointerRef's doc comment.
+func testJSONPointerSelection(t *testing.T, c Config) {
+	t.Helper()
+	if c.PointerRef == nil {
+		t.Skip("providertest: provider supplies no PointerRef; its #fragment is not a JSON selector")
+		return
+	}
+	ctx := context.Background()
+	p := c.New()
+	key := c.key("jsonpointer")
+
+	const payload = `{"outer":{"inner":"deep"},"list":[{"n":"zero"},{"n":"one"}],"dotted.key":"literal"}`
+	if err := c.Seed(ctx, key, payload); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	ok := []struct{ frag, want string }{
+		{"#/outer/inner", "deep"},
+		{"#/list/1/n", "one"},
+		{"#dotted.key", "literal"}, // literal fragment, not a path
+	}
+	for _, tc := range ok {
+		ref, err := mamori.ParseRef(c.PointerRef(key, tc.frag))
+		if err != nil {
+			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
+		}
+		v, err := p.Resolve(ctx, ref)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", tc.frag, err)
+		}
+		if string(v.Bytes) != tc.want {
+			t.Errorf("Resolve(%q) = %q, want %q", tc.frag, v.Bytes, tc.want)
+		}
+	}
+
+	bad := []struct {
+		frag string
+		want error
+	}{
+		{"#/outer/absent", mamori.ErrNotFound},
+		{"#/list/9", mamori.ErrNotFound},
+		{"#/outer/inner/deeper", mamori.ErrInvalid},
+	}
+	for _, tc := range bad {
+		ref, err := mamori.ParseRef(c.PointerRef(key, tc.frag))
+		if err != nil {
+			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
+		}
+		if _, err := p.Resolve(ctx, ref); !errors.Is(err, tc.want) {
+			t.Errorf("Resolve(%q) err = %v, want %v", tc.frag, err, tc.want)
 		}
 	}
 }

--- a/providertest/providertest.go
+++ b/providertest/providertest.go
@@ -130,17 +130,6 @@ type Config struct {
 	// is a hard error, so this exemption is explicit and greppable, never a
 	// silent skip.
 	NoResolveErrors bool
-
-	// NoStructuredPayload declares that this provider's values are never JSON
-	// documents, so fragment selection cannot be exercised against it. A
-	// feature-flag provider returning a bare bool, or a backend whose values are
-	// opaque binary, is the usual case.
-	//
-	// Like NoResolveErrors, this is a deliberate, greppable declaration rather
-	// than a silent gap: a provider that stores JSON and does not call
-	// mamori.SelectKey has a real bug, and the JSONPointerSelection case exists
-	// to catch exactly that.
-	NoStructuredPayload bool
 }
 
 func (c Config) key(name string) string {
@@ -175,7 +164,6 @@ func Run(t *testing.T, c Config) {
 	t.Run("Scheme", func(t *testing.T) { testScheme(t, c) })
 	t.Run("ResolveSeeded", func(t *testing.T) { testResolveSeeded(t, c) })
 	t.Run("NotFoundTyped", func(t *testing.T) { testNotFound(t, c) })
-	t.Run("JSONPointerSelection", func(t *testing.T) { testJSONPointerSelection(t, c) })
 	t.Run("ErrorClassification", func(t *testing.T) { RunErrorClassification(t, c) })
 	t.Run("ContextCancel", func(t *testing.T) { testContextCancel(t, c) })
 	t.Run("ConcurrentResolve", func(t *testing.T) { testConcurrentResolve(t, c) })
@@ -281,61 +269,6 @@ func RunErrorClassification(tb testing.TB, c Config) {
 				tc.name, got, tc.want, resolveErr)
 			return
 		}
-	}
-}
-
-// testJSONPointerSelection verifies the provider routes its #fragment through
-// mamori.SelectKey, so nested selection works identically everywhere. A
-// provider that hand-rolls a top-level-only key lookup passes every other case
-// in this kit and fails this one.
-func testJSONPointerSelection(t *testing.T, c Config) {
-	t.Helper()
-	if c.NoStructuredPayload {
-		t.Skip("providertest: provider declares NoStructuredPayload; values are never JSON documents")
-		return
-	}
-	ctx := context.Background()
-	p := c.New()
-	key := c.key("jsonpointer")
-
-	const payload = `{"outer":{"inner":"deep"},"list":[{"n":"zero"},{"n":"one"}],"dotted.key":"literal"}`
-	if err := c.Seed(ctx, key, payload); err != nil {
-		t.Fatalf("Seed: %v", err)
-	}
-
-	cases := []struct{ frag, want string }{
-		{"#/outer/inner", "deep"},
-		{"#/list/1/n", "one"},
-		{"#dotted.key", "literal"}, // literal fragment, not a path
-	}
-	for _, tc := range cases {
-		ref, err := mamori.ParseRef(c.Ref(key) + tc.frag)
-		if err != nil {
-			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
-		}
-		v, err := p.Resolve(ctx, ref)
-		if err != nil {
-			t.Fatalf("Resolve(%q): %v", tc.frag, err)
-		}
-		if string(v.Bytes) != tc.want {
-			t.Errorf("Resolve(%q) = %q, want %q", tc.frag, v.Bytes, tc.want)
-		}
-	}
-
-	ref, err := mamori.ParseRef(c.Ref(key) + "#/outer/absent")
-	if err != nil {
-		t.Fatalf("ParseRef: %v", err)
-	}
-	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrNotFound) {
-		t.Errorf("absent pointer err = %v, want ErrNotFound", err)
-	}
-
-	ref, err = mamori.ParseRef(c.Ref(key) + "#/outer/inner/deeper")
-	if err != nil {
-		t.Fatalf("ParseRef: %v", err)
-	}
-	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrInvalid) {
-		t.Errorf("descend-into-scalar err = %v, want ErrInvalid", err)
 	}
 }
 

--- a/providertest/providertest.go
+++ b/providertest/providertest.go
@@ -130,6 +130,17 @@ type Config struct {
 	// is a hard error, so this exemption is explicit and greppable, never a
 	// silent skip.
 	NoResolveErrors bool
+
+	// NoStructuredPayload declares that this provider's values are never JSON
+	// documents, so fragment selection cannot be exercised against it. A
+	// feature-flag provider returning a bare bool, or a backend whose values are
+	// opaque binary, is the usual case.
+	//
+	// Like NoResolveErrors, this is a deliberate, greppable declaration rather
+	// than a silent gap: a provider that stores JSON and does not call
+	// mamori.SelectKey has a real bug, and the JSONPointerSelection case exists
+	// to catch exactly that.
+	NoStructuredPayload bool
 }
 
 func (c Config) key(name string) string {
@@ -164,6 +175,7 @@ func Run(t *testing.T, c Config) {
 	t.Run("Scheme", func(t *testing.T) { testScheme(t, c) })
 	t.Run("ResolveSeeded", func(t *testing.T) { testResolveSeeded(t, c) })
 	t.Run("NotFoundTyped", func(t *testing.T) { testNotFound(t, c) })
+	t.Run("JSONPointerSelection", func(t *testing.T) { testJSONPointerSelection(t, c) })
 	t.Run("ErrorClassification", func(t *testing.T) { RunErrorClassification(t, c) })
 	t.Run("ContextCancel", func(t *testing.T) { testContextCancel(t, c) })
 	t.Run("ConcurrentResolve", func(t *testing.T) { testConcurrentResolve(t, c) })
@@ -269,6 +281,61 @@ func RunErrorClassification(tb testing.TB, c Config) {
 				tc.name, got, tc.want, resolveErr)
 			return
 		}
+	}
+}
+
+// testJSONPointerSelection verifies the provider routes its #fragment through
+// mamori.SelectKey, so nested selection works identically everywhere. A
+// provider that hand-rolls a top-level-only key lookup passes every other case
+// in this kit and fails this one.
+func testJSONPointerSelection(t *testing.T, c Config) {
+	t.Helper()
+	if c.NoStructuredPayload {
+		t.Skip("providertest: provider declares NoStructuredPayload; values are never JSON documents")
+		return
+	}
+	ctx := context.Background()
+	p := c.New()
+	key := c.key("jsonpointer")
+
+	const payload = `{"outer":{"inner":"deep"},"list":[{"n":"zero"},{"n":"one"}],"dotted.key":"literal"}`
+	if err := c.Seed(ctx, key, payload); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	cases := []struct{ frag, want string }{
+		{"#/outer/inner", "deep"},
+		{"#/list/1/n", "one"},
+		{"#dotted.key", "literal"}, // literal fragment, not a path
+	}
+	for _, tc := range cases {
+		ref, err := mamori.ParseRef(c.Ref(key) + tc.frag)
+		if err != nil {
+			t.Fatalf("ParseRef(%q): %v", tc.frag, err)
+		}
+		v, err := p.Resolve(ctx, ref)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", tc.frag, err)
+		}
+		if string(v.Bytes) != tc.want {
+			t.Errorf("Resolve(%q) = %q, want %q", tc.frag, v.Bytes, tc.want)
+		}
+	}
+
+	ref, err := mamori.ParseRef(c.Ref(key) + "#/outer/absent")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrNotFound) {
+		t.Errorf("absent pointer err = %v, want ErrNotFound", err)
+	}
+
+	ref, err = mamori.ParseRef(c.Ref(key) + "#/outer/inner/deeper")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if _, err := p.Resolve(ctx, ref); !errors.Is(err, mamori.ErrInvalid) {
+		t.Errorf("descend-into-scalar err = %v, want ErrInvalid", err)
 	}
 }
 

--- a/providertest/providertest_test.go
+++ b/providertest/providertest_test.go
@@ -41,7 +41,11 @@ func (f *fakeBackend) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value
 	if !ok {
 		return mamori.Value{}, mamori.ErrNotFound
 	}
-	return mamori.Value{Bytes: []byte(v), Version: strconv.Itoa(f.version[ref.Path])}, nil
+	selected, err := mamori.SelectKey([]byte(v), ref.Key)
+	if err != nil {
+		return mamori.Value{}, err
+	}
+	return mamori.Value{Bytes: selected, Version: strconv.Itoa(f.version[ref.Path])}, nil
 }
 
 func (f *fakeBackend) Watch(ctx context.Context, ref mamori.Ref) (<-chan mamori.Update, error) {
@@ -306,7 +310,11 @@ func (p *classifyingProvider) Resolve(ctx context.Context, ref mamori.Ref) (mamo
 	if !ok {
 		return mamori.Value{}, fmt.Errorf("%w: %s", mamori.ErrNotFound, ref.Path)
 	}
-	return mamori.Value{Bytes: []byte(v), Version: mamori.VersionHash([]byte(v))}, nil
+	selected, err := mamori.SelectKey([]byte(v), ref.Key)
+	if err != nil {
+		return mamori.Value{}, err
+	}
+	return mamori.Value{Bytes: selected, Version: mamori.VersionHash([]byte(v))}, nil
 }
 
 func (p *classifyingProvider) set(key, val string) {

--- a/providertest/providertest_test.go
+++ b/providertest/providertest_test.go
@@ -41,11 +41,7 @@ func (f *fakeBackend) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value
 	if !ok {
 		return mamori.Value{}, mamori.ErrNotFound
 	}
-	selected, err := mamori.SelectKey([]byte(v), ref.Key)
-	if err != nil {
-		return mamori.Value{}, err
-	}
-	return mamori.Value{Bytes: selected, Version: strconv.Itoa(f.version[ref.Path])}, nil
+	return mamori.Value{Bytes: []byte(v), Version: strconv.Itoa(f.version[ref.Path])}, nil
 }
 
 func (f *fakeBackend) Watch(ctx context.Context, ref mamori.Ref) (<-chan mamori.Update, error) {
@@ -310,11 +306,7 @@ func (p *classifyingProvider) Resolve(ctx context.Context, ref mamori.Ref) (mamo
 	if !ok {
 		return mamori.Value{}, fmt.Errorf("%w: %s", mamori.ErrNotFound, ref.Path)
 	}
-	selected, err := mamori.SelectKey([]byte(v), ref.Key)
-	if err != nil {
-		return mamori.Value{}, err
-	}
-	return mamori.Value{Bytes: selected, Version: mamori.VersionHash([]byte(v))}, nil
+	return mamori.Value{Bytes: []byte(v), Version: mamori.VersionHash([]byte(v))}, nil
 }
 
 func (p *classifyingProvider) set(key, val string) {

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -30,6 +30,7 @@ const groups = [
       { slug: "quickstart", title: "Quick start" },
       { slug: "comparison", title: "Why mamori" },
       { slug: "concepts", title: "Concepts" },
+      { slug: "concepts/ref-grammar", title: "Ref grammar", indent: true },
       { slug: "concepts/source-chains", title: "Source chains", indent: true },
       { slug: "concepts/error-kinds", title: "Error kinds", indent: true },
       { slug: "concepts/secret-types", title: "Secret types", indent: true },

--- a/site/src/pages/docs/concepts/index.md
+++ b/site/src/pages/docs/concepts/index.md
@@ -29,6 +29,8 @@ type Config struct {
 	APIKey     secret.String `source:"aws-sm://prod/api-key"`
 	// one key of a JSON secret
 	DBPassword secret.String `source:"aws-sm://prod/db#password"`
+	// a nested key, addressed with an RFC 6901 JSON Pointer fragment
+	DBUser     string        `source:"aws-sm://prod/db#/credentials/user"`
 	// provider option
 	Leased     secret.String `source:"vault://kv/data/api#key?renew=true"`
 	// opaque scheme
@@ -38,7 +40,7 @@ type Config struct {
 }
 ```
 
-`ParseRef` produces a `Ref{Scheme, Path, Key, Opts, Raw}`. `#key` selects one field from a structured (JSON) payload; `?opts` are provider-specific plus a small set of core-recognized options (`debounce`, `optional`, `version`).
+`ParseRef` produces a `Ref{Scheme, Path, Key, Opts, Raw}`. `#key` selects one field from a structured (JSON) payload - either a literal top-level key, or, when the fragment begins with `/`, an RFC 6901 JSON Pointer addressing a value at any depth (see [Ref grammar](/docs/concepts/ref-grammar/) for the full rules). `?opts` are provider-specific plus a small set of core-recognized options (`debounce`, `optional`, `version`).
 
 ### Supplementary tags
 
@@ -85,6 +87,7 @@ type Value struct {
 
 ## Next
 
+- [Ref grammar](/docs/concepts/ref-grammar/) - the full scheme/fragment/query grammar, JSON Pointer selection, and the error table.
 - [Source chains and precedence](/docs/concepts/source-chains/) - multiple refs per field, `onfail`, and the comma-split rule.
 - [Snapshots and pinning](/docs/usage/snapshots/) - snapshot versions, `WithHistory`, and pinning.
 - [Error kinds](/docs/concepts/error-kinds/) - the typed `Kind` values and their sentinels.

--- a/site/src/pages/docs/concepts/ref-grammar.md
+++ b/site/src/pages/docs/concepts/ref-grammar.md
@@ -172,15 +172,11 @@ type Config struct {
 
 ## Value decoding (`?decode=`)
 
-Not yet released. A future `?decode=` ref option will apply a declarative,
-per-field transform (`base64`, `gzip`, and similar) to a resolved value before
-it reaches your struct field.
+Not yet released - this section will be filled in when it ships.
 
 ## Ref interpolation (`${VAR}`)
 
-Not yet released. A future `${VAR}` substitution in a `source` tag, supplied
-via a `WithRefVars` option, will let one struct field name a per-environment
-ref without a compile-time constant per environment.
+Not yet released - this section will be filled in when it ships.
 
 ## See also
 

--- a/site/src/pages/docs/concepts/ref-grammar.md
+++ b/site/src/pages/docs/concepts/ref-grammar.md
@@ -1,0 +1,195 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Ref grammar
+---
+
+# Ref grammar
+
+A `source` tag is parsed into a `Ref` by `ParseRef`. This page is the
+consolidated reference for that grammar: the scheme forms, the two fragment
+forms (literal key and JSON Pointer), the RFC 6901 escaping and array-index
+rules, the error table that decides whether `default:` applies, and the
+gotcha you hit when a value is itself a string containing JSON.
+
+## The full grammar
+
+```text
+scheme://path[#key][?opt=v&...]   (hierarchical: aws-sm, vault, file, ...)
+scheme:path[#key][?opt=v&...]     (opaque: env, exec)
+```
+
+Opaque schemes such as `env:` and `exec:` take everything after the colon as
+the path, with no `//` authority section. Both forms place the optional
+`#key` fragment **before** the optional `?opts` query - the reverse of a
+standard URL, which puts the fragment last. `ParseRef` therefore parses by
+hand rather than via `net/url`, splitting the query off first and the
+fragment second:
+
+```go
+type Config struct {
+	// literal top-level key
+	DBPassword secret.String `source:"aws-sm://prod/db#password"`
+	// nested key via a JSON Pointer fragment
+	APIKey     secret.String `source:"aws-sm://prod/svc#/credentials/api_key"`
+	// #key before ?opts, not after
+	Leased     secret.String `source:"vault://kv/data/api#key?renew=true"`
+	// opaque scheme
+	LogLevel   string        `source:"env:LOG_LEVEL"`
+}
+```
+
+`ParseRef` produces `Ref{Scheme, Path, Key, Opts, Raw}`. `Key` holds the
+fragment verbatim, including any leading `/`; it is `SelectKey`, not
+`ParseRef`, that decides what the fragment means.
+
+## Fragment selection: two forms
+
+The fragment's first character is the whole discriminator:
+
+- **A fragment beginning with `/` is an RFC 6901 JSON Pointer**, addressing a
+  value at any depth through objects and array elements alike.
+- **Any other fragment is a literal top-level key**, exactly as it has always
+  been.
+
+```text
+aws-sm://prod/db#password                     literal key "password"
+k8s-secret://prod/tls#ca.crt                  literal key "ca.crt"
+aws-sm://prod/db#/credentials/password        nested, through an object
+aws-sm://prod/db#/replicas/5/creds/password   nested, through an array element
+aws-sm://prod/db#/a~1b                        a pointer whose one token
+                                               unescapes to "a/b", so it
+                                               also addresses a top-level key -
+                                               just one whose name itself
+                                               contains a "/"
+```
+
+This is what keeps `#ca.crt`, `#tls.crt`, and `#tls.key` addressing the keys
+they name rather than being parsed as paths: those are the canonical
+Kubernetes TLS secret keys, and dotted keys are the norm in ConfigMaps and
+Java properties files too. A leading `/` is a discriminator no such key can
+collide with, since none of them start with a slash.
+
+An empty fragment is unaffected either way: `SelectKey` returns the payload
+unchanged when `key` is empty.
+
+## JSON Pointer syntax
+
+### Escapes
+
+A reference token may contain two RFC 6901 escapes:
+
+| Escape | Meaning |
+| --- | --- |
+| `~0` | literal `~` |
+| `~1` | literal `/` |
+
+They are applied in one left-to-right pass, not as two independent
+find-and-replace calls: replacing every `~0` before every `~1` would turn the
+literal token `~01` into `~1` and then into `/`, which is wrong. Escapes let a
+pointer address a key whose name contains a literal `/` or `~`, exactly as if
+you had looked it up directly by that name.
+
+### Array indices
+
+Indices are **zero-based**: `/replicas/5` is the sixth element.
+
+```json
+{
+  "replicas": [
+    { "host": "r0.db" },
+    { "host": "r1.db" }
+  ]
+}
+```
+
+```go
+type Config struct {
+	Host string `source:"aws-sm://prod/db#/replicas/1/host"`
+}
+```
+
+An index token is digits only, per RFC 6901's `"0" / (%x31-39 *DIGIT)`:
+
+- A **leading zero is rejected**: `/replicas/05` is an error, not a silent
+  alias for `/replicas/5`.
+- A **sign is rejected**: `/replicas/+1` and `/replicas/-0` are both errors,
+  never `1` and `0`.
+- The **`-` token is rejected**: RFC 6901 defines it as one-past-the-end for
+  JSON Patch's add operation, and it can never address an existing value, so
+  mamori treats it as invalid rather than not-found.
+
+## Return semantics
+
+Object keys and array indices interleave freely at any depth. A JSON string
+yields its unquoted contents; any other JSON value (object, array, number,
+boolean, null) yields its JSON encoding, byte-for-byte as it appeared in the
+payload. This holds for both fragment forms and is what makes the same
+fragment usable for both a `secret.String` field and a `flatten:"json"`
+struct field with no second rule.
+
+## Errors
+
+| Situation | Sentinel | `default:` / `optional` applies |
+| --- | --- | --- |
+| Object key absent | `ErrNotFound` | yes |
+| Array index out of range | `ErrNotFound` | yes |
+| Pointer descends into a string, number, boolean, or null | `ErrInvalid` | no |
+| Non-numeric, signed, or leading-zero array token; the `-` token | `ErrInvalid` | no |
+| Malformed escape (`~` not followed by `0` or `1`) | `ErrInvalid` | no |
+| Payload is not valid JSON | `ErrInvalid` | no |
+
+Only the first two rows are genuine absence, so only they trigger a field's
+`default:` or `optional:"true"` handling, exactly like a missing top-level key
+today. Every other row is a structural mismatch - a malformed request against
+this particular payload, not an absence - and must fail loudly rather than be
+silently masked by a default. See [Error kinds](/docs/concepts/error-kinds/)
+for how `ErrNotFound` and `ErrInvalid` map onto `mamori.ErrorKind`.
+
+## When a value is itself a JSON string
+
+The row worth knowing before you hit it: if a value is stored as a **string
+containing JSON**, rather than a nested object, a pointer cannot descend into
+it - that is the "pointer descends into a string" row above, reported as
+`ErrInvalid`. This happens whenever a backend double-encodes a payload (a
+secret manager entry whose value is itself a serialized JSON document, for
+instance), and it looks at first glance like it should be walkable.
+
+The remedy is two steps: select the string itself with a pointer (or a
+literal key, if it is top-level), and give the field a struct type with
+`flatten:"json"` so mamori's own decode step does the second unwrap:
+
+```go
+type Creds struct {
+	User     string        `mapstructure:"user"`
+	Password secret.String `mapstructure:"password"`
+}
+
+type Config struct {
+	// #/metadata selects the JSON *string*; flatten:"json" then decodes it.
+	Creds Creds `source:"aws-sm://prod/db#/metadata" flatten:"json"`
+}
+```
+
+## Value decoding (`?decode=`)
+
+Not yet released. A future `?decode=` ref option will apply a declarative,
+per-field transform (`base64`, `gzip`, and similar) to a resolved value before
+it reaches your struct field.
+
+## Ref interpolation (`${VAR}`)
+
+Not yet released. A future `${VAR}` substitution in a `source` tag, supplied
+via a `WithRefVars` option, will let one struct field name a per-environment
+ref without a compile-time constant per environment.
+
+## See also
+
+- [Concepts overview](/docs/concepts/) - refs, providers, and the reconciler.
+- [Source chains and precedence](/docs/concepts/source-chains/) - multiple
+  refs per field, `onfail`, and the comma-split rule.
+- [Error kinds](/docs/concepts/error-kinds/) - the typed `Kind` values and
+  their sentinels.
+- [Resolve and errors](/docs/writing-a-provider/resolve/) - how a provider
+  earns pointer support by calling `mamori.SelectKey`.
+- [Kubernetes provider](/docs/providers/kubernetes/) - a provider whose
+  fragment is always a literal key, never a pointer.

--- a/site/src/pages/docs/providers/kubernetes.md
+++ b/site/src/pages/docs/providers/kubernetes.md
@@ -47,6 +47,8 @@ k8s-cm://<namespace>/<name>[#key]
 - `k8s-cm://prod/app-config#log_level` - returns the `log_level` entry of the `app-config` ConfigMap.
 - `k8s-cm://prod/app-config` - returns the whole ConfigMap data map as a JSON object.
 
+`ca.crt`, `tls.crt`, and `tls.key` are literal key names, not paths. A mamori fragment is only a JSON Pointer when it begins with `/`, so a dotted key addresses exactly the key it names. A Kubernetes Secret's `data` is a flat map with no nesting to point into, so this provider only ever does a literal lookup.
+
 ```go
 type Config struct {
 	DBPassword secret.String `source:"k8s-secret://prod/db-creds#password"`

--- a/site/src/pages/docs/usage/index.md
+++ b/site/src/pages/docs/usage/index.md
@@ -25,7 +25,7 @@ type Config struct {
 	DBPassword secret.String `source:"aws-sm://prod/db-password"`
 	// #/credentials/user is an RFC 6901 JSON Pointer fragment, selecting a
 	// value nested inside the secret's JSON payload rather than a top-level key.
-	DBUser     string        `source:"aws-sm://prod/db#/credentials/user"`
+	DBUser     string        `source:"aws-sm://prod/db-password#/credentials/user"`
 }
 
 func main() {

--- a/site/src/pages/docs/usage/index.md
+++ b/site/src/pages/docs/usage/index.md
@@ -23,6 +23,9 @@ import (
 type Config struct {
 	Port       string        `source:"env:PORT" default:"8080"`
 	DBPassword secret.String `source:"aws-sm://prod/db-password"`
+	// #/credentials/user is an RFC 6901 JSON Pointer fragment, selecting a
+	// value nested inside the secret's JSON payload rather than a top-level key.
+	DBUser     string        `source:"aws-sm://prod/db#/credentials/user"`
 }
 
 func main() {
@@ -59,5 +62,6 @@ Batch-capable providers (for example AWS Secrets Manager) are resolved in a sing
 ## See also
 
 - [Concepts](/docs/concepts/) for refs, the tag grammar, and error kinds.
+- [Ref grammar](/docs/concepts/ref-grammar/) for the full `#key` fragment grammar, including nested JSON Pointer selection.
 - [Validation](/docs/validation/) for the defaults and validation rules applied on every load.
 - [Observability](/docs/observability/) for `Status`, `Health`, `Doctor`, and the read-only HTTP surface.

--- a/site/src/pages/docs/writing-a-provider/conformance.md
+++ b/site/src/pages/docs/writing-a-provider/conformance.md
@@ -5,7 +5,7 @@ title: Conformance
 
 # Conformance
 
-`github.com/xavidop/mamori/providertest` runs one function that exercises resolution, not-found typing, error classification, `Version` monotonicity, concurrency, context cancellation, native watch, goroutine hygiene (goleak), and a no-payload-logging assertion. Every provider must pass it.
+`github.com/xavidop/mamori/providertest` runs one function that exercises resolution, not-found typing, error classification, nested JSON Pointer selection (opt-in), `Version` monotonicity, concurrency, context cancellation, native watch, goroutine hygiene (goleak), and a no-payload-logging assertion. Every provider must pass it.
 
 ## Run the conformance case
 
@@ -31,6 +31,23 @@ Set `NoResolveErrors: true` (with a comment naming why) only if your backend has
 
 Classification is guarded twice: the conformance case cannot prove your SDK mapping exists (no fake produces real SDK errors), so add a table test over real SDK errors too. `KindUnknown` is always a legal outcome.
 
+## `JSONPointerSelection`
+
+This case proves your provider routes `#key` through `mamori.SelectKey` rather than hand-rolling a top-level-only lookup, so RFC 6901 JSON Pointer selection (`#/credentials/password`, `#/replicas/5/host`) behaves identically everywhere. It is **opt-in**, because a fragment does not mean the same thing in every provider:
+
+```go
+providertest.Config{
+	// ...
+	PointerRef: func(key, frag string) string {
+		return "myscheme://" + key + frag
+	},
+}
+```
+
+Supply `PointerRef` only when your provider's fragment slot **is** a JSON selector into a structured payload. Leave it `nil`, with a comment naming why, when the fragment is something else entirely - a backend-native key (a Kubernetes Secret's `data` map entry, a Doppler secret name), a facet selector on an evaluated result (`flipt`'s `#attachment`, `unleash`'s `#variant`/`#payload`), or nothing at all (`providers/mamori` never reads `ref.Key`). None of those is a defect; the case simply skips.
+
+`PointerRef` is a ref *builder*, not a boolean, because `Config.Ref` is not fragment-free by convention - several providers bake a fixed fragment into it (`vault://secret/<key>#value`, and the same shape in `mongodb`, `firestore`, and `k8s`), so appending a second fragment to `Ref`'s output would produce a doubled, unparseable fragment. The builder lets each provider say exactly where its selector goes.
+
 ## Build and test the module
 
 Build and test each module independently with the workspace disabled, exactly as CI does:
@@ -51,6 +68,7 @@ Or from the repo root, `make test` / `make lint` run every module.
 - [ ] Other failures map to a sentinel (`ErrPermissionDenied`, `ErrUnauthenticated`, `ErrUnavailable`, `ErrRateLimited`, `ErrInvalid`) with `%w`. Cover it two ways: `Fail`/`Clear` in `providertest.Config` (required unless `NoResolveErrors: true` with a reason), AND a table test mapping real SDK errors to kinds.
 - [ ] `Value.Version` is set and changes when the value changes; secret-bearing values set `Sensitive: true`.
 - [ ] `#key` uses `mamori.SelectKey`; the payload is never logged.
+- [ ] If your fragment is a JSON selector, supply `providertest.Config.PointerRef` so `JSONPointerSelection` runs; otherwise leave it `nil` with a comment naming why (backend-native key, facet selector, or unused).
 - [ ] `Watch` is implemented only for native-push backends, closes on `ctx` cancel, and leaks no goroutines.
 - [ ] A client interface is injected so `providertest.Run` passes against a fake; live tests are behind `//go:build integration`.
 - [ ] `go build`, `go vet`, and `go test` are clean with `GOWORK=off`; the README documents scheme, ref grammar, and auth.

--- a/site/src/pages/docs/writing-a-provider/resolve.md
+++ b/site/src/pages/docs/writing-a-provider/resolve.md
@@ -42,6 +42,18 @@ Rules that keep providers interchangeable:
 - Set `Sensitive: true` on secret-bearing values; never log the payload.
 - Honor `ctx` in every network call.
 
+### `SelectKey`'s contract
+
+`SelectKey(data []byte, key string) ([]byte, error)` handles both forms `ref.Key` can take, so your provider never has to branch on them itself:
+
+- `key == ""` returns `data` unchanged.
+- A `key` beginning with `/` is an RFC 6901 JSON Pointer, addressing a value at any depth through objects and array elements (`"/credentials/password"`, `"/replicas/5/host"`).
+- Any other `key` is a literal top-level key, exactly as before.
+
+Calling `SelectKey` is what earns your provider pointer support **for free**: a provider that hand-rolls its own `map[string]json.RawMessage` lookup instead passes every other conformance case and fails only `JSONPointerSelection` (see [Conformance](/docs/writing-a-provider/conformance/)). An absent key or an out-of-range array index wraps `ErrNotFound`, so `default:`/`optional` still apply exactly as they do for a missing top-level key; a structural mismatch - a pointer descending into a scalar, a malformed array token, a bad escape, or a non-JSON payload - wraps `ErrInvalid` instead, because it is a malformed request against this payload rather than genuine absence. See [Ref grammar](/docs/concepts/ref-grammar/) for the full grammar and error table.
+
+This only applies when your provider's fragment is actually a JSON selector. Some providers use `ref.Key` for a backend-native lookup that has no JSON document to point into at all (a Kubernetes Secret's `data` map, a facet like `#variant`/`#payload` on a feature-flag evaluation); those providers correctly skip `SelectKey` and are not expected to support pointers.
+
 ## Map backend errors to kinds
 
 `ErrNotFound` is the only error that changes mamori's behavior (it triggers `default:` and `optional` handling). Classify every other failure too, so telemetry (`mamori.error.kind`) and callers using `mamori.ErrorKind` can tell an operator what went wrong.

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -46,6 +46,13 @@ Rules to hold onto:
 - `default:` applies only to genuine absence (not-found), never to a real error.
 - `validate:` uses go-playground/validator/v10 syntax and runs on load AND on
   every reconciled update; an invalid update is rejected atomically.
+- `#key` selects one field from a JSON payload. A fragment beginning with `/`
+  is an RFC 6901 JSON Pointer, addressing a value at any depth through objects
+  and array elements: `source:"aws-sm://prod/db#/credentials/password"`,
+  `source:"aws-sm://prod/db#/replicas/5/host"`. Any other fragment is a
+  literal top-level key, exactly as before: `source:"k8s-secret://prod/tls#ca.crt"`.
+  Do not restructure a secret or add application-code plumbing to reach a
+  nested field when a pointer fragment already reaches it directly.
 
 ## Watch for live changes
 


### PR DESCRIPTION
Implements section 5 of `docs/superpowers/specs/2026-07-27-ref-grammar-design.md`. Stacked on #52.

A `source` tag fragment beginning with `/` is now an RFC 6901 JSON Pointer, addressing a value at any depth through objects and array elements:

```go
type Config struct {
    Pass secret.String `source:"aws-sm://prod/db#/credentials/password"`
    Host string        `source:"aws-sm://prod/db#/replicas/5/host"`
    CA   []byte        `source:"k8s-secret://prod/tls#ca.crt"`  // still a literal key
}
```

## Backward compatibility

Any fragment not beginning with `/` stays a literal top-level key, forever. `#ca.crt`, `#tls.crt`, `#tls.key`, and `#application.properties` all address exactly the keys they name. `TestSelectKeyLiteralDottedKeysUnchanged` guards this.

## Error classification

| Situation | Sentinel | `default:` applies |
|---|---|---|
| Object key absent, or array index out of range | `ErrNotFound` | yes |
| Pointer descends into a string, number, boolean, or null | `ErrInvalid` | no |
| Non-numeric, signed, or leading-zero array token; the `-` token | `ErrInvalid` | no |
| Malformed `~` escape, or a non-JSON payload | `ErrInvalid` | no |

The last row is a small behavior change: a non-object payload previously wrapped no sentinel and classified as `KindUnknown`; it now classifies as `KindInvalid`.

## Notes

- The walk descends over `json.RawMessage` one level at a time rather than unmarshalling into an `any` tree, so a selected object comes back byte-identical instead of key-reordered by a marshal round trip. That matters for `Value.changed`'s byte comparison on providers that supply no `Version`. `TestSelectPointerPreservesBytes` guards it.
- All 26 provider files that call `mamori.SelectKey` inherit this with no change. No provider module is edited.
- Review caught one real bug pre-merge: `arrayIndex` originally leaned on `strconv.Atoi`'s sign tolerance, so `#/replicas/+1` and `#/replicas/-0` silently addressed real elements. Fixed in 7448521 by validating digits-only before parsing.

Still to land on this branch: the `providertest` conformance case, and the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)