### PR TITLE
test: close the FakeClock Advance/NewTimer race behind BlockUntil

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,6 +1,7 @@
 package mamori
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
@@ -63,12 +64,18 @@ func SystemClock() Clock { return systemClock{} }
 
 // FakeClock is a manually-driven Clock for deterministic tests. Advance moves
 // time forward, firing any timers/tickers whose deadline is reached.
+//
+// Advance only ever fires the timers that are already registered when it runs,
+// so a test that advances the clock on behalf of another goroutine must first
+// wait for that goroutine to arm its timer. BlockUntil is how to wait; see its
+// doc comment for the race it closes.
 type FakeClock struct {
-	mu      sync.Mutex
-	now     time.Time
-	waiters []*waiter
-	tickers []*fakeTicker
-	nextID  int
+	mu       sync.Mutex
+	now      time.Time
+	waiters  []*waiter
+	tickers  []*fakeTicker
+	blockers []*blocker
+	nextID   int
 }
 
 type waiter struct {
@@ -76,6 +83,14 @@ type waiter struct {
 	deadline time.Time
 	ch       chan time.Time
 	fired    bool
+}
+
+// blocker is one outstanding BlockUntil call: ch is closed once at least want
+// timers are pending. It carries no deadline of its own - the caller's context
+// is what bounds the wait.
+type blocker struct {
+	want int
+	ch   chan struct{}
 }
 
 type fakeTicker struct {
@@ -113,6 +128,7 @@ func (c *FakeClock) NewTimer(d time.Duration) *Timer {
 		w.fired = true
 	} else {
 		c.waiters = append(c.waiters, w)
+		c.notifyBlockersLocked()
 	}
 	id := w.id
 	return &Timer{C: w.ch, stop: func() bool { return c.removeWaiter(id) }}
@@ -133,6 +149,98 @@ func (c *FakeClock) NewTicker(d time.Duration) *Ticker {
 	c.tickers = append(c.tickers, t)
 	id := t.id
 	return &Ticker{C: t.ch, stop: func() { c.stopTicker(id) }}
+}
+
+// BlockUntil waits until at least n timers are pending on the clock - that is,
+// until n calls to NewTimer or After (across any goroutine) have registered a
+// deadline that has not yet fired and has not been stopped - and returns nil.
+// It returns ctx.Err() if the context is done first, so a test that is wrong
+// about what it is waiting for fails on its own deadline with a clear message
+// instead of hanging until the package test timeout.
+//
+// It exists because Advance is not a synchronization point. Advance fires only
+// the timers already registered at the moment it runs, and a test typically
+// advances the clock on behalf of a goroutine that arms its own timers: the
+// polling watch adapter, the reconciler's debounce. Nothing orders that
+// goroutine's NewTimer call against the test's Advance call. Lose that race and
+// the goroutine registers its timer just after Advance walked the waiter list,
+// computing its deadline from the already-advanced now - so the deadline lands
+// in the future the test believes it has already passed, the timer never fires,
+// and the test waits for an event that can no longer happen. The failure is
+// silent at the point it happens and only surfaces later, as a timeout in a
+// receive that looks unrelated.
+//
+// Blocking on the registration first is what makes the ordering real:
+//
+//	clk.BlockUntil(ctx, 1) // the watched goroutine has armed its timer
+//	clk.Advance(2 * time.Second)
+//
+// The alternative - sleeping long enough to usually win the race - trades a
+// deterministic test for a slow flaky one, which is the whole thing FakeClock
+// exists to avoid.
+//
+// Two properties are worth knowing before choosing n. Only timers count, not
+// tickers, and a NewTimer(d) with d <= 0 fires immediately without ever
+// becoming pending, so it never counts. And n is compared against the
+// instantaneous pending set, not a running total: firing a timer (Advance) or
+// stopping it (Timer.Stop) drops the count again, so n describes what should be
+// armed right now, not how many have been armed since the clock was created.
+func (c *FakeClock) BlockUntil(ctx context.Context, n int) error {
+	c.mu.Lock()
+	if len(c.waiters) >= n {
+		c.mu.Unlock()
+		return nil
+	}
+	b := &blocker{want: n, ch: make(chan struct{})}
+	c.blockers = append(c.blockers, b)
+	c.mu.Unlock()
+
+	select {
+	case <-b.ch:
+		return nil
+	case <-ctx.Done():
+		// notifyBlockersLocked closes ch while holding the lock, so taking the
+		// lock here orders this against any concurrent satisfaction: if the
+		// count was reached before ctx expired, removeBlocker will not find b
+		// and the recheck below sees the closed channel. Report success in that
+		// case rather than a spurious error.
+		c.removeBlocker(b)
+		select {
+		case <-b.ch:
+			return nil
+		default:
+			return ctx.Err()
+		}
+	}
+}
+
+// notifyBlockersLocked releases every BlockUntil call whose count has now been
+// reached. It must be called with c.mu held, and only after c.waiters grows:
+// the count never has to be rechecked when a timer fires or is stopped, since
+// that can only lower it. Closing under the lock is what makes a racing
+// BlockUntil's ctx.Done path able to tell "satisfied" from "timed out".
+func (c *FakeClock) notifyBlockersLocked() {
+	n := len(c.waiters)
+	kept := c.blockers[:0]
+	for _, b := range c.blockers {
+		if n >= b.want {
+			close(b.ch)
+			continue
+		}
+		kept = append(kept, b)
+	}
+	c.blockers = kept
+}
+
+func (c *FakeClock) removeBlocker(target *blocker) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, b := range c.blockers {
+		if b == target {
+			c.blockers = append(c.blockers[:i], c.blockers[i+1:]...)
+			return
+		}
+	}
 }
 
 func (c *FakeClock) removeWaiter(id int) bool {

--- a/clock_test.go
+++ b/clock_test.go
@@ -1,9 +1,33 @@
 package mamori
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"go.uber.org/goleak"
 )
+
+// blockUntilTimersBudget bounds blockUntilTimers. It is a safety net, not a
+// timing assumption: in a passing run the wait is satisfied as soon as the
+// watched goroutine arms its timer, usually in microseconds. It only matters
+// when the timer is never armed at all, where a bounded failure with a clear
+// message beats hanging until the package test timeout.
+const blockUntilTimersBudget = 5 * time.Second
+
+// blockUntilTimers waits for n timers to be armed on clk before the caller
+// advances it, failing the test if they never are. Every clk.Advance that is
+// meant to fire a timer belonging to another goroutine needs this first; see
+// FakeClock.BlockUntil for the race it closes.
+func blockUntilTimers(t *testing.T, clk *FakeClock, n int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), blockUntilTimersBudget)
+	defer cancel()
+	if err := clk.BlockUntil(ctx, n); err != nil {
+		t.Fatalf("waiting for %d pending timer(s) on the fake clock: %v", n, err)
+	}
+}
 
 func TestFakeClockTimer(t *testing.T) {
 	c := NewFakeClock(time.Time{})
@@ -57,6 +81,91 @@ func TestFakeClockAfter(t *testing.T) {
 	case <-ch:
 	case <-time.After(time.Second):
 		t.Fatal("After channel did not unblock on advance")
+	}
+}
+
+func TestFakeClockBlockUntilAlreadySatisfied(t *testing.T) {
+	c := NewFakeClock(time.Time{})
+	timer := c.NewTimer(time.Second)
+	defer timer.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.BlockUntil(ctx, 1); err != nil {
+		t.Fatalf("BlockUntil with the timer already armed = %v, want nil", err)
+	}
+	// n == 0 is trivially true even with nothing armed.
+	if err := c.BlockUntil(ctx, 0); err != nil {
+		t.Fatalf("BlockUntil(0) = %v, want nil", err)
+	}
+}
+
+// TestFakeClockBlockUntilOrdersAdvance is the regression test for the race
+// BlockUntil exists to close: a goroutine that arms its timer only after the
+// test has started running must still have that timer fired by Advance.
+func TestFakeClockBlockUntilOrdersAdvance(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	c := NewFakeClock(time.Time{})
+	fired := make(chan time.Time, 1)
+	start := make(chan struct{})
+	go func() {
+		<-start
+		// Deliberately arm late, the way a real watched goroutine does: after
+		// the test goroutine is already on its way to Advance.
+		fired <- <-c.NewTimer(10 * time.Second).C
+	}()
+	close(start)
+
+	blockUntilTimers(t, c, 1)
+	c.Advance(10 * time.Second)
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timer armed after BlockUntil returned did not fire on Advance")
+	}
+}
+
+func TestFakeClockBlockUntilContextExpires(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	c := NewFakeClock(time.Time{})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := c.BlockUntil(ctx, 1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("BlockUntil with nothing ever armed = %v, want context.DeadlineExceeded", err)
+	}
+	// The abandoned blocker must not be left behind to be closed twice by a
+	// later registration.
+	timer := c.NewTimer(time.Second)
+	defer timer.Stop()
+	timer2 := c.NewTimer(time.Second)
+	defer timer2.Stop()
+}
+
+// TestFakeClockBlockUntilCountsPendingOnly pins the two properties BlockUntil's
+// doc comment calls out: an immediately-firing timer never becomes pending, and
+// the count drops again once a timer fires.
+func TestFakeClockBlockUntilCountsPendingOnly(t *testing.T) {
+	c := NewFakeClock(time.Time{})
+	c.NewTimer(0) // fires immediately, never pending
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := c.BlockUntil(ctx, 1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("NewTimer(0) counted as pending: BlockUntil = %v", err)
+	}
+
+	timer := c.NewTimer(time.Second)
+	blockUntilTimers(t, c, 1)
+	c.Advance(time.Second)
+	<-timer.C
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel2()
+	if err := c.BlockUntil(ctx2, 1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("a fired timer still counted as pending: BlockUntil = %v", err)
 	}
 }
 

--- a/notfound_health_test.go
+++ b/notfound_health_test.go
@@ -58,8 +58,12 @@ func TestHandleErrToleratesNotFoundOnDefaultField(t *testing.T) {
 
 	// Give the reconciler goroutine time to consume the update. There is no
 	// externally observable state change to poll for in the tolerated case
-	// (that is the point of the fix), so this mirrors waitPending's fixed
-	// delay used elsewhere in this package for a single update hop.
+	// (that is the point of the fix): the assertion below is that nothing
+	// happened, and a tolerated not-found arms no timer and moves no version,
+	// so there is nothing for blockUntilTimers or waitFlushed to wait on. A
+	// fixed delay is the honest shape for a negative assertion - unlike an
+	// Advance, it can only make this test miss a regression, never invent a
+	// failure.
 	time.Sleep(50 * time.Millisecond)
 
 	rep := w.Status()

--- a/poll_test.go
+++ b/poll_test.go
@@ -66,12 +66,16 @@ func TestPollInitialThenChange(t *testing.T) {
 
 	drainOne(t, ch, "v1") // initial baseline
 
-	// Unchanged across a tick -> no update.
+	// Unchanged across a tick -> no update. The poll goroutine arms its
+	// interval timer only after the baseline above is delivered, so wait for
+	// that registration: Advance fires nothing that is not already armed.
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(11 * time.Second)
 	noUpdate(t, ch)
 
 	// Changed value -> one update.
 	p.setVal(Value{Bytes: []byte("v2"), Version: "2"})
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(11 * time.Second)
 	drainOne(t, ch, "v2")
 
@@ -109,6 +113,12 @@ func TestPollNotAfterEarlyRefresh(t *testing.T) {
 	// Change the value; a refresh should happen before the lease NotAfter,
 	// well before the 1h poll interval.
 	p.setVal(Value{Bytes: []byte("lease2"), Version: "2", NotAfter: start.Add(4 * time.Second)})
+	// The lease-refresh timer is armed by the poll goroutine only after the
+	// baseline above is delivered, and Advance fires nothing that is not
+	// already armed. Without this the advance can outrun the registration,
+	// leaving the timer with a deadline in the test's own past that never
+	// fires - which is exactly the flake this test used to show in CI.
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(2 * time.Second)
 	drainOne(t, ch, "lease2")
 }

--- a/site/src/pages/docs/testing.md
+++ b/site/src/pages/docs/testing.md
@@ -223,17 +223,28 @@ Unlike `Load`, `Doctor` never aborts on the first failure, so one run reports ev
 `mamoritest.Provider` delivers changes natively, not on a poll timer. To drive time itself (for example, testing `mamori.WithPollInterval` against a provider that only polls), inject `mamori.NewFakeClock` with `mamori.WithClock` and advance it manually:
 
 ```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
 clk := mamori.NewFakeClock(time.Time{})
 
-w, err := mamori.Watch[Config](context.Background(),
+w, err := mamori.Watch[Config](ctx,
 	mamori.WithProvider(p),
 	mamori.WithClock(clk),
 	mamori.WithPollInterval(30*time.Second),
 )
 // ... err check, defer w.Close()
 
+// Wait for the poll goroutine to arm its timer before advancing.
+if err := clk.BlockUntil(ctx, 1); err != nil {
+	t.Fatal(err)
+}
 clk.Advance(30 * time.Second) // fires the next poll tick deterministically
 ```
+
+That `BlockUntil` is not optional politeness - it is what makes the test deterministic. `Advance` fires only the timers already registered when it runs, and the watch goroutine arms its next timer *after* delivering the previous value, computing the deadline from whatever `Now()` says at that moment. Advance ahead of the registration and the timer is created with a deadline in the time you have already skipped past: it never fires, and the test blocks until some unrelated timeout with nothing to point at.
+
+`BlockUntil(ctx, n)` returns once at least `n` timers are armed on the clock, or `ctx.Err()` if they never are - so an expectation that is simply wrong fails on your own deadline instead of hanging. Reach for it before **every** `Advance` meant to fire a timer belonging to another goroutine. Sleeping first only makes the race rarer.
 
 ## How it works
 

--- a/status_test.go
+++ b/status_test.go
@@ -300,7 +300,7 @@ func TestStatusSnapshotVersionAdvances(t *testing.T) {
 	}
 
 	wp.push("cfg/level", "debug", "l2")
-	waitPending(clk)
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(defaultDebounce)
 
 	deadline := time.Now().Add(2 * time.Second)

--- a/watch_semantics_test.go
+++ b/watch_semantics_test.go
@@ -38,7 +38,21 @@ func TestWatchCoalescing(t *testing.T) {
 	wp.push("a", "2", "a2")
 	wp.push("b", "2", "b2")
 	wp.push("c", "2", "c2")
-	waitPending(clk)
+	// All three updates must reach the reconciler before the clock advances.
+	// Waiting for the debounce timer alone would not be enough here: the first
+	// update arms it and the other two only re-arm the same deadline, so a
+	// timer-count wait can be satisfied while b and c are still in flight and
+	// the flush would then coalesce fewer than three fields. The published
+	// report is the stronger observable - the reconciler stores it after
+	// folding in each update, which is after it has armed the timer - so
+	// waiting for all three versions to appear there orders both.
+	waitUntil(t, 2*time.Second, "all three pushed versions observed", func() bool {
+		seen := map[string]bool{}
+		for _, f := range w.Status().Fields {
+			seen[f.Version] = true
+		}
+		return seen["a2"] && seen["b2"] && seen["c2"]
+	})
 	clk.Advance(defaultDebounce)
 
 	select {
@@ -86,8 +100,14 @@ func TestWatchSerializedDispatch(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		ver := "v" + string(rune('a'+i))
 		wp.push("prod/db#password", "p"+ver, ver)
-		waitPending(clk)
+		blockUntilTimers(t, clk, 1)
 		clk.Advance(defaultDebounce)
+		// Wait for this round's flush before pushing again. Otherwise the next
+		// push can reach the reconciler before it has taken the tick this
+		// Advance just delivered, which re-arms the debounce at a deadline
+		// already in the past: a timer that fires immediately and is therefore
+		// never pending for the next blockUntilTimers to observe.
+		waitFlushed(t, w, uint64(i+2))
 	}
 	// Wait for delivery.
 	deadline := time.Now().Add(2 * time.Second)
@@ -127,9 +147,13 @@ func TestWatchDropOldest(t *testing.T) {
 	for i := 2; i <= 5; i++ {
 		ver := "v" + string(rune('0'+i))
 		wp.push("prod/db#password", "p"+ver, ver)
-		waitPending(clk)
+		blockUntilTimers(t, clk, 1)
 		clk.Advance(defaultDebounce)
-		time.Sleep(20 * time.Millisecond)
+		// Each round must flush (and enqueue its Change) before the next push,
+		// both so the queue-depth-1 drop-oldest path is exercised one event at
+		// a time and so the next debounce is armed from an empty pending batch
+		// - see the same wait in TestWatchSerializedDispatch.
+		waitFlushed(t, w, uint64(i))
 	}
 	close(gate) // release the blocked first delivery
 
@@ -200,8 +224,12 @@ func TestWatchBackoffRetainsLastGood(t *testing.T) {
 	if w.Get().V != "good" {
 		t.Fatalf("initial V = %q, want good", w.Get().V)
 	}
-	// Trigger a poll that fails.
-	time.Sleep(20 * time.Millisecond)
+	// Trigger a poll that fails. This provider is not watchable, so the field
+	// is driven by the polling adapter, which arms its interval timer only
+	// after its own baseline resolve has been delivered - wait for that
+	// registration rather than guessing at a sleep, or Advance can run first
+	// and leave the timer with a deadline it will never reach.
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(11 * time.Second)
 
 	select {
@@ -234,9 +262,12 @@ func TestWatchShutdownNoLeak(t *testing.T) {
 		t.Fatal(err)
 	}
 	wp.push("prod/db#password", "new", "v2")
-	waitPending(clk)
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(defaultDebounce)
-	time.Sleep(30 * time.Millisecond)
+	// Close while an update has actually been through the reconciler, which is
+	// the shutdown this test is about; waiting for the flush rather than
+	// sleeping is what guarantees the update got that far.
+	waitFlushed(t, w, 2)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)

--- a/watch_test.go
+++ b/watch_test.go
@@ -3,6 +3,7 @@ package mamori
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -103,6 +104,25 @@ type watchConfig struct {
 	Level    string        `source:"w://cfg/level" default:"info" validate:"oneof=debug info warn error"`
 }
 
+// waitFlushed waits until the reconciler has applied snapshot version want.
+// It is the counterpart to blockUntilTimers for the other half of a debounce
+// round trip: blockUntilTimers orders the test's Advance after the timer is
+// armed, and this orders whatever the test does next after the flush that
+// Advance triggered. A test that pushes repeatedly needs both, because pushing
+// again while the previous tick is still unconsumed re-arms the debounce with
+// a deadline already in the past - a timer that fires immediately and so never
+// becomes pending for the next blockUntilTimers to see.
+//
+// The published report is what makes this observable: flush stores it last,
+// after bumping the version and enqueuing the Change, so a report carrying
+// version want proves the whole round completed.
+func waitFlushed[T any](t *testing.T, w *Watcher[T], want uint64) {
+	t.Helper()
+	waitUntil(t, 2*time.Second, fmt.Sprintf("reconciler to apply snapshot version %d", want), func() bool {
+		return w.Status().Live >= want
+	})
+}
+
 func TestWatchInitialAndNoStartupEvent(t *testing.T) {
 	clk := NewFakeClock(time.Time{})
 	wp := newWatchProvider("w")
@@ -148,8 +168,9 @@ func TestWatchAppliesValidUpdate(t *testing.T) {
 	defer func() { _ = w.Close() }()
 
 	wp.push("prod/db#password", "new", "v2")
-	// Let the update reach the reconciler, then advance past the debounce window.
-	waitPending(clk)
+	// Let the update reach the reconciler and arm its debounce timer, then
+	// advance past the debounce window.
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(defaultDebounce)
 
 	select {
@@ -193,7 +214,7 @@ func TestWatchRejectsInvalidUpdateAtomically(t *testing.T) {
 	defer func() { _ = w.Close() }()
 
 	wp.push("cfg/level", "BOGUS", "l2") // fails oneof validation
-	waitPending(clk)
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(defaultDebounce)
 
 	select {
@@ -214,7 +235,3 @@ func TestWatchRejectsInvalidUpdateAtomically(t *testing.T) {
 		t.Errorf("Get().Level = %q, want info (last good)", w.Get().Level)
 	}
 }
-
-// waitPending gives the reconciler goroutine a moment to consume the pushed
-// update and arm its debounce timer against the fake clock before we advance.
-func waitPending(_ *FakeClock) { time.Sleep(30 * time.Millisecond) }

--- a/watchref_test.go
+++ b/watchref_test.go
@@ -43,6 +43,18 @@ func (p *wrefStaticProvider) setVal(v mamori.Value) {
 	p.mu.Unlock()
 }
 
+// wrefBlockUntilTimers waits for n timers to be armed on clk before the caller
+// advances it. It is the external-test-package twin of the internal helper of
+// the same shape; see mamori.FakeClock.BlockUntil for the race it closes.
+func wrefBlockUntilTimers(t *testing.T, clk *mamori.FakeClock, n int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := clk.BlockUntil(ctx, n); err != nil {
+		t.Fatalf("waiting for %d pending timer(s) on the fake clock: %v", n, err)
+	}
+}
+
 func wrefDrainOne(t *testing.T, ch <-chan mamori.Update, wantBytes string) {
 	t.Helper()
 	select {
@@ -113,12 +125,16 @@ func TestWatchRefPollsNonWatchableProvider(t *testing.T) {
 
 	wrefDrainOne(t, ch, "v1") // initial baseline, exactly as pollWatch emits
 
-	// Unchanged across a tick -> no update.
+	// Unchanged across a tick -> no update. The polling adapter arms its
+	// interval timer only after the baseline above is delivered, so wait for
+	// that registration: Advance fires nothing that is not already armed.
+	wrefBlockUntilTimers(t, clk, 1)
 	clk.Advance(11 * time.Second)
 	wrefNoUpdate(t, ch)
 
 	// Changed value -> one update, only after the poll interval elapses.
 	p.setVal(mamori.Value{Bytes: []byte("v2"), Version: "2"})
+	wrefBlockUntilTimers(t, clk, 1)
 	clk.Advance(11 * time.Second)
 	wrefDrainOne(t, ch, "v2")
 


### PR DESCRIPTION
CI ran commit `190d8c7` **twice under the same workflow**: one run passed, one failed on `TestPollNotAfterEarlyRefresh`. Same code, different results. That is a flaky test, and this fixes the cause rather than the symptom.

## The race

`FakeClock.Advance` fires only timers already present in `c.waiters`, and `NewTimer` dates its deadline from `c.now` **at call time**. A test that starts a goroutine and then immediately calls `Advance` has no ordering between the two:

```go
ch := pollWatch(ctx, p, ref, o)   // goroutine will register a timer... eventually
drainOne(t, ch, "lease1")
clk.Advance(2 * time.Second)      // ...but maybe not before this
drainOne(t, ch, "lease2")         // times out
```

Lose the race and the timer is armed *after* the advance, either missing the lease shortcut entirely (`untilExpiry == 0`, so it falls back to the 1h poll interval) or landing on a deadline the clock has already skipped past. It never fires, and `drainOne` burns its timeout. The 2.00s in the CI log is that timeout.

## The fix

`FakeClock.BlockUntil(ctx context.Context, n int) error` blocks until `n` waiters are registered, on the same list `Advance` walks. Tests then read:

```go
if err := clk.BlockUntil(ctx, 1); err != nil { t.Fatal(err) }
clk.Advance(2 * time.Second)
```

It takes a `context` deliberately: a wrong `n` fails on the caller's deadline with a clear error instead of hanging the suite forever.

Deliberately **not** fixed by widening a timeout or adding a sleep. That trades a fast deterministic failure for a slow nondeterministic one, which is the exact anti-pattern `FakeClock` exists to avoid.

## Scope: this was not one test

20 `Advance` call sites assessed.

- **10 were hazardous** and are fixed: `TestPollNotAfterEarlyRefresh` plus 3 more poll tests, 2 watchref, 4 reconciler debounce.
- **3 were hazardous but needed a stronger wait than a timer count.** A debounce re-armed at an already-passed deadline becomes `NewTimer(0)`, which fires immediately and is never pending, so a naive `BlockUntil` there would have introduced a *new* flake. Those wait on the published report instead.
- **6 are genuinely safe** and were left alone: single-goroutine `clock_test.go` cases, `middleware.Cache` (registers no timers), and `status_test.go` (only ages the clock for read-time recomputation).

`watch_test.go`'s `waitPending` was a `time.Sleep(30ms)` standing in for synchronization. It is gone, along with three other sleeps that existed for the same reason.

## Verification

`go test -run TestPollNotAfterEarlyRefresh -count=1000 -race .`

- **before: 22/1000 failures (2.2%)**
- **after: 0/1000**

Plus 0 failures across 400 `-race` runs of all 16 touched tests, full `-race ./...` green, `golangci-lint` clean.

## Notes

- No production behavior changes. `clock.go`'s change is purely additive; `poll.go` and the reconciler are untouched.
- `BlockUntil` is new public API on an already-exported type, so it is documented in `site/src/pages/docs/testing.md`.
- Typed `test:` rather than `fix:` on purpose: test code and test-support API only, so semantic-release does not cut a version.
- One trap worth knowing before adding `BlockUntil` to a new push-in-a-loop test: a timer created with a non-positive duration fires immediately and never appears as a pending waiter, so counting waiters will not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `FakeClock.BlockUntil` to wait deterministically for pending timers, with context cancellation support.
* **Bug Fixes**
  * Improved reliability of fake-clock polling, watch, status, and shutdown tests by synchronizing timer registration before advancing time.
  * Reduced timing-related test flakiness and clarified timer-related assertions.
* **Documentation**
  * Updated testing guidance to demonstrate deterministic fake-clock synchronization with `BlockUntil`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->