### PR TITLE
feat: ?decode= value transforms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,13 @@ Read the [Write a provider guide](https://mamorigo.dev/docs/writing-a-provider) 
    selector on an evaluated result, or unused - the case skips rather than
    failing.
 
+   The kit also runs `DecodeOption` unconditionally (no opt-in, no config
+   field to wire): it asserts your `Resolve` passes an unrecognized query
+   option like `?decode=base64` through untouched, since decoding a resolved
+   value is entirely core's job (`applyDecode`), not the provider's. This
+   normally requires no extra work - it only fails if your provider inspects,
+   strips, or rejects query options it does not itself recognize.
+
 6. Add a `README.md` documenting schemes, ref grammar, auth, and what is verified vs needs a live backend. A provider that passes `providertest` gets listed in the root README with a badge.
 7. If you classified errors beyond not-found (step 3), also: add an `## Error classification` section to the module's `README.md`, mirror it onto the module's docs-site page, and flip that module's row in both coverage tables (the root `README.md` and `site/src/pages/docs/providers/index.md`).
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ type Config struct {
     // A file-backed value, hot-reloaded via fsnotify
     TLSCert    []byte        `source:"file:///etc/tls/tls.crt"`
 
+    // ?decode=base64 declares the stored value is base64; core decodes it
+    // back to raw bytes before TLSKey is populated
+    TLSKey     []byte        `source:"aws-sm://prod/tls#key?decode=base64"`
+
     // A nested struct decoded from one JSON secret
     Redis      RedisConfig   `source:"aws-sm://prod/redis" flatten:"json"`
 }
@@ -84,6 +88,7 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 
 - **Typed & tag-driven** - one struct, multiple sources, generics API (`Load[T]` / `Watch[T]`).
 - **Nested selection** - `#/credentials/password` is an RFC 6901 JSON Pointer, addressing a value at any depth through objects and array elements; any other fragment (`#ca.crt`, `#tls.key`) stays a literal top-level key, exactly as before.
+- **Value decoding** - `?decode=base64,gzip` runs a stdlib-only pipeline (`base64`, `base64url`, `hex`, `gzip`, `trim`) over a resolved value before it reaches your struct field, left to right, outermost wrapper first; a bad payload is a loud `ErrInvalid`, never a silent passthrough.
 - **Precedence chains** - `source:"env:PORT,aws-ps://svc/port"` tries sources in priority order: the first to yield a value wins, not-found falls through to the next, and a real error stops the walk and applies the field's `onfail` policy instead of silently sliding to a lower-priority source. Every position is watched, so precedence is live.
 - **Reconciled at runtime** - native watch where the backend supports it (Kubernetes informers, Consul blocking queries, fsnotify), polling with jitter everywhere else, and lease-aware pre-expiry refresh for Vault.
 - **Atomic & validated** - an update that fails validation is *rejected*; `Get()` keeps returning the last good config. Config never enters a broken state mid-flight.

--- a/decode.go
+++ b/decode.go
@@ -108,6 +108,15 @@ func walkSpecs(t reflect.Type, prefix string, index []int) ([]fieldSpec, error) 
 			return nil, fmt.Errorf("mamori: field %s: %w", path, err)
 		}
 
+		// Every ref in the chain is validated, not just the first: a typo in a
+		// lower-precedence position would otherwise stay silent until that
+		// position actually won.
+		for _, r := range refs {
+			if _, err := parseDecodePipeline(r.Opt("decode")); err != nil {
+				return nil, fmt.Errorf("mamori: field %s: %w", path, err)
+			}
+		}
+
 		onFail := onFailKeepLast
 		if hasOnFail {
 			switch onFailTag {

--- a/decode_test.go
+++ b/decode_test.go
@@ -118,6 +118,28 @@ func TestFieldSpecsRejectsUnknownDecodeCoding(t *testing.T) {
 	}
 }
 
+// TestFieldSpecsRejectsUnknownDecodeCodingInLowerChainPosition is the reason
+// the spec walk checks every ref rather than only Refs[0]: a lower-precedence
+// position is not consulted until the ones above it are all absent, so a typo
+// there would otherwise stay silent for as long as the primary source keeps
+// answering, and then fail the process at the worst possible moment - during
+// the outage that finally promotes it.
+func TestFieldSpecsRejectsUnknownDecodeCodingInLowerChainPosition(t *testing.T) {
+	type cfg struct {
+		A string `source:"env:A,env:B?decode=rot13"`
+	}
+	_, err := fieldSpecs(reflect.TypeOf(cfg{}))
+	if err == nil {
+		t.Fatal("want an error for an unknown decode coding on the second chain position, got nil")
+	}
+	if !strings.Contains(err.Error(), "rot13") {
+		t.Errorf("error %q should name the offending coding", err)
+	}
+	if !strings.Contains(err.Error(), "A") {
+		t.Errorf("error %q should name the offending field", err)
+	}
+}
+
 func TestFieldSpecsAcceptsKnownDecodeCodings(t *testing.T) {
 	type cfg struct {
 		A string `source:"env:A?decode=base64,gzip"`

--- a/decode_test.go
+++ b/decode_test.go
@@ -101,3 +101,28 @@ func TestWalkSpecsChain(t *testing.T) {
 		}
 	})
 }
+
+func TestFieldSpecsRejectsUnknownDecodeCoding(t *testing.T) {
+	type cfg struct {
+		A string `source:"env:A?decode=rot13"`
+	}
+	_, err := fieldSpecs(reflect.TypeOf(cfg{}))
+	if err == nil {
+		t.Fatal("want an error for an unknown decode coding, got nil")
+	}
+	if !strings.Contains(err.Error(), "rot13") {
+		t.Errorf("error %q should name the offending coding", err)
+	}
+	if !strings.Contains(err.Error(), "A") {
+		t.Errorf("error %q should name the offending field", err)
+	}
+}
+
+func TestFieldSpecsAcceptsKnownDecodeCodings(t *testing.T) {
+	type cfg struct {
+		A string `source:"env:A?decode=base64,gzip"`
+	}
+	if _, err := fieldSpecs(reflect.TypeOf(cfg{})); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/decodeopt.go
+++ b/decodeopt.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -22,6 +23,22 @@ type decodeStep struct {
 // stated property of the project layout, and an extension point here would
 // duplicate WithDecodeHook, which already exists one layer down for arbitrary
 // per-type conversion.
+//
+// The whitespace handling here is deliberately asymmetric, and the asymmetry
+// is load-bearing rather than an oversight: base64, base64url, and hex trim
+// surrounding whitespace, gzip does not.
+//
+// The textual codings need the trim because stored values routinely pick up a
+// trailing newline - `base64 < key.pem > secret` writes one, most editors add
+// one on save, and several backends' CLIs round-trip through a file - and
+// rejecting a secret over an invisible byte is a miserable failure to debug.
+//
+// gzip must NOT be trimmed, because its payload is binary: a valid gzip stream
+// can legitimately begin or end with bytes whose numeric values are ASCII
+// whitespace (the 4-byte CRC32 and 4-byte ISIZE trailer are raw little-endian
+// integers, so a trailer ending in 0x0a, 0x0d, 0x09, or 0x20 is entirely
+// ordinary). Trimming those would silently corrupt a valid stream into a CRC
+// or length mismatch. Please do not "fix" the inconsistency by trimming here.
 var decodeCodings = map[string]func([]byte) ([]byte, error){
 	"base64":    func(b []byte) ([]byte, error) { return base64.StdEncoding.DecodeString(string(bytes.TrimSpace(b))) },
 	"base64url": func(b []byte) ([]byte, error) { return base64.URLEncoding.DecodeString(string(bytes.TrimSpace(b))) },
@@ -30,13 +47,49 @@ var decodeCodings = map[string]func([]byte) ([]byte, error){
 	"trim":      func(b []byte) ([]byte, error) { return bytes.TrimSpace(b), nil },
 }
 
+// maxGzipDecoded bounds how many bytes one gzip coding will produce. gzip is
+// the only coding here whose output is not linear in its input: base64 and hex
+// shrink, trim cannot grow, but a few hundred bytes of gzip can expand to
+// gigabytes. Since mamori resolves from remote backends whose contents an
+// operator may not fully control - an S3 object, a Secrets Manager entry, a
+// config server's response - an unbounded io.ReadAll here is a
+// denial-of-service reachable by whoever can write the stored value.
+//
+// 16 MiB is chosen to sit far above every realistic payload and far below
+// anything that threatens a process. The backends mamori reads from impose
+// their own, much tighter ceilings on a single value: 64 KiB for AWS Secrets
+// Manager and GCP Secret Manager, 25 KiB for Azure Key Vault, 512 KiB for
+// Consul KV, 1 MiB for a Kubernetes Secret, ~1.5 MiB for an etcd value. The
+// unbounded sources are the local ones (file:, exec:, dotenv:), and a 16 MiB
+// decompressed application config or secret bundle from those is already well
+// past anything this library is meant to carry. That leaves roughly a 16x
+// margin over the most permissive remote backend while capping a bomb's
+// expansion at a single, recoverable allocation.
+//
+// Exceeding it is an error, never a truncation. Handing an application 16 MiB
+// of a longer secret would be worse than failing: a silently truncated key or
+// certificate fails later, somewhere else, in a way that looks like anything
+// but a decode problem.
+const maxGzipDecoded = 16 << 20 // 16 MiB
+
 func gunzip(b []byte) ([]byte, error) {
 	zr, err := gzip.NewReader(bytes.NewReader(b))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = zr.Close() }()
-	return io.ReadAll(zr)
+	// Read one byte past the cap so "expanded to exactly the cap" stays legal
+	// and is still distinguishable from "expanded past it": io.LimitReader
+	// alone reports a clean io.EOF at its limit, which io.ReadAll cannot tell
+	// apart from a stream that genuinely ended there.
+	out, err := io.ReadAll(io.LimitReader(zr, maxGzipDecoded+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(out) > maxGzipDecoded {
+		return nil, fmt.Errorf("payload expands past the %d-byte gzip decompression limit: %w", maxGzipDecoded, ErrInvalid)
+	}
+	return out, nil
 }
 
 // parseDecodePipeline turns a ?decode= option value into an ordered pipeline.
@@ -89,6 +142,14 @@ func applyDecode(ref Ref, v Value) (Value, error) {
 	for _, s := range steps {
 		b, err = s.fn(b)
 		if err != nil {
+			// A coding that already classified its own failure (gunzip's
+			// decompression bound) is wrapped once; everything else - the
+			// stdlib's own base64/hex errors, which carry no mamori sentinel -
+			// gets the two-verb form so the classification is always present
+			// exactly once in the chain rather than repeated in the message.
+			if errors.Is(err, ErrInvalid) {
+				return Value{}, fmt.Errorf("mamori: ref %q: %s decode failed: %w", redactRef(ref), s.name, err)
+			}
 			return Value{}, fmt.Errorf("mamori: ref %q: %s decode failed: %w: %w", redactRef(ref), s.name, ErrInvalid, err)
 		}
 	}

--- a/decodeopt.go
+++ b/decodeopt.go
@@ -1,0 +1,97 @@
+package mamori
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// decodeStep is one coding in a ?decode= pipeline, carrying its name so a
+// failure can say which stage failed rather than only that decoding failed.
+type decodeStep struct {
+	name string
+	fn   func([]byte) ([]byte, error)
+}
+
+// decodeCodings is the closed set of codings ?decode= understands. It is
+// deliberately closed and deliberately stdlib-only: core's dependency set is a
+// stated property of the project layout, and an extension point here would
+// duplicate WithDecodeHook, which already exists one layer down for arbitrary
+// per-type conversion.
+var decodeCodings = map[string]func([]byte) ([]byte, error){
+	"base64":    func(b []byte) ([]byte, error) { return base64.StdEncoding.DecodeString(string(bytes.TrimSpace(b))) },
+	"base64url": func(b []byte) ([]byte, error) { return base64.URLEncoding.DecodeString(string(bytes.TrimSpace(b))) },
+	"hex":       func(b []byte) ([]byte, error) { return hex.DecodeString(string(bytes.TrimSpace(b))) },
+	"gzip":      gunzip,
+	"trim":      func(b []byte) ([]byte, error) { return bytes.TrimSpace(b), nil },
+}
+
+func gunzip(b []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = zr.Close() }()
+	return io.ReadAll(zr)
+}
+
+// parseDecodePipeline turns a ?decode= option value into an ordered pipeline.
+// Codings are applied left to right, outermost wrapper first: "base64,gzip"
+// means the stored value is base64 of gzip of the payload, so it is
+// base64-decoded and then gunzipped.
+//
+// The option is named decode rather than encoding precisely so that order is
+// unambiguous. HTTP's Content-Encoding lists codings in the order they were
+// applied and is therefore decoded in reverse; naming this one after the action
+// removes any question of which direction the list reads.
+func parseDecodePipeline(spec string) ([]decodeStep, error) {
+	if spec == "" {
+		return nil, nil
+	}
+	parts := strings.Split(spec, ",")
+	steps := make([]decodeStep, 0, len(parts))
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		fn, ok := decodeCodings[name]
+		if !ok {
+			return nil, fmt.Errorf("mamori: unknown decode coding %q (want base64, base64url, hex, gzip, or trim): %w", name, ErrInvalid)
+		}
+		steps = append(steps, decodeStep{name: name, fn: fn})
+	}
+	return steps, nil
+}
+
+// applyDecode runs ref's ?decode= pipeline over v's bytes, returning v
+// unchanged when the ref carries no decode option.
+//
+// Version, Sensitive, NotAfter, and Metadata are carried through untouched. In
+// particular Version still describes the provider's revision of the source, not
+// the decoded form, so Value.changed keeps detecting change exactly as it does
+// for an undecoded field.
+//
+// The pipeline is re-derived per call rather than cached on the Ref: it is a
+// string split and a map lookup per coding, which is free next to the network
+// round trip that produced v, and caching it would mean giving Ref mutable
+// state it does not otherwise have.
+func applyDecode(ref Ref, v Value) (Value, error) {
+	steps, err := parseDecodePipeline(ref.Opt("decode"))
+	if err != nil {
+		return Value{}, fmt.Errorf("mamori: ref %q: %w", redactRef(ref), err)
+	}
+	if len(steps) == 0 {
+		return v, nil
+	}
+	b := v.Bytes
+	for _, s := range steps {
+		b, err = s.fn(b)
+		if err != nil {
+			return Value{}, fmt.Errorf("mamori: ref %q: %s decode failed: %w: %w", redactRef(ref), s.name, ErrInvalid, err)
+		}
+	}
+	v.Bytes = b
+	return v, nil
+}

--- a/decodeopt.go
+++ b/decodeopt.go
@@ -34,11 +34,16 @@ type decodeStep struct {
 // rejecting a secret over an invisible byte is a miserable failure to debug.
 //
 // gzip must NOT be trimmed, because its payload is binary: a valid gzip stream
-// can legitimately begin or end with bytes whose numeric values are ASCII
-// whitespace (the 4-byte CRC32 and 4-byte ISIZE trailer are raw little-endian
-// integers, so a trailer ending in 0x0a, 0x0d, 0x09, or 0x20 is entirely
-// ordinary). Trimming those would silently corrupt a valid stream into a CRC
-// or length mismatch. Please do not "fix" the inconsistency by trimming here.
+// can legitimately END with bytes whose numeric values are ASCII whitespace.
+// The 4-byte CRC32 and 4-byte ISIZE trailer are raw little-endian integers, so
+// a trailer ending in 0x0a, 0x0d, 0x09, or 0x20 is entirely ordinary, and
+// trimming it would silently corrupt a valid stream into a CRC or length
+// mismatch. (The leading bytes are not at risk - a gzip stream always starts
+// with the magic 0x1f 0x8b - but the trailing case alone settles it.)
+//
+// Please do not "fix" the inconsistency by trimming here. A genuinely
+// whitespace-padded gzip payload already has an explicit escape hatch that
+// does not put every other gzip value at risk: ?decode=trim,gzip.
 var decodeCodings = map[string]func([]byte) ([]byte, error){
 	"base64":    func(b []byte) ([]byte, error) { return base64.StdEncoding.DecodeString(string(bytes.TrimSpace(b))) },
 	"base64url": func(b []byte) ([]byte, error) { return base64.URLEncoding.DecodeString(string(bytes.TrimSpace(b))) },
@@ -70,6 +75,13 @@ var decodeCodings = map[string]func([]byte) ([]byte, error){
 // of a longer secret would be worse than failing: a silently truncated key or
 // certificate fails later, somewhere else, in a way that looks like anything
 // but a decode problem.
+//
+// The cap is deliberately a constant with no Option to override it, so a
+// legitimate payload above it - realistically only from an unbounded local
+// source like file: or exec: - has no escape hatch short of not declaring
+// ?decode=gzip and gunzipping in application code. That is the accepted cost
+// of not growing the public API for a case no supported backend can even
+// produce; raising the constant is the intended response if one ever appears.
 const maxGzipDecoded = 16 << 20 // 16 MiB
 
 func gunzip(b []byte) ([]byte, error) {

--- a/decodeopt_test.go
+++ b/decodeopt_test.go
@@ -1,0 +1,132 @@
+package mamori
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+func gz(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestApplyDecodeRoundTrip(t *testing.T) {
+	plain := []byte("s3cr3t")
+	tests := []struct {
+		spec string
+		in   []byte
+	}{
+		{"base64", []byte(base64.StdEncoding.EncodeToString(plain))},
+		{"base64url", []byte(base64.URLEncoding.EncodeToString(plain))},
+		{"hex", []byte(hex.EncodeToString(plain))},
+		{"gzip", gz(t, plain)},
+		{"trim", []byte("  s3cr3t\n")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.spec, func(t *testing.T) {
+			ref, err := ParseRef("env:X?decode=" + tt.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := applyDecode(ref, Value{Bytes: tt.in})
+			if err != nil {
+				t.Fatalf("applyDecode: %v", err)
+			}
+			if string(got.Bytes) != string(plain) {
+				t.Errorf("= %q, want %q", got.Bytes, plain)
+			}
+		})
+	}
+}
+
+func TestApplyDecodeChainAppliesLeftToRight(t *testing.T) {
+	plain := []byte("s3cr3t")
+	// decode=base64,gzip means: base64-decode first, then gunzip. So the stored
+	// value is base64(gzip(plain)).
+	stored := []byte(base64.StdEncoding.EncodeToString(gz(t, plain)))
+	ref, err := ParseRef("env:X?decode=base64,gzip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := applyDecode(ref, Value{Bytes: stored})
+	if err != nil {
+		t.Fatalf("applyDecode: %v", err)
+	}
+	if string(got.Bytes) != string(plain) {
+		t.Errorf("= %q, want %q", got.Bytes, plain)
+	}
+}
+
+func TestApplyDecodeFailureIsInvalid(t *testing.T) {
+	for _, spec := range []string{"base64", "base64url", "hex", "gzip"} {
+		t.Run(spec, func(t *testing.T) {
+			ref, err := ParseRef("env:X?decode=" + spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = applyDecode(ref, Value{Bytes: []byte("!!! not valid !!!")})
+			if !errors.Is(err, ErrInvalid) {
+				t.Fatalf("err = %v, want ErrInvalid", err)
+			}
+		})
+	}
+}
+
+func TestApplyDecodePreservesMetadata(t *testing.T) {
+	ref, err := ParseRef("env:X?decode=base64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := Value{
+		Bytes:     []byte(base64.StdEncoding.EncodeToString([]byte("v"))),
+		Version:   "abc123",
+		Sensitive: true,
+		Metadata:  map[string]string{"k": "v"},
+	}
+	got, err := applyDecode(ref, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != "abc123" {
+		t.Errorf("Version = %q, want abc123 (the provider revision describes the source, not the decoded form)", got.Version)
+	}
+	if !got.Sensitive {
+		t.Error("Sensitive was lost across the decode pipeline")
+	}
+	if got.Metadata["k"] != "v" {
+		t.Error("Metadata was lost across the decode pipeline")
+	}
+}
+
+func TestApplyDecodeNoOptIsPassthrough(t *testing.T) {
+	ref, err := ParseRef("env:X")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := applyDecode(ref, Value{Bytes: []byte("raw")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Bytes) != "raw" {
+		t.Errorf("= %q, want raw", got.Bytes)
+	}
+}
+
+func TestParseDecodePipelineUnknownCoding(t *testing.T) {
+	_, err := parseDecodePipeline("base64,rot13")
+	if !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
+	}
+}

--- a/decodeopt_test.go
+++ b/decodeopt_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"testing"
+	"time"
 )
 
 func gz(t *testing.T, b []byte) []byte {
@@ -89,10 +90,12 @@ func TestApplyDecodePreservesMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	notAfter := time.Date(2031, 4, 5, 6, 7, 8, 0, time.UTC)
 	in := Value{
 		Bytes:     []byte(base64.StdEncoding.EncodeToString([]byte("v"))),
 		Version:   "abc123",
 		Sensitive: true,
+		NotAfter:  notAfter,
 		Metadata:  map[string]string{"k": "v"},
 	}
 	got, err := applyDecode(ref, in)
@@ -101,6 +104,9 @@ func TestApplyDecodePreservesMetadata(t *testing.T) {
 	}
 	if got.Version != "abc123" {
 		t.Errorf("Version = %q, want abc123 (the provider revision describes the source, not the decoded form)", got.Version)
+	}
+	if !got.NotAfter.Equal(notAfter) {
+		t.Errorf("NotAfter = %v, want %v (expiry describes the source value and must survive decoding)", got.NotAfter, notAfter)
 	}
 	if !got.Sensitive {
 		t.Error("Sensitive was lost across the decode pipeline")
@@ -121,6 +127,52 @@ func TestApplyDecodeNoOptIsPassthrough(t *testing.T) {
 	}
 	if string(got.Bytes) != "raw" {
 		t.Errorf("= %q, want raw", got.Bytes)
+	}
+}
+
+// TestGunzipRejectsDecompressionBomb feeds gunzip a payload that is tiny on
+// the wire and enormous once expanded. mamori reads from remote backends an
+// operator may not fully control (an S3 object, a config server response), so
+// an unbounded io.ReadAll here would let a crafted value exhaust the process's
+// memory. The bound must be a loud error rather than a silent truncation: a
+// truncated secret handed to the application is worse than a failed resolve.
+func TestGunzipRejectsDecompressionBomb(t *testing.T) {
+	bomb := gz(t, make([]byte, maxGzipDecoded+1)) // zeroes compress to a few hundred bytes
+	if len(bomb) > 64*1024 {
+		t.Fatalf("bomb is %d bytes on the wire; the test wants a genuinely small payload", len(bomb))
+	}
+
+	out, err := gunzip(bomb)
+	if err == nil {
+		t.Fatalf("gunzip accepted a %d-byte expansion (returned %d bytes); it must be bounded", maxGzipDecoded+1, len(out))
+	}
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("err = %v, want one wrapping ErrInvalid", err)
+	}
+	if out != nil {
+		t.Errorf("gunzip returned %d bytes alongside the error; a truncated payload must never reach the caller", len(out))
+	}
+
+	// The same bomb through the public pipeline must fail the same way, so the
+	// bound is real for every caller and not just a direct gunzip call.
+	ref, err := ParseRef("env:X?decode=gzip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyDecode(ref, Value{Bytes: bomb}); !errors.Is(err, ErrInvalid) {
+		t.Errorf("applyDecode err = %v, want one wrapping ErrInvalid", err)
+	}
+}
+
+// TestGunzipAcceptsPayloadAtTheLimit pins that the bound is off-by-one-free:
+// a payload expanding to exactly the cap is legal, only one byte more is not.
+func TestGunzipAcceptsPayloadAtTheLimit(t *testing.T) {
+	out, err := gunzip(gz(t, make([]byte, maxGzipDecoded)))
+	if err != nil {
+		t.Fatalf("gunzip rejected a payload of exactly the limit: %v", err)
+	}
+	if len(out) != maxGzipDecoded {
+		t.Errorf("len = %d, want %d", len(out), maxGzipDecoded)
 	}
 }
 

--- a/decodepath_test.go
+++ b/decodepath_test.go
@@ -88,7 +88,9 @@ func TestDecodeAppliesOnWatchUpdate(t *testing.T) {
 	}
 
 	p.push("a", b64("second"), "v2")
-	waitPending(clk)
+	// Let the update reach the reconciler and arm its debounce timer, then
+	// advance past the debounce window.
+	blockUntilTimers(t, clk, 1)
 	clk.Advance(defaultDebounce)
 
 	select {
@@ -132,9 +134,14 @@ func TestDecodeFailureOnWatchKeepsLastGoodValue(t *testing.T) {
 	defer func() { _ = w.Close() }()
 
 	p.push("a", "!!! not base64 !!!", "v2")
-	waitPending(clk)
-	clk.Advance(defaultDebounce)
-
+	// No clock handshake here, deliberately, and the asymmetry with the
+	// success-path test above is the point: a decode failure never reaches the
+	// debounce timer. recordSourceUpdate stores it as the chain position's
+	// error, recomputeWinner stops the walk there, and the error is dispatched
+	// to OnError directly - no candidate snapshot is built, so nothing is
+	// coalesced and no timer is ever armed. Waiting for one (or advancing the
+	// clock past a debounce window that will never open) would hang until the
+	// budget expired.
 	select {
 	case e := <-errs:
 		if !errors.Is(e, ErrInvalid) {

--- a/decodepath_test.go
+++ b/decodepath_test.go
@@ -1,0 +1,304 @@
+package mamori
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+// This file covers Task 6: ?decode= must be applied at every point a Value
+// enters the engine, not just the obvious one. Each test below pins one of
+// those entry points, so wiring any single site while missing another leaves a
+// red test rather than a silent production bug.
+//
+// The tests live in package mamori (not mamori_test) for two reasons: the
+// chain-seeding entry point is only reachable through the unexported
+// engine.seedChainSources, and the watchProvider fake from watch_test.go can
+// seed a value silently (set) and push an update separately (push), which is
+// what makes "decoded on load but not on update" observable at all. A
+// mamoritest.Provider always publishes a baseline on subscribe, so a missing
+// decode on the update path would be masked by the baseline replay.
+
+func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+// TestDecodeAppliesOnLoad covers resolveRef (resolve.go), the entry point used
+// by Load, Doctor, and the reconciler's own re-resolves.
+func TestDecodeAppliesOnLoad(t *testing.T) {
+	type cfg struct {
+		A string `source:"decl://a?decode=base64"`
+	}
+	p := newWatchProvider("decl")
+	p.set("a", b64("plain"), "v1")
+
+	got, err := Load[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.A != "plain" {
+		t.Errorf("A = %q, want plain", got.A)
+	}
+}
+
+// TestDecodeAppliesOnWatchUpdate is the regression test for the failure mode
+// this task exists to prevent: decoding correctly on the initial load and then
+// silently passing raw bytes through on every subsequent update. It covers
+// recordSourceUpdate (reconciler.go), the single funnel every native watch and
+// every poll update flows through.
+func TestDecodeAppliesOnWatchUpdate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"decw://a?decode=base64"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("decw")
+	p.set("a", b64("first"), "v1")
+
+	changed := make(chan cfg, 4)
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		OnChange(func(ev Change[cfg]) { changed <- ev.New }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if got := w.Get().A; got != "first" {
+		t.Fatalf("initial A = %q, want first", got)
+	}
+
+	p.push("a", b64("second"), "v2")
+	waitPending(clk)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case got := <-changed:
+		if got.A != "second" {
+			t.Errorf("after update A = %q, want second (decode was not applied on the watch path)", got.A)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the update")
+	}
+	if got := w.Get().A; got != "second" {
+		t.Errorf("Get().A = %q, want second", got)
+	}
+}
+
+// TestDecodeFailureOnWatchKeepsLastGoodValue pins the failure contract on the
+// watch path: an undecodable update is a terminal, non-not-found error for
+// that chain position, so the field's onfail policy applies (keeplast, the
+// default) and the last good value survives. It must never panic and must
+// never substitute the raw or empty bytes.
+func TestDecodeFailureOnWatchKeepsLastGoodValue(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"decf://a?decode=base64"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("decf")
+	p.set("a", b64("good"), "v1")
+
+	changed := make(chan cfg, 4)
+	errs := make(chan error, 4)
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		OnChange(func(ev Change[cfg]) { changed <- ev.New }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "!!! not base64 !!!", "v2")
+	waitPending(clk)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case e := <-errs:
+		if !errors.Is(e, ErrInvalid) {
+			t.Errorf("error = %v, want one wrapping ErrInvalid", e)
+		}
+		if ErrorKind(e) != KindInvalid {
+			t.Errorf("ErrorKind = %q, want %q", ErrorKind(e), KindInvalid)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no error delivered for an undecodable watch update")
+	}
+	select {
+	case ev := <-changed:
+		t.Fatalf("OnChange fired for an undecodable update: %+v", ev)
+	default:
+	}
+	if got := w.Get().A; got != "good" {
+		t.Errorf("Get().A = %q, want good (last good value must survive a decode failure)", got)
+	}
+}
+
+// batchDecodeProvider is a BatchProvider whose single-ref Resolve deliberately
+// fails, so a test asserting a decoded result through it can only pass if
+// resolveAll actually took the ResolveBatch path. There is no BatchProvider
+// fake anywhere else in this package's tests (grep: the only in-repo batch
+// tests are per-provider, in providers/mamori/batch_test.go), so this is the
+// minimal one this entry point needs.
+type batchDecodeProvider struct {
+	scheme string
+	data   map[string]string // keyed by Ref.Path
+}
+
+func (b *batchDecodeProvider) Scheme() string { return b.scheme }
+
+func (b *batchDecodeProvider) Resolve(_ context.Context, ref Ref) (Value, error) {
+	return Value{}, fmt.Errorf("batchDecodeProvider.Resolve called for %s: resolveAll must use ResolveBatch here", ref.Raw)
+}
+
+// ResolveBatch keys its result map by each input Ref's Raw, which is the
+// contract resolveBatchScheme looks values up by (provider.go).
+func (b *batchDecodeProvider) ResolveBatch(_ context.Context, refs []Ref) (map[string]Value, error) {
+	out := make(map[string]Value, len(refs))
+	for _, ref := range refs {
+		v, ok := b.data[ref.Path]
+		if !ok {
+			continue // absent keys are simply omitted; resolveBatchScheme applies default/optional
+		}
+		out[ref.Raw] = Value{Bytes: []byte(v), Version: "v1"}
+	}
+	return out, nil
+}
+
+// TestDecodeAppliesOnBatchResolve covers resolveBatchScheme (resolve.go), the
+// entry point every BatchProvider's values arrive through. A single-ref field
+// of a batch-capable scheme never goes near resolveRef, so this site has to be
+// wired independently of it.
+func TestDecodeAppliesOnBatchResolve(t *testing.T) {
+	type cfg struct {
+		A string `source:"decb://a?decode=base64"`
+		B string `source:"decb://b?decode=hex"`
+		C string `source:"decb://c"`
+	}
+	p := &batchDecodeProvider{
+		scheme: "decb",
+		data: map[string]string{
+			"a": b64("alpha"),
+			"b": hex.EncodeToString([]byte("bravo")),
+			"c": "charlie",
+		},
+	}
+
+	got, err := Load[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.A != "alpha" {
+		t.Errorf("A = %q, want alpha (decode was not applied on the batch path)", got.A)
+	}
+	if got.B != "bravo" {
+		t.Errorf("B = %q, want bravo (decode was not applied on the batch path)", got.B)
+	}
+	if got.C != "charlie" {
+		t.Errorf("C = %q, want charlie (a ref with no decode option must pass through untouched)", got.C)
+	}
+}
+
+// TestDecodeFailureOnBatchResolveFailsLoad pins that an undecodable batch
+// result fails the Load loudly rather than reaching the struct raw.
+func TestDecodeFailureOnBatchResolveFailsLoad(t *testing.T) {
+	type cfg struct {
+		A string `source:"decbf://a?decode=base64"`
+	}
+	p := &batchDecodeProvider{scheme: "decbf", data: map[string]string{"a": "!!! not base64 !!!"}}
+
+	_, err := Load[cfg](context.Background(), WithProvider(p))
+	if err == nil {
+		t.Fatal("Load succeeded; an undecodable batch value must fail the Load")
+	}
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("err = %v, want one wrapping ErrInvalid", err)
+	}
+}
+
+// TestDecodeAppliesOnChainSeed covers seedChainSources (reconciler.go), the
+// fourth place a Value becomes engine state: the synchronous per-position walk
+// engine.start performs for a multi-ref chain before any watch source exists.
+// It calls Provider.Resolve directly rather than going through resolveRef, so
+// it does not inherit resolveRef's decoding.
+//
+// Left unwired, a rotation landing between Watch's initial Load and this seed
+// would store the RAW bytes at the winning position with the NEW version. The
+// winner recompute triggered by any other position's first update would then
+// publish those raw bytes, and the winning position's own watch baseline -
+// carrying that same new version, correctly decoded - would be discarded as
+// "unchanged" by markChanged's version comparison. The field would stay
+// corrupted for the rest of the process's life.
+func TestDecodeAppliesOnChainSeed(t *testing.T) {
+	type cfg struct {
+		A string `source:"decs1://x?decode=base64,decs2://y?decode=base64"`
+	}
+	a := newWatchProvider("decs1")
+	b := newWatchProvider("decs2")
+	a.set("x", b64("from-a"), "v1")
+	b.set("y", b64("from-b"), "v1")
+
+	o := defaultOptions()
+	WithProvider(a)(o)
+	WithProvider(b)(o)
+	specs, err := fieldSpecs(reflect.TypeOf(cfg{}))
+	if err != nil {
+		t.Fatalf("fieldSpecs: %v", err)
+	}
+	e := &engine[cfg]{o: o}
+
+	st := e.seedChainSources(context.Background(), specs[0])
+	if st[0].err != nil {
+		t.Fatalf("seeded position 0 error: %v", st[0].err)
+	}
+	if string(st[0].value.Bytes) != "from-a" {
+		t.Errorf("seeded position 0 = %q, want from-a (decode was not applied when seeding chain state)", st[0].value.Bytes)
+	}
+	if st[0].value.Version != "v1" {
+		t.Errorf("seeded Version = %q, want v1 (decoding must not disturb the provider's revision)", st[0].value.Version)
+	}
+}
+
+// TestDecodeFailureOnChainSeedStopsWalk pins that an undecodable leading
+// position is seeded as a terminal error, exactly as any other non-not-found
+// resolve failure is, so recomputeWinner stops the walk there instead of
+// sliding down to a lower-precedence source (spec 10.3 case 3).
+func TestDecodeFailureOnChainSeedStopsWalk(t *testing.T) {
+	type cfg struct {
+		A string `source:"decsf1://x?decode=base64,decsf2://y"`
+	}
+	a := newWatchProvider("decsf1")
+	b := newWatchProvider("decsf2")
+	a.set("x", "!!! not base64 !!!", "v1")
+	b.set("y", "from-b", "v1")
+
+	o := defaultOptions()
+	WithProvider(a)(o)
+	WithProvider(b)(o)
+	specs, err := fieldSpecs(reflect.TypeOf(cfg{}))
+	if err != nil {
+		t.Fatalf("fieldSpecs: %v", err)
+	}
+	e := &engine[cfg]{o: o}
+
+	st := e.seedChainSources(context.Background(), specs[0])
+	if st[0].err == nil {
+		t.Fatal("seeded position 0 has no error; an undecodable value must stop the chain walk")
+	}
+	if !errors.Is(st[0].err, ErrInvalid) {
+		t.Errorf("seeded position 0 error = %v, want one wrapping ErrInvalid", st[0].err)
+	}
+	if st[1].seen {
+		t.Error("position 1 was seeded; a non-not-found error at position 0 must stop the walk, not fail over")
+	}
+}

--- a/decodepath_test.go
+++ b/decodepath_test.go
@@ -18,13 +18,25 @@ import (
 // those entry points, so wiring any single site while missing another leaves a
 // red test rather than a silent production bug.
 //
-// The tests live in package mamori (not mamori_test) for two reasons: the
+// The tests live in package mamori (not mamori_test), which forces the use of
+// the watchProvider fake from watch_test.go rather than mamoritest.Provider.
+// The dispositive reason is a hard constraint, not a preference: the
 // chain-seeding entry point is only reachable through the unexported
-// engine.seedChainSources, and the watchProvider fake from watch_test.go can
-// seed a value silently (set) and push an update separately (push), which is
-// what makes "decoded on load but not on update" observable at all. A
-// mamoritest.Provider always publishes a baseline on subscribe, so a missing
-// decode on the update path would be masked by the baseline replay.
+// engine.seedChainSources, so the file must be in package mamori, and
+// mamoritest imports mamori, so importing it here would be an import cycle.
+//
+// Being able to set a value silently (set) and push an update separately
+// (push), with explicit control of each Value's Version, is a genuine
+// secondary benefit - it is what lets the tests below state exactly which
+// revision each assertion is about. It is NOT, however, required to catch the
+// core bug: a mamoritest.Provider would catch it too. Its baseline-on-subscribe
+// replays the stored bytes under VersionHash of those same bytes, which equals
+// the Version the decoded Load value already carries (applyDecode preserves
+// Version), so markChanged drops the raw baseline as unchanged and the first
+// real Set still surfaces the undecoded bytes. Verified by running exactly
+// that test with the decode removed from recordSourceUpdate: it fails on
+// A = "c2Vjb25k". Recorded here because an earlier version of this comment
+// claimed the opposite.
 
 func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
 
@@ -223,6 +235,56 @@ func TestDecodeFailureOnBatchResolveFailsLoad(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalid) {
 		t.Errorf("err = %v, want one wrapping ErrInvalid", err)
+	}
+}
+
+// TestDecodeFailureOnBatchResolveHonorsOnFail pins that the batch path applies
+// the field's onfail policy to a decode failure exactly as the non-batch path
+// does. Whether a scheme's provider happens to implement BatchProvider is an
+// implementation detail the user did not choose and cannot see from the struct
+// tag, so it must not decide whether onfail:"default" is honored or ignored.
+func TestDecodeFailureOnBatchResolveHonorsOnFail(t *testing.T) {
+	type cfg struct {
+		A string `source:"decbo://a?decode=base64" default:"fallback" onfail:"default"`
+	}
+	p := &batchDecodeProvider{scheme: "decbo", data: map[string]string{"a": "!!! not base64 !!!"}}
+
+	got, err := Load[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Load: %v (onfail:\"default\" must absorb a decode failure on the batch path, as it does on the non-batch path)", err)
+	}
+	if got.A != "fallback" {
+		t.Errorf("A = %q, want fallback", got.A)
+	}
+}
+
+// TestDecodeFailureOnFailAgreesAcrossBatchAndSingleResolve is the equivalence
+// this task's batch wiring has to preserve: the same struct tag and the same
+// undecodable payload must produce the same outcome whether the scheme's
+// provider implements BatchProvider or only Resolve.
+func TestDecodeFailureOnFailAgreesAcrossBatchAndSingleResolve(t *testing.T) {
+	type batchCfg struct {
+		A string `source:"decbe://a?decode=base64" default:"fallback" onfail:"default"`
+	}
+	type singleCfg struct {
+		A string `source:"decse://a?decode=base64" default:"fallback" onfail:"default"`
+	}
+
+	batched := &batchDecodeProvider{scheme: "decbe", data: map[string]string{"a": "!!! not base64 !!!"}}
+	single := newWatchProvider("decse")
+	single.set("a", "!!! not base64 !!!", "v1")
+
+	gotBatch, batchErr := Load[batchCfg](context.Background(), WithProvider(batched))
+	gotSingle, singleErr := Load[singleCfg](context.Background(), WithProvider(single))
+
+	if (batchErr == nil) != (singleErr == nil) {
+		t.Fatalf("batch err = %v but single-resolve err = %v; the two paths must agree on whether onfail applies", batchErr, singleErr)
+	}
+	if batchErr != nil {
+		t.Fatalf("both paths failed: %v", batchErr)
+	}
+	if gotBatch.A != gotSingle.A {
+		t.Errorf("batch A = %q but single-resolve A = %q; the two paths must agree", gotBatch.A, gotSingle.A)
 	}
 }
 

--- a/providers/mamori/conformance_test.go
+++ b/providers/mamori/conformance_test.go
@@ -83,12 +83,24 @@ const (
 
 // fixedConformanceNames is the complete, static binding table the server is
 // constructed with: one entry per fixed key providertest.go generates
-// (scheme, resolve, ctxcancel, concurrent, version, watch, watchclose, leak)
-// plus "classify", the single reused slot every classify-* case normalizes
-// onto. "absent" is deliberately NOT in this list - see Config.Key below.
+// (scheme, resolve, ctxcancel, concurrent, version, watch, watchclose, leak,
+// decodeopt) plus "classify", the single reused slot every classify-* case
+// normalizes onto. "absent" is deliberately NOT in this list - see Config.Key
+// below.
+//
+// decodeopt backs providertest's DecodeOption case. That case is unconditional
+// (unlike JSONPointerSelection, which skips here because this provider
+// supplies no PointerRef), so unlike a skipped case it always calls Seed, and
+// without a real binding for it Seed's pollUntil times out waiting for a
+// Resolve that can never succeed - not because this client mishandles
+// ?decode=, but because there is no "conformance-decodeopt" binding for the
+// server to answer. Resolve never even looks at ref.Opts (see resolve.go), so
+// an unrecognized query option already passes through untouched by
+// construction; this entry only gives that passthrough a slot to prove itself
+// against.
 var fixedConformanceNames = []string{
 	"scheme", "resolve", "ctxcancel", "concurrent", "version",
-	"watch", "watchclose", "leak", "classify",
+	"watch", "watchclose", "leak", "decodeopt", "classify",
 }
 
 // conformanceKey builds the normalized binding name for a fixed conformance

--- a/providertest/providertest.go
+++ b/providertest/providertest.go
@@ -19,6 +19,7 @@ package providertest
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"sync"
@@ -194,6 +195,7 @@ func Run(t *testing.T, c Config) {
 	t.Run("ResolveSeeded", func(t *testing.T) { testResolveSeeded(t, c) })
 	t.Run("NotFoundTyped", func(t *testing.T) { testNotFound(t, c) })
 	t.Run("JSONPointerSelection", func(t *testing.T) { testJSONPointerSelection(t, c) })
+	t.Run("DecodeOption", func(t *testing.T) { testDecodeOption(t, c) })
 	t.Run("ErrorClassification", func(t *testing.T) { RunErrorClassification(t, c) })
 	t.Run("ContextCancel", func(t *testing.T) { testContextCancel(t, c) })
 	t.Run("ConcurrentResolve", func(t *testing.T) { testConcurrentResolve(t, c) })
@@ -360,6 +362,42 @@ func testJSONPointerSelection(t *testing.T, c Config) {
 		if _, err := p.Resolve(ctx, ref); !errors.Is(err, tc.want) {
 			t.Errorf("Resolve(%q) err = %v, want %v", tc.frag, err, tc.want)
 		}
+	}
+}
+
+// testDecodeOption verifies a provider passes an unrecognized query option
+// through untouched, so core's ?decode= pipeline sees it. Decoding is core's
+// job (applyDecode, run at every point a Value enters the engine); providers
+// never inspect or act on ?decode= themselves. What this case catches is a
+// provider that strips, rewrites, or chokes on a query option it does not
+// recognize - a bug that would pass every other case in this kit yet silently
+// break ?decode= (and any future core-owned option) for that provider's users.
+//
+// The seeded value is itself a base64 string; that is deliberate, not a stand-in
+// for "the decoded form". The provider must hand back exactly what was stored,
+// still encoded, because decoding it here would be the provider doing core's
+// job.
+func testDecodeOption(t *testing.T, c Config) {
+	t.Helper()
+	ctx := context.Background()
+	p := c.New()
+	key := c.key("decodeopt")
+	encoded := base64.StdEncoding.EncodeToString([]byte("plain"))
+
+	if err := c.Seed(ctx, key, encoded); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	ref, err := mamori.ParseRef(c.Ref(key) + "?decode=base64")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	// The provider must resolve normally and ignore the option; core decodes.
+	v, err := p.Resolve(ctx, ref)
+	if err != nil {
+		t.Fatalf("Resolve with an unrecognized query option: %v", err)
+	}
+	if string(v.Bytes) != encoded {
+		t.Errorf("provider returned %q; it must return the stored value untouched and leave ?decode= to core", v.Bytes)
 	}
 }
 

--- a/reconciler.go
+++ b/reconciler.go
@@ -679,8 +679,9 @@ func refDebounceOverride(ref Ref) (time.Duration, bool) {
 //
 // Decoding here, rather than later at the winner or at flush, means it happens
 // exactly once and before the value becomes engine state, so recomputeWinner,
-// buildReport, buildCandidate, and the published snapshot all agree on the
-// same decoded bytes.
+// buildCandidate, and the published snapshot all agree on the same decoded
+// bytes. (buildReport is unaffected either way: it reads only Version, never
+// the bytes - and Version is exactly what applyDecode leaves untouched.)
 func (e *engine[T]) recordSourceUpdate(specIdx, pos int, up Update, sensitive bool) {
 	st := &e.sources[specIdx][pos]
 	st.seen = true
@@ -788,14 +789,29 @@ func (e *engine[T]) recomputeWinner(specIdx int) (val Value, pos int, err error)
 // Calling Resolve directly does mean this bypasses resolveRef's ?decode=
 // handling, so it applies the pipeline itself - it is a fourth place a Value
 // becomes state that can reach the application, alongside resolveRef,
-// resolveBatchScheme, and recordSourceUpdate. Skipping it here would not be merely
-// cosmetic: if the source value changes between Watch's initial Load and this
-// seed (a rotation racing startup), the seeded state carries the RAW bytes
-// under the NEW version. Any other position's first update then triggers a
-// recompute that publishes those raw bytes, and when the winning position's
-// own watch baseline arrives - same new version, correctly decoded -
-// markChanged discards it as unchanged, leaving the field permanently
-// corrupted rather than transiently so.
+// resolveBatchScheme, and recordSourceUpdate. Skipping it here would not be
+// merely cosmetic, and it goes wrong in two different ways depending on
+// whether the winning position's provider supplies a Version:
+//
+//   - Version-less provider (Value.changed falls back to comparing bytes):
+//     the seeded RAW bytes differ from the decoded bytes Load just stored, so
+//     no rotation is needed at all. Any other position reporting in first at
+//     startup triggers a recompute that publishes the raw bytes, and the
+//     application sees a Change carrying an undecoded value. It heals when the
+//     winning position's own watch baseline arrives (raw vs decoded bytes
+//     differ again), so this one is a startup flap - but a flap the
+//     application has already been handed and may have acted on.
+//
+//   - Versioned provider: it takes a rotation landing between Watch's initial
+//     Load and this seed. The seeded state then carries the RAW bytes under
+//     the NEW version, another position's first update publishes them, and the
+//     winning position's own baseline - same new version, correctly decoded -
+//     is discarded by markChanged as unchanged. This is the worse case,
+//     because nothing corrects it until the next revision change at that
+//     position. On a 90-day rotation schedule that is a quarter of serving
+//     undecoded bytes. It is not permanent - the following rotation produces a
+//     version the stale raw value does not match, and the field heals - but
+//     "eventually, at the next rotation" is not a recovery story worth having.
 func (e *engine[T]) seedChainSources(ctx context.Context, spec fieldSpec) []srcState {
 	st := make([]srcState, len(spec.Refs))
 	for i, ref := range spec.Refs {

--- a/reconciler.go
+++ b/reconciler.go
@@ -663,10 +663,24 @@ func refDebounceOverride(ref Ref) (time.Duration, bool) {
 }
 
 // recordSourceUpdate stores up as the latest state of one position in a
-// field's precedence chain (see srcState), applying the field's Sensitive
-// flag to a delivered value exactly as the pre-chain single-source path
-// always did. It is called on every srcUpdate, before the chain's winner is
-// recomputed.
+// field's precedence chain (see srcState), applying the ref's ?decode=
+// pipeline and then the field's Sensitive flag to a delivered value exactly as
+// the pre-chain single-source path always did. It is called on every
+// srcUpdate, before the chain's winner is recomputed.
+//
+// This is the single funnel every watch-delivered value passes through -
+// start's per-position forwarders feed it from a native WatchableProvider and
+// from the polling adapter alike (see watchRef) - which is why the decode
+// belongs here rather than in either of those. Without it a field with
+// ?decode= would resolve correctly at Load (resolveRef decodes) and then hand
+// the application raw, undecoded bytes from its first update onward: a bug
+// that passes every startup-only test and first appears in production at the
+// moment a secret rotates.
+//
+// Decoding here, rather than later at the winner or at flush, means it happens
+// exactly once and before the value becomes engine state, so recomputeWinner,
+// buildReport, buildCandidate, and the published snapshot all agree on the
+// same decoded bytes.
 func (e *engine[T]) recordSourceUpdate(specIdx, pos int, up Update, sensitive bool) {
 	st := &e.sources[specIdx][pos]
 	st.seen = true
@@ -675,7 +689,22 @@ func (e *engine[T]) recordSourceUpdate(specIdx, pos int, up Update, sensitive bo
 		st.value = Value{}
 		return
 	}
-	val := up.Value
+	// A decode failure is recorded exactly like a transient resolve failure
+	// delivered by the source itself: this position carries the error and no
+	// value, recomputeWinner stops the chain walk here (ErrInvalid is not
+	// ErrNotFound, so it does not fall through to a lower-precedence source),
+	// and loop applies the field's OnFail policy - keeplast by default, which
+	// leaves Get() serving the last good snapshot. Storing Value{} rather than
+	// the raw bytes is what makes "keep the last good value" true: a stored
+	// raw value could win a later recompute and reach the application
+	// undecoded, which is the exact outcome this whole path exists to prevent.
+	dec, err := applyDecode(e.specs[specIdx].Refs[pos], up.Value)
+	if err != nil {
+		st.err = err
+		st.value = Value{}
+		return
+	}
+	val := dec
 	if sensitive {
 		val.Sensitive = true
 	}
@@ -755,6 +784,18 @@ func (e *engine[T]) recomputeWinner(specIdx int) (val Value, pos int, err error)
 // live watch update's raw error is wrapped, so a chain's seeded state and
 // its later-observed state can never format an error differently depending
 // on which one happened to win.
+//
+// Calling Resolve directly does mean this bypasses resolveRef's ?decode=
+// handling, so it applies the pipeline itself - it is a fourth place a Value
+// becomes state that can reach the application, alongside resolveRef,
+// resolveBatchScheme, and recordSourceUpdate. Skipping it here would not be merely
+// cosmetic: if the source value changes between Watch's initial Load and this
+// seed (a rotation racing startup), the seeded state carries the RAW bytes
+// under the NEW version. Any other position's first update then triggers a
+// recompute that publishes those raw bytes, and when the winning position's
+// own watch baseline arrives - same new version, correctly decoded -
+// markChanged discards it as unchanged, leaving the field permanently
+// corrupted rather than transiently so.
 func (e *engine[T]) seedChainSources(ctx context.Context, spec fieldSpec) []srcState {
 	st := make([]srcState, len(spec.Refs))
 	for i, ref := range spec.Refs {
@@ -768,6 +809,14 @@ func (e *engine[T]) seedChainSources(ctx context.Context, spec fieldSpec) []srcS
 			break
 		}
 		val, err := p.Resolve(ctx, ref)
+		if err == nil {
+			// A decode failure is a non-not-found error, so it falls into the
+			// same branch below as a permission denial: this position is
+			// seeded as terminal and the walk stops, rather than sliding down
+			// to a lower-precedence source on the strength of a
+			// misconfigured coding.
+			val, err = applyDecode(ref, val)
+		}
 		if err == nil {
 			if spec.Sensitive {
 				val.Sensitive = true

--- a/resolve.go
+++ b/resolve.go
@@ -218,11 +218,25 @@ func applyOnFail(r *resolved, terminal error) error {
 // because the batch groups by scheme only - two fields of the same scheme can
 // declare completely different codings, or none.
 //
-// A decode failure fails the whole Load rather than defaulting the field:
-// resolveAll is fail-fast on any non-not-found error, and a wrongly declared
-// encoding is a configuration bug, not an absent value. Note this deliberately
-// does not consult applyDefault - only a genuinely missing key (the !ok branch
-// above it) does.
+// A decode failure is routed through applyOnFail, exactly as resolveOne routes
+// the terminal error of a non-batch resolve. Whether a scheme's provider
+// happens to implement BatchProvider is an implementation detail the operator
+// did not choose and cannot see from the struct tag, so it must not decide
+// whether the field's `onfail` policy is honored: without this, a field tagged
+// onfail:"default" would fall back to its default on a provider that only
+// implements Resolve and fail the whole Load on one that also implements
+// ResolveBatch, for the same tag and the same undecodable payload.
+//
+// applyOnFail, not applyDefault, is the right counterpart here. The two are
+// not interchangeable: applyDefault applies `default:` on genuine absence,
+// which is the !ok branch above, while applyOnFail applies `default:` to an
+// error only when the field explicitly opted in with onfail:"default". A
+// decode failure is an error, not an absence, so a bare `default:` tag must
+// not silently absorb it - that is the same footgun applyOnFail's own doc
+// comment exists to prevent. With the default onFailKeepLast (or
+// onfail:"fail") applyOnFail returns the error unchanged and the Load still
+// fails fast, which is the previous behavior for every field that did not opt
+// in.
 func resolveBatchScheme(ctx context.Context, bp BatchProvider, scheme string, idxs []int, out []resolved, o *options) error {
 	refs := make([]Ref, 0, len(idxs))
 	for _, i := range idxs {
@@ -245,7 +259,11 @@ func resolveBatchScheme(ctx context.Context, bp BatchProvider, scheme string, id
 		}
 		dec, derr := applyDecode(r.spec.Refs[0], val)
 		if derr != nil {
-			return &ProviderError{Scheme: scheme, Ref: redactRef(r.spec.Refs[0]), Err: derr}
+			pe := &ProviderError{Scheme: scheme, Ref: redactRef(r.spec.Refs[0]), Err: derr}
+			if err := applyOnFail(r, pe); err != nil {
+				return err
+			}
+			continue
 		}
 		setResolved(r, dec)
 	}

--- a/resolve.go
+++ b/resolve.go
@@ -137,6 +137,20 @@ func resolveChain(ctx context.Context, refs []Ref, o *options) (Value, int, erro
 // tracer/meter observability for the call and wrapping any failure -
 // including an unregistered scheme, which can never resolve for this process
 // - as a *ProviderError tagged with that ref's scheme and redacted form.
+//
+// It applies the ref's ?decode= pipeline before returning, so every caller
+// downstream (resolveChain, and through it Load, Doctor, and the reconciler's
+// re-resolves) sees decoded bytes and nothing has to remember to decode. The
+// decode happens after the observability calls deliberately: the tracer span
+// and the meter's latency both describe the provider round trip, and folding a
+// local CPU-bound transform into that measurement would misattribute it to the
+// backend. A decode failure is reported as a *ProviderError for the same ref,
+// because from every caller's point of view this ref did not yield a usable
+// value - and because ErrInvalid is a non-not-found error, it stops a
+// precedence chain's walk rather than falling through to a lower-priority
+// source (resolveChain case 3). Sliding down to a different source because the
+// declared encoding is wrong would hide the misconfiguration behind whatever
+// answered next.
 func resolveRef(ctx context.Context, ref Ref, o *options) (Value, error) {
 	p, ok := o.provider(ref.Scheme)
 	if !ok {
@@ -152,6 +166,10 @@ func resolveRef(ctx context.Context, ref Ref, o *options) (Value, error) {
 	val, err := p.Resolve(sctx, ref)
 	finish(err)
 	o.meter.RecordResolve(ref.Scheme, o.clock.Now().Sub(start), err)
+	if err != nil {
+		return Value{}, &ProviderError{Scheme: ref.Scheme, Ref: redactRef(ref), Err: err}
+	}
+	val, err = applyDecode(ref, val)
 	if err != nil {
 		return Value{}, &ProviderError{Scheme: ref.Scheme, Ref: redactRef(ref), Err: err}
 	}
@@ -189,6 +207,22 @@ func applyOnFail(r *resolved, terminal error) error {
 	return terminal
 }
 
+// resolveBatchScheme resolves every single-ref spec of one batch-capable
+// scheme in a single provider call, then applies each ref's own ?decode=
+// pipeline to its result.
+//
+// The decode cannot be inherited from resolveRef here: a single-ref field
+// whose scheme implements BatchProvider never goes through resolveRef at all
+// (see resolveAll's grouping), so this is an independent entry point for a
+// Value and needs its own wiring. Decoding is per-ref rather than per-batch
+// because the batch groups by scheme only - two fields of the same scheme can
+// declare completely different codings, or none.
+//
+// A decode failure fails the whole Load rather than defaulting the field:
+// resolveAll is fail-fast on any non-not-found error, and a wrongly declared
+// encoding is a configuration bug, not an absent value. Note this deliberately
+// does not consult applyDefault - only a genuinely missing key (the !ok branch
+// above it) does.
 func resolveBatchScheme(ctx context.Context, bp BatchProvider, scheme string, idxs []int, out []resolved, o *options) error {
 	refs := make([]Ref, 0, len(idxs))
 	for _, i := range idxs {
@@ -209,7 +243,11 @@ func resolveBatchScheme(ctx context.Context, bp BatchProvider, scheme string, id
 			}
 			continue
 		}
-		setResolved(r, val)
+		dec, derr := applyDecode(r.spec.Refs[0], val)
+		if derr != nil {
+			return &ProviderError{Scheme: scheme, Ref: redactRef(r.spec.Refs[0]), Err: derr}
+		}
+		setResolved(r, dec)
 	}
 	return nil
 }

--- a/site/src/pages/docs/concepts/ref-grammar.md
+++ b/site/src/pages/docs/concepts/ref-grammar.md
@@ -172,7 +172,131 @@ type Config struct {
 
 ## Value decoding (`?decode=`)
 
-Not yet released - this section will be filled in when it ships.
+`?decode=` is a ref query option declaring that a resolved value is encoded, so
+core decodes it before it reaches your struct field:
+
+```go
+type Config struct {
+	// The Secrets Manager entry holds base64 text; decode it back to raw
+	// bytes before TLSKey is populated.
+	TLSKey []byte `source:"aws-sm://prod/tls#key?decode=base64"`
+
+	// Stacked codings: the stored value is base64 of a gzip stream.
+	Bundle []byte `source:"aws-sm://prod/bundle?decode=base64,gzip"`
+}
+```
+
+### Codings
+
+| Coding | Applies |
+| --- | --- |
+| `base64` | `encoding/base64`, standard alphabet, padded (`base64.StdEncoding`) |
+| `base64url` | `encoding/base64`, URL-safe alphabet (`base64.URLEncoding`) |
+| `hex` | `encoding/hex` |
+| `gzip` | `compress/gzip` - decompresses, output capped at 16 MiB |
+| `trim` | strips leading/trailing whitespace |
+
+This is a **closed set**, all stdlib, with no extension point: core's minimal
+dependency set (validator, mapstructure, fsnotify) is a stated property of the
+project layout, and an open coding registry here would duplicate
+`WithDecodeHook`, which already exists one layer down for arbitrary per-type
+conversion.
+
+The whitespace handling is deliberately asymmetric: `base64`, `base64url`, and
+`hex` trim surrounding whitespace before decoding - a trailing newline from
+`base64 < key.pem > secret`, an editor's save, or a round trip through a
+backend's CLI is common, and rejecting a secret over an invisible byte is a
+miserable failure to debug. `gzip` does **not** trim, because its payload is
+binary: a valid gzip stream can legitimately end in bytes whose numeric values
+are ASCII whitespace (the trailing CRC32/ISIZE bytes are raw integers, not
+text), and trimming them would silently corrupt the stream. A genuinely
+whitespace-padded gzip payload has its own explicit escape hatch instead:
+`?decode=trim,gzip` trims first, then gunzips.
+
+`gzip`'s decompressed output is capped at 16 MiB. Exceeding it is a loud
+`ErrInvalid`, never a truncation - handing an application a silently
+truncated secret or certificate would fail later, somewhere else, in a way
+that looks like anything but a decode problem. The cap is a constant with no
+option to override it: a legitimate payload above it is realistically only
+possible from an unbounded local source (`file:`, `exec:`), and the remedy
+there is to not declare `?decode=gzip` and gunzip in application code instead.
+
+### Ordering: left to right, outermost wrapper first
+
+Codings apply in the order written, outermost wrapper first: `?decode=base64,gzip`
+means the stored value is base64 **of** gzip **of** the payload, so it is
+base64-decoded first, then gunzipped.
+
+This is why the option is named `decode` rather than `encoding`. HTTP's
+`Content-Encoding` header lists codings in the order they were *applied*, and a
+client decodes that list in *reverse*. Naming this option after the action
+instead removes any question of which direction the list reads: unlike
+`Content-Encoding`, `?decode=`'s list reads exactly as written, left to right,
+first coding first.
+
+### Failure is loud: `ErrInvalid`, never a silent passthrough
+
+A payload that fails a decode step - malformed base64, a truncated gzip
+stream, and so on - wraps `ErrInvalid`. There is no silent passthrough of the
+raw, still-encoded bytes: a decode failure is a non-not-found error, so it
+stops a precedence chain's walk exactly like any other real error (a
+`default:` does not silently mask it - see below). See
+[Error kinds](/docs/concepts/error-kinds/) for how `ErrInvalid` maps onto
+`mamori.ErrorKind`.
+
+An unrecognized coding name is rejected up front, at spec-walk time, so a typo
+(`?decode=base64,gzp`) fails at `Load`, `Watch`, or `Doctor` rather than on
+some later poll tick. Every ref in a precedence chain is validated this way,
+not just the one that ultimately wins - a typo in a lower-precedence fallback
+ref would otherwise stay silent until that ref actually won.
+
+### `Version` is untouched
+
+Decoding only transforms `Value.Bytes`. `Version`, `Sensitive`, `NotAfter`,
+and `Metadata` all carry through unchanged, so change detection keeps
+comparing the provider's own revision - not the decoded bytes - exactly as it
+does for a field with no `?decode=` at all.
+
+### Decoding runs after `#key` selection
+
+Decode applies to whatever `#key` already selected (or the whole payload, if
+there is no fragment) - not the other way around. `#tls.crt?decode=base64`
+means "select `tls.crt` from the payload, then base64-decode what was
+selected."
+
+That ordering has a consequence: `#key` cannot select a field *out of* what
+decoding produces. If a JSON Pointer needs to look inside a payload that only
+exists after decoding - a base64-encoded JSON document, for instance - drop
+the `#key`, decode the whole payload, and use `flatten:"json"` to do the
+selection afterward:
+
+```go
+type Creds struct {
+	User     string        `mapstructure:"user"`
+	Password secret.String `mapstructure:"password"`
+}
+
+type Config struct {
+	// No #key: the whole entry is base64. It decodes to a JSON object, and
+	// flatten:"json" does the field selection ?decode= could not.
+	Creds Creds `source:"aws-sm://prod/bundle?decode=base64" flatten:"json"`
+}
+```
+
+### `?decode=` and `default:`
+
+A field whose refs all report not-found falls back to its `default:` tag
+value, used **as-is, undecoded** - even if the field also carries `?decode=`.
+A default is a literal you wrote in the tag, not an encoded payload from a
+backend, so running it through the decode pipeline would be wrong far more
+often than right. Write the default already in its final, decoded form.
+
+### `?decode=` is not redacted
+
+`decode` is not on the list of query options [`Status()`](/docs/observability/)
+and `mamori doctor` redact, so it stays visible in a `Report`. That is
+deliberate: an operator debugging a garbled value needs to see that a
+decoding step is in play, and `?decode=` alone is not itself sensitive.
 
 ## Ref interpolation (`${VAR}`)
 

--- a/site/src/pages/docs/usage/index.md
+++ b/site/src/pages/docs/usage/index.md
@@ -22,10 +22,13 @@ import (
 
 type Config struct {
 	Port       string        `source:"env:PORT" default:"8080"`
-	DBPassword secret.String `source:"aws-sm://prod/db-password"`
+	DBPassword secret.String `source:"aws-sm://prod/db-password#password"`
 	// #/credentials/user is an RFC 6901 JSON Pointer fragment, selecting a
 	// value nested inside the secret's JSON payload rather than a top-level key.
 	DBUser     string        `source:"aws-sm://prod/db-password#/credentials/user"`
+	// ?decode=base64 declares the stored value is base64; core decodes it
+	// back to raw bytes before TLSKey is populated.
+	TLSKey     []byte        `source:"aws-sm://prod/tls#key?decode=base64"`
 }
 
 func main() {
@@ -42,6 +45,8 @@ func main() {
 ```
 
 One call resolves every ref, applies defaults, validates, and returns a fully typed `Config`.
+
+`TLSKey`'s `?decode=base64` is a ref query option, not a struct tag: it tells core the resolved value is encoded, so it is decoded (left to right, outermost wrapper first for a comma-separated list like `?decode=base64,gzip`) before the field is populated. A field's `default:` value is exempt - it is used as-is, undecoded, since it is a literal you wrote rather than an encoded payload from a backend. See [Ref grammar](/docs/concepts/ref-grammar/#value-decoding-decode) for the full coding table and failure semantics.
 
 ## Load config once
 
@@ -62,6 +67,6 @@ Batch-capable providers (for example AWS Secrets Manager) are resolved in a sing
 ## See also
 
 - [Concepts](/docs/concepts/) for refs, the tag grammar, and error kinds.
-- [Ref grammar](/docs/concepts/ref-grammar/) for the full `#key` fragment grammar, including nested JSON Pointer selection.
+- [Ref grammar](/docs/concepts/ref-grammar/) for the full `#key` fragment grammar, including nested JSON Pointer selection and `?decode=` value transforms.
 - [Validation](/docs/validation/) for the defaults and validation rules applied on every load.
 - [Observability](/docs/observability/) for `Status`, `Health`, `Doctor`, and the read-only HTTP surface.

--- a/site/src/pages/docs/writing-a-provider/conformance.md
+++ b/site/src/pages/docs/writing-a-provider/conformance.md
@@ -5,7 +5,7 @@ title: Conformance
 
 # Conformance
 
-`github.com/xavidop/mamori/providertest` runs one function that exercises resolution, not-found typing, error classification, nested JSON Pointer selection (opt-in), `Version` monotonicity, concurrency, context cancellation, native watch, goroutine hygiene (goleak), and a no-payload-logging assertion. Every provider must pass it.
+`github.com/xavidop/mamori/providertest` runs one function that exercises resolution, not-found typing, nested JSON Pointer selection (opt-in), `?decode=` option passthrough, error classification, `Version` monotonicity, concurrency, context cancellation, native watch, goroutine hygiene (goleak), and a no-payload-logging assertion. Every provider must pass it.
 
 ## Run the conformance case
 
@@ -48,6 +48,14 @@ Supply `PointerRef` only when your provider's fragment slot **is** a JSON select
 
 `PointerRef` is a ref *builder*, not a boolean, because `Config.Ref` is not fragment-free by convention - several providers bake a fixed fragment into it (`vault://secret/<key>#value`, and the same shape in `mongodb`, `firestore`, and `k8s`), so appending a second fragment to `Ref`'s output would produce a doubled, unparseable fragment. The builder lets each provider say exactly where its selector goes.
 
+## `DecodeOption`
+
+Decoding a resolved value (`?decode=base64`, `?decode=base64,gzip`, ...) is entirely core's job: `applyDecode` runs on every `Value` at every point it enters the engine, and no provider ever inspects or acts on `?decode=` itself. Unlike `JSONPointerSelection`, this case is **not opt-in** - it runs unconditionally for every provider.
+
+What it catches is narrower and easy to miss otherwise: a provider that strips, rewrites, or errors on a query option it does not recognize. That bug would pass every other case in this kit and still silently break `?decode=` (and any future core-owned option) for that provider's users. The rule it enforces:
+
+**A provider must pass an unrecognized query option through untouched.** `DecodeOption` seeds a value that is itself a base64 string, resolves it through a ref carrying `?decode=base64`, and asserts the provider hands back exactly the stored (still-encoded) bytes - proving the provider read `ref.Path`/`ref.Key` and ignored the option rather than rejecting it or trying to interpret it itself.
+
 ## Build and test the module
 
 Build and test each module independently with the workspace disabled, exactly as CI does:
@@ -69,6 +77,7 @@ Or from the repo root, `make test` / `make lint` run every module.
 - [ ] `Value.Version` is set and changes when the value changes; secret-bearing values set `Sensitive: true`.
 - [ ] `#key` uses `mamori.SelectKey`; the payload is never logged.
 - [ ] If your fragment is a JSON selector, supply `providertest.Config.PointerRef` so `JSONPointerSelection` runs; otherwise leave it `nil` with a comment naming why (backend-native key, facet selector, or unused).
+- [ ] `Resolve` passes an unrecognized query option (e.g. `?decode=`) through untouched rather than stripping, rewriting, or erroring on it; `DecodeOption` proves this and runs unconditionally.
 - [ ] `Watch` is implemented only for native-push backends, closes on `ctx` cancel, and leaks no goroutines.
 - [ ] A client interface is injected so `providertest.Run` passes against a fake; live tests are behind `//go:build integration`.
 - [ ] `go build`, `go vet`, and `go test` are clean with `GOWORK=off`; the README documents scheme, ref grammar, and auth.

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -53,6 +53,16 @@ Rules to hold onto:
   literal top-level key, exactly as before: `source:"k8s-secret://prod/tls#ca.crt"`.
   Do not restructure a secret or add application-code plumbing to reach a
   nested field when a pointer fragment already reaches it directly.
+- `?decode=` declares a resolved value is encoded, so core decodes it before
+  the field is populated: `source:"aws-sm://prod/tls#key?decode=base64"`.
+  Codings are `base64`, `base64url`, `hex`, `gzip`, `trim` - a closed,
+  stdlib-only set - applied left to right, outermost wrapper first:
+  `?decode=base64,gzip` reads as "base64 of gzip", so it is base64-decoded
+  then gunzipped. Decode runs *after* `#key` selection, so it cannot reach
+  into a payload that only exists once decoded - drop the `#key`, decode the
+  whole payload, and use `flatten:"json"` for that case instead. A bad
+  payload is a loud `ErrInvalid`, never silently passed through; a field's
+  `default:` value is exempt - it is used as-is, undecoded.
 
 ## Watch for live changes
 


### PR DESCRIPTION
Implements section 6 of `docs/superpowers/specs/2026-07-27-ref-grammar-design.md`. Third PR in the ref-grammar stack, on top of #53.

A `source` ref can now declare that its stored value is encoded, and core decodes it on the way through:

```go
type Config struct {
    TLSKey secret.Bytes `source:"aws-sm://prod/certs#tls.key?decode=base64"`
    Blob   []byte       `source:"s3://bucket/keystore?decode=base64,gzip"`
    Token  string       `source:"env:PADDED_TOKEN?decode=trim"`
}
```

Codings: `base64`, `base64url`, `hex`, `gzip`, `trim`. Closed set, all stdlib, so **core gains no dependency**.

## Ordering, and why it is named `decode`

The list applies **left to right, outermost wrapper first**: `decode=base64,gzip` means the stored value is base64 of gzip of the payload.

It is named `decode` rather than `encoding` for exactly this reason. HTTP's `Content-Encoding` lists codings *in the order they were applied* and is therefore decoded in reverse; naming ours after the action removes any question of which direction the list reads.

## Four entry points, not three

A `Value` enters the engine at four places, and all four are wired:

| Site | Covers |
|---|---|
| `resolveRef` | `Load`, `Doctor`, and the reconciler's re-resolves |
| `resolveBatchScheme` | any `BatchProvider` |
| `recordSourceUpdate` | every native watch and poll update |
| `seedChainSources` | the startup seed for multi-ref precedence chains |

The design spec named only the first three. The fourth was found during implementation, and missing it would have been subtle: a rotation landing between `Watch`'s initial `Load` and the chain seed stores **raw undecoded bytes under the new version**, so the correctly-decoded value then arrives carrying that same version and is discarded as unchanged. For a version-less provider it is worse: byte-comparison fallback means it corrupts with no rotation at all, purely on which chain position reports first at startup.

The watch-path wiring was proven load-bearing by experiment: reverting only that hunk leaves the load test green while the update test returns raw base64, which is precisely the "correct at startup, wrong after the first rotation" failure.

## Safety

- **A failed decode wraps `ErrInvalid`**, never a silent passthrough.
- **gzip output is capped at 16 MiB.** Exceeding it is a loud `ErrInvalid`, never a truncation that would hand the application a corrupted secret. This is a decompression-bomb guard: mamori reads from remote backends that could serve a crafted payload.
- **`Value.Version` is untouched**, so change detection keys on the provider's own revision rather than the decoded bytes.
- **An unknown coding name is rejected at spec-walk time**, so a typo fails at `Load`/`Watch`/`Doctor` rather than an hour later on a poll tick. Every ref in a precedence chain is validated, not just the first.
- **`onfail` is honored identically on every path.** A decode failure on the batch path previously bypassed `applyOnFail`, so a field tagged `?decode= default: onfail:"default"` succeeded on a normal provider and failed on a batch one. Fixed, with a test asserting the two paths agree.

## Notes

- Decoding runs **after** the provider's `#key` selection. For the decode-then-select case, drop the `#key`, decode the whole payload, and use `flatten:"json"`.
- A `default:` value is used **as-is, undecoded**. It is a literal you wrote, not an encoded payload from a backend.
- `?decode=trim,gzip` is the escape hatch for a whitespace-padded gzip payload, since `gzip` alone deliberately does not trim (its binary trailer can contain bytes whose values are ASCII whitespace).
- `decode` is not redaction-denylisted, so it stays visible in `Status()` and `mamori doctor`. An operator debugging a garbled value needs to see a decoding step is in play.
- New `DecodeOption` conformance case proves every provider passes unrecognized query options through untouched. Verified it can actually fail by temporarily making a provider reject them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)