### PR TITLE
fix(server): Close/Serve data race on listenWG

### DIFF
--- a/server/resolve.go
+++ b/server/resolve.go
@@ -192,6 +192,12 @@ var errClosed = fmt.Errorf("mamori/server: server is closed")
 // and start then sees closed already true and refuses outright (errClosed,
 // below) - spawning nothing at all. There is no window in between where a
 // goroutine could be spawned uncounted or a resolveCancel left unreadable.
+//
+// That every resolveWG.Add below is made under resolveMu, behind the closed
+// check above, is also exactly what keeps teardown's resolveWG.Wait from
+// being a data race in its own right: see teardown's doc comment for why a
+// positive Add concurrent with a Wait is one, and beginListening for the same
+// rule applied to Serve's listener goroutines.
 func (s *Server) start(ctx context.Context) error {
 	s.resolveMu.Lock()
 	defer s.resolveMu.Unlock()
@@ -400,11 +406,24 @@ func (s *Server) readiness() (state string, ready bool) {
 // listener bind, say - can still observe closed as false and find nothing
 // yet to tear down, the same way a Close-before-Serve does. Serve handles
 // that case from its own end: once it finishes creating everything it is
-// going to create, it checks isClosed one more time and, if Close raced in
-// and beat it, tears down what it just built itself via teardown below (see
-// Serve's doc comment in transport.go) - teardown is safe to invoke from
-// both places, even concurrently, since closeTransports, cancel, and
-// resolveWG.Wait are each safe to call more than once.
+// going to create, it makes one more closed check (beginListening, below)
+// and, if Close raced in and beat it, tears down what it just built itself
+// via teardown below (see Serve's doc comment in transport.go) - teardown is
+// safe to invoke from both places, even concurrently, since closeTransports,
+// cancel, and the two WaitGroup Waits are each safe to call more than once.
+//
+// Repeat-safety is not the whole of what those two Waits need, though, and
+// the distinction is worth stating because it is easy to conflate: a
+// WaitGroup tolerates concurrent and repeated WAITS, but a positive Add made
+// while the counter is zero must happen before a Wait, so what actually keeps
+// teardown's resolveWG.Wait and listenWG.Wait sound is that no Add can ever
+// be concurrent with them. Both WaitGroups get that from this same closed
+// flag: every resolveWG.Add is made by start, and every listenWG.Add by
+// beginListening, each under resolveMu having first observed closed as false,
+// while teardown only ever runs once closed is already permanently true. So
+// for either WaitGroup, any Add either precedes teardown's own resolveMu
+// acquisition (and therefore happens-before its Wait) or never happens at
+// all.
 func (s *Server) Close() error {
 	s.resolveMu.Lock()
 	if s.closed {
@@ -454,17 +473,52 @@ func (s *Server) Close() error {
 	return nil
 }
 
-// isClosed reports whether Close has already made its idempotent closed
-// transition, under the same resolveMu that guards closed and resolveCancel.
-// Serve (transport.go) calls this once it finishes binding every configured
-// listener, to detect a Close that raced in and fired before there was
-// anything to tear down yet - see Close's own doc comment above for why that
-// ordering is possible and how Serve is expected to respond (teardown,
-// below).
-func (s *Server) isClosed() bool {
+// beginListening is Serve's counterpart to start's own closed check: the one
+// transition, made once Serve has bound every configured listener and
+// immediately before it spawns a goroutine for any of them, that both asks
+// whether Close already ran and - if it did not - registers the goroutines
+// Serve is about to spawn with s.listenWG. It reports false when Close got
+// there first, which is Serve's cue to tear down what it just built itself
+// (teardown, below) and return errClosed; see Close's doc comment above for
+// why a Close can arrive mid-setup and find nothing to tear down yet, and
+// Serve's own doc comment (transport.go) for the other half.
+//
+// The check and the Add have to be ONE resolveMu critical section, not a
+// check followed by an unsynchronized Add, and that is the whole point of
+// this function rather than a plain "is it closed?" predicate.
+// sync.WaitGroup's contract is that a positive Add made when the counter is
+// zero must happen before a Wait, and teardown (below) reaches
+// s.listenWG.Wait via closeTransports. Fusing them under resolveMu makes the
+// two mutually exclusive by construction, because closed is already
+// permanently true by the time any teardown runs (Close sets it before
+// calling teardown, and Serve only calls teardown having observed it here):
+// either this critical section runs first, in which case every Add
+// happens-before teardown's own resolveMu acquisition and therefore before
+// the Wait, or teardown's runs first, in which case this one observes closed,
+// adds nothing, and spawns nothing - so the Wait it will do can only ever see
+// a counter that is zero and can never grow again. There is no window in
+// between where a listener goroutine could be counted concurrently with the
+// Wait that is supposed to be counting it.
+//
+// That is deliberately the same rule start (above) already follows for
+// s.resolveWG, whose Add calls are likewise made under resolveMu behind a
+// closed check - see start's resolveMu paragraph. Serve's listener goroutines
+// were the half that had been left out.
+//
+// Every Add made here is matched by a Done: the spawn loop it guards runs
+// immediately afterward over the same entries slice, cannot fail, and cannot
+// return early, and each goroutine it starts defers s.listenWG.Done. A Serve
+// that returns BEFORE reaching here - the fail-fast bad-bind path - therefore
+// leaves the counter at zero, so a later Close's Wait returns at once rather
+// than blocking forever on goroutines that were never started.
+func (s *Server) beginListening(entries []*listenerEntry) bool {
 	s.resolveMu.Lock()
 	defer s.resolveMu.Unlock()
-	return s.closed
+	if s.closed {
+		return false
+	}
+	s.listenWG.Add(len(entries))
+	return true
 }
 
 // teardown does Close's actual shutdown work: FIRST cancel servingCtx (so
@@ -477,12 +531,24 @@ func (s *Server) isClosed() bool {
 // the context start derived, then wait for resolveWG). It is split out from
 // Close's idempotent closed transition so that Serve (transport.go) can
 // invoke this exact same teardown itself, unconditionally, when its own
-// post-setup isClosed check finds that Close already ran (and, being
+// post-setup beginListening check finds that Close already ran (and, being
 // idempotent, will never run again) - see Close's doc comment above. Every
-// step here is safe to overlap or repeat: a context.CancelFunc, closeTransports,
-// and resolveWG.Wait are each safe to call more than once, including
-// concurrently with themselves - so both callers' invocations composing all
-// of this together stays safe too.
+// step here is safe to overlap or repeat: a context.CancelFunc,
+// closeTransports, and both WaitGroup Waits are each safe to call more than
+// once, including concurrently with themselves - so both callers' invocations
+// composing all of this together stays safe too.
+//
+// Both callers also guarantee the precondition the two Waits actually depend
+// on, which repeat-safety alone does not supply: closed is already true
+// whenever this runs (Close sets it before calling here; Serve calls here
+// only having observed it in beginListening), and every Add to either
+// WaitGroup is made under resolveMu behind a check of that same flag - by
+// start for resolveWG, by beginListening for listenWG. So the resolveMu
+// acquisition immediately below is the ordering point: any Add at all either
+// happened before it, and so happens-before the Waits, or will never happen.
+// See Close's doc comment above for why an Add racing a Wait would be a data
+// race (and, without the race detector, a WaitGroup misuse panic) rather than
+// a harmless overlap.
 func (s *Server) teardown() {
 	s.resolveMu.Lock()
 	servingCancel := s.servingCancel

--- a/server/server.go
+++ b/server/server.go
@@ -177,6 +177,15 @@ type Server struct {
 	// Close and start need their own explicit synchronization; a plain field
 	// would otherwise be a genuine data race between the two, not merely a
 	// theoretical one - see closeTransports and Close's own doc comment.
+	//
+	// resolveMu carries one more job beyond guarding those four fields: it is
+	// the happens-before edge between every WaitGroup Add this Server makes
+	// and the matching Wait in teardown. Both start (for resolveWG) and
+	// beginListening (for listenWG) Add while holding it, having first seen
+	// closed as false, and teardown takes it before either Wait at a point
+	// where closed is already permanently true - so an Add can never be
+	// concurrent with a Wait, which for a WaitGroup is a data race rather
+	// than a benign overlap. See beginListening's doc comment in resolve.go.
 	resolved      map[string]*resolverState
 	resolveCancel context.CancelFunc
 	servingCtx    context.Context
@@ -205,6 +214,19 @@ type Server struct {
 	// listener's Serve goroutine to actually exit, mirroring resolveWG above
 	// for the transport half of the lifecycle. They stay nil/zero until
 	// Serve runs.
+	//
+	// listenWG is added to under resolveMu, not entriesMu, even though it is
+	// otherwise transport state. That is not an oversight in the split: its
+	// Add has to be ordered against the listenWG.Wait that Close's teardown
+	// reaches through closeTransports (a positive Add made when a WaitGroup's
+	// counter is zero must happen before a Wait, or it is a data race and, on
+	// an unlucky interleaving without the race detector, a WaitGroup misuse
+	// panic), and the only thing that can supply that ordering is the closed
+	// flag below, which resolveMu guards. So Serve makes its Adds inside the
+	// same resolveMu critical section as its final closed check - see
+	// beginListening in resolve.go - exactly as start makes resolveWG's Adds
+	// inside its own. entriesMu could not do this job: teardown's snapshot of
+	// entries deliberately does not hold it across the Wait.
 	entries   []*listenerEntry
 	entriesMu sync.Mutex
 	listenWG  sync.WaitGroup

--- a/server/server.go
+++ b/server/server.go
@@ -179,8 +179,11 @@ type Server struct {
 	// theoretical one - see closeTransports and Close's own doc comment.
 	//
 	// resolveMu carries one more job beyond guarding those four fields: it is
-	// the happens-before edge between every WaitGroup Add this Server makes
-	// and the matching Wait in teardown. Both start (for resolveWG) and
+	// the happens-before edge between every Add to either of this Server's
+	// WaitGroup fields and the matching Wait in teardown. (closeTransports
+	// has a third WaitGroup, but it is function-local, so even two concurrent
+	// invocations get separate instances and it needs no such edge.) Both
+	// start (for resolveWG) and
 	// beginListening (for listenWG) Add while holding it, having first seen
 	// closed as false, and teardown takes it before either Wait at a point
 	// where closed is already permanently true - so an Add can never be

--- a/server/transport.go
+++ b/server/transport.go
@@ -515,11 +515,12 @@ func (s *Server) Serve(ctx context.Context) error {
 // waiting on it is a data race, not a benign overlap, so this Wait is only
 // sound because of that ordering; see beginListening's doc comment.
 //
-// Note the Wait is reached even when Serve never got as far as spawning
-// anything - a fail-fast bad bind returns before beginListening - which is
-// harmless precisely because no Add was made in that case either: the counter
-// is zero and the Wait returns immediately, while the loops above still
-// release the listeners that DID bind.
+// Note that a Serve which never got as far as spawning anything - a fail-fast
+// bad bind returns before beginListening - is harmless either way, because no
+// Add was made in that case. If some listeners had already bound, the loops
+// above release them and this Wait finds a zero counter and returns at once;
+// if the very first bind failed, entries is empty and the guard at the top of
+// this function returns before the Wait is reached at all.
 //
 // Finally, every Unix listener's socket file is removed, so neither this run
 // nor a restart trips over a stale file left behind (see Unix's doc comment

--- a/server/transport.go
+++ b/server/transport.go
@@ -371,11 +371,14 @@ func (s *Server) Addrs() []net.Addr {
 // no subsequent Close could ever reach). A Close that instead arrives
 // concurrently, WHILE Serve is still binding listeners below, is handled
 // from the other end: once every configured listener has been bound, Serve
-// checks isClosed one more time and, if a concurrent Close raced in and beat
-// it, tears down everything it just built itself (teardown, resolve.go)
-// before returning errClosed - see Close's own doc comment (resolve.go) for
-// why that self-teardown, rather than relying on the racing Close, is what
-// actually reclaims the listeners in that interleaving.
+// makes one more closed check (beginListening, resolve.go) and, if a
+// concurrent Close raced in and beat it, tears down everything it just built
+// itself (teardown, resolve.go) before returning errClosed - see Close's own
+// doc comment (resolve.go) for why that self-teardown, rather than relying on
+// the racing Close, is what actually reclaims the listeners in that
+// interleaving. That same call is where the listener goroutines below are
+// counted into s.listenWG, so that Close's teardown can never be waiting on
+// that WaitGroup while Serve is still adding to it.
 func (s *Server) Serve(ctx context.Context) error {
 	if s.noAuth && s.hasTCP {
 		return errNoAuthOnTCP
@@ -403,6 +406,8 @@ func (s *Server) Serve(ctx context.Context) error {
 		s.addEntry(&listenerEntry{ln: ln, srv: s.newHTTPServer(handler, false)})
 	}
 
+	entries := s.snapshotEntries()
+
 	// Close may have already raced in concurrently with the setup above -
 	// Serve is meant to run in the background (`go s.Serve(ctx)`) with Close
 	// driven independently, e.g. from a signal handler (see resolveMu's doc
@@ -412,12 +417,20 @@ func (s *Server) Serve(ctx context.Context) error {
 	// considers itself done and will never run again on its own. Detect
 	// that here and tear down everything just built ourselves, via the same
 	// teardown Close itself uses, rather than leaving it orphaned.
-	if s.isClosed() {
+	//
+	// The same call also registers the goroutines spawned just below with
+	// s.listenWG, because that registration must be ordered against the
+	// s.listenWG.Wait a concurrent Close's teardown reaches through
+	// closeTransports, and this closed check is the only place that ordering
+	// can be established - see beginListening's doc comment (resolve.go) for
+	// why the check and the Add have to be one critical section rather than
+	// two. Nothing between here and the spawn loop may return early: the Adds
+	// are already made, and only the loop's own deferred Done calls balance
+	// them.
+	if !s.beginListening(entries) {
 		s.teardown()
 		return errClosed
 	}
-
-	entries := s.snapshotEntries()
 
 	// errCh is fully buffered (one slot per entry) so every listener
 	// goroutine below can always send its result and return, even if Serve
@@ -427,7 +440,6 @@ func (s *Server) Serve(ctx context.Context) error {
 	// report a result nobody consumes, which goleak would catch as a leak.
 	errCh := make(chan error, len(entries))
 	for _, e := range entries {
-		s.listenWG.Add(1)
 		go func(e *listenerEntry) {
 			defer s.listenWG.Done()
 			err := e.srv.Serve(e.ln)
@@ -465,7 +477,7 @@ func (s *Server) Serve(ctx context.Context) error {
 // resolver goroutines - see this file's package doc comment for why the two
 // halves share one Close, and Close's own doc comment (resolve.go) for how
 // this can also be invoked directly by Serve itself, when Serve's post-setup
-// isClosed check finds a concurrent Close already ran.
+// beginListening check finds a concurrent Close already ran.
 //
 // Every entry's http.Server is offered a graceful Shutdown first, all of
 // them concurrently, sharing ONE bounded deadline (shutdownGrace) rather
@@ -493,7 +505,21 @@ func (s *Server) Serve(ctx context.Context) error {
 // It then waits on s.listenWG so every srv.Serve(ln) goroutine Serve started
 // has actually returned before this function does - the transport half of
 // the goleak-clean contract Close's own doc comment (resolve.go) promises,
-// mirrored here the same way resolveWG covers the resolver goroutines.
+// mirrored here the same way resolveWG covers the resolver goroutines. That
+// mirroring extends to how the Wait is synchronized, which is not optional:
+// Serve counts its listener goroutines in beginListening (resolve.go), under
+// resolveMu and behind the same closed check that gates start's own
+// resolveWG.Add calls, so by the time teardown - this function's only caller
+// - has taken resolveMu, every Add either already happened or never will.
+// Adding to a WaitGroup whose counter is zero while another goroutine is
+// waiting on it is a data race, not a benign overlap, so this Wait is only
+// sound because of that ordering; see beginListening's doc comment.
+//
+// Note the Wait is reached even when Serve never got as far as spawning
+// anything - a fail-fast bad bind returns before beginListening - which is
+// harmless precisely because no Add was made in that case either: the counter
+// is zero and the Wait returns immediately, while the loops above still
+// release the listeners that DID bind.
 //
 // Finally, every Unix listener's socket file is removed, so neither this run
 // nor a restart trips over a stale file left behind (see Unix's doc comment

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -951,5 +953,102 @@ func TestCloseWaitsForInFlightClose(t *testing.T) {
 	// And it must have actually waited, rather than racing through by luck.
 	if elapsed < grace/2 {
 		t.Errorf("Close returned in %v, too fast to have waited for the in-flight teardown (grace %v)", elapsed, grace)
+	}
+}
+
+// closeRaceIterations is how many Serve/Close races
+// TestCloseRacingServeSetupNeverRacesListenWG drives. The window it aims at
+// is a handful of instructions wide, so a single attempt proves nothing: at
+// 25 iterations the pre-fix code was caught by -race on 20 of 20 local runs,
+// and this leaves an order of magnitude of headroom on top of that for a
+// slower or busier CI machine without making the test itself slow (the whole
+// loop is well under a second even under -race).
+const closeRaceIterations = 250
+
+// TestCloseRacingServeSetupNeverRacesListenWG is the regression test for a
+// Close that lands in the sliver of Serve between "the listener is bound and
+// visible" and "the goroutine that will serve it has been registered with
+// s.listenWG".
+//
+// Serve is documented to run in the background (`go s.Serve(ctx)`) with Close
+// driven independently, so this interleaving is ordinary usage, not an abuse:
+// every test in this file that does `go s.Serve(ctx)` + `defer s.Close()` is
+// one instance of it, and TestUnixSocketHasRequestedMode is the one that
+// happened to lose the coin flip on CI.
+//
+// What used to go wrong: Serve called s.listenWG.Add(1) with no
+// synchronization against Close, while Close -> teardown -> closeTransports
+// called s.listenWG.Wait(). sync.WaitGroup requires that "calls with a
+// positive delta that occur when the counter is zero must happen before a
+// Wait", and nothing in the code established that ordering. Under -race that
+// is reported as a write (Wait) racing a read (Add) on the WaitGroup's
+// internal semaphore word; without -race, sync itself can panic with
+// "WaitGroup misuse: Add called concurrently with Wait". The fix moves the
+// Add into the same resolveMu-guarded, closed-checked transition Serve
+// already made before spawning anything (beginListening, resolve.go), which
+// is exactly how start's resolveWG.Add calls have always been ordered against
+// the same teardown.
+//
+// The loop closes as soon as Addrs() reports the listener, because that is
+// the first moment an outside goroutine can observe Serve's progress and is
+// therefore the tightest aim at the window. Each iteration also asserts the
+// documented contracts still hold: Serve returns either nil or errClosed
+// (never a bind failure from a socket the previous iteration failed to clean
+// up), and Close always reports success. goleak covers the other half - that
+// no interleaving leaves a listener goroutine, a watch goroutine, or a
+// channel waiter behind.
+func TestCloseRacingServeSetupNeverRacesListenWG(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	sockPath := shortSocketPath(t)
+
+	for i := 0; i < closeRaceIterations; i++ {
+		p := mamoritest.NewProvider("udsrace")
+		p.Set("k", "v1")
+
+		s, err := New(
+			WithPolicy(AllowAll()),
+			NoAuth(),
+			Bind("b", "udsrace://k"),
+			WithProvider(p),
+			Unix(sockPath, 0o600),
+		)
+		if err != nil {
+			t.Fatalf("iteration %d: New: %v", i, err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var serveErr error
+		go func() {
+			defer wg.Done()
+			serveErr = s.Serve(ctx)
+		}()
+
+		var closeErr error
+		go func() {
+			defer wg.Done()
+			// Spin rather than sleep: a sleep of any length lands after the
+			// window in nearly every iteration, which is precisely why the
+			// existing tests only reproduced this on an unlucky CI run.
+			deadline := time.Now().Add(transportTestWait)
+			for len(s.Addrs()) == 0 && time.Now().Before(deadline) {
+				runtime.Gosched()
+			}
+			closeErr = s.Close()
+		}()
+
+		wg.Wait()
+		cancel()
+
+		if serveErr != nil && !errors.Is(serveErr, errClosed) {
+			t.Fatalf("iteration %d: Serve = %v, want nil or errClosed", i, serveErr)
+		}
+		if closeErr != nil {
+			t.Fatalf("iteration %d: Close = %v, want nil", i, closeErr)
+		}
 	}
 }


### PR DESCRIPTION
Fixes an intermittent `-race` failure of `TestUnixSocketHasRequestedMode` on `macos-latest`, seen on #52 (a docs-only PR, which is what made it clear the cause was pre-existing rather than introduced).

## The bug

`Serve` added each listener goroutine to `s.listenWG` **after** its post-setup closed check and outside any lock. `Close`'s `teardown` reaches `s.listenWG.Wait()` through `closeTransports`. So a `Close` arriving while `Serve` was still spawning listeners put an `Add` concurrent with a `Wait` on a zero counter.

`sync.WaitGroup`'s contract forbids exactly that: "calls with a positive delta that start when the counter is zero must happen before a Wait."

It is reachable through documented usage, not just tests. `Serve`'s own doc comment describes the trigger: `go s.Serve(ctx)` with `Close` driven independently from a signal handler.

**Severity, stated precisely.** For a server with **two or more listeners** this is not merely a race-detector artifact: the same interleaving can trip `sync`'s own `WaitGroup misuse: Add called concurrently with Wait` panic on a plain build, killing the process during shutdown. For a **single-listener** server, the `0 -> positive` transition cannot observe a registered waiter, so the pre-fix bug was detector-only there. The originally failing test is single-listener, so the CI failure itself was the detector doing its job on a latent bug rather than a crash in the wild.

## The fix

`isClosed()` becomes `beginListening(entries)`, fusing the closed check and `listenWG.Add(len(entries))` into a single `resolveMu` critical section. Six lines of behavior change.

Either `beginListening` runs first, so every `Add` happens-before `teardown`'s own `resolveMu` acquisition and therefore before the `Wait`; or `teardown` runs first, so `beginListening` observes `closed`, adds nothing, spawns nothing, and the counter can never grow again. There is no window between.

This is the rule `start` **already followed** for `resolveWG`, whose `Add` calls are made under `resolveMu` behind the same closed check. Serve's listener goroutines were simply the half left out. `resolveWG` itself was never exposed.

Batching to a single `Add(len(entries))` is also strictly safer than the old per-iteration `Add(1)`: it collapses the counter to one `0 -> n` transition, closing the misuse-panic windows the old loop could hit with two or more listeners.

## Testing

`TestCloseRacingServeSetupNeverRacesListenWG` spins on `Addrs()` and closes the instant a listener appears. The race is nondeterministic, so iteration count is load-bearing. Measured detection rate against the unfixed code, 20 runs per configuration:

| iterations | runs detecting the race |
|---|---|
| 1 | 0 / 20 |
| 5 | 12 / 20 |
| 10 | 18 / 20 |
| 25 | 20 / 20 |

The test ships at 250, roughly 10-50x headroom over the reliable threshold, costing about 0.13s under `-race`. The 1-iteration row is why the loop exists.

Post-fix: clean under `-race` with `GORACE=halt_on_error=1`, full `server` suite green at `-count=2` under `-race` and `-count=5` without it (the panic path). `TestUnixSocketHasRequestedMode` is unmodified and passes at `-count=500`.

Adversarial review reproduced the race independently and tried six interleavings against the new invariant, all holding: concurrent `Serve` calls, `Close` landing mid-window, fail-fast bind, `Serve` after `Close`, triple concurrent `Close`, and `GOMAXPROCS=1`, each with a 20s hang detector.

## Notes

- No public API change. `Serve`, `Close`, `New`, and the options keep their signatures.
- `Close` stays idempotent and still blocks until teardown completes.
- Most of the diff is doc comments. This area already carried detailed reasoning about Close/Serve interleaving, and it now distinguishes what a WaitGroup actually guarantees (concurrent and repeated *Waits*) from what it does not (an `Add` racing a `Wait`), so the next reader does not have to rediscover the difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)