### PR TITLE
fix(server): unlink the Unix socket before draining, not after

### DIFF
--- a/server/resolve.go
+++ b/server/resolve.go
@@ -372,7 +372,7 @@ func (s *Server) readiness() (state string, ready bool) {
 
 // Close shuts this Server down completely: every listener Serve bound
 // (transport.go's closeTransports - gracefully, bounded by shutdownGrace,
-// unlinking any Unix socket file afterward), then every binding's upstream
+// unlinking any Unix socket file first), then every binding's upstream
 // watch (cancel, then wg.Wait, mirroring Watcher.Close in reconciler.go).
 // Transports are torn down first so that no HTTP handler goroutine can still
 // be calling lookup (resolve.go) while the resolver goroutines it reads from

--- a/server/transport.go
+++ b/server/transport.go
@@ -131,8 +131,10 @@ func InsecureNoTLS() TCPOption {
 // Serve removes ("unlinks") any file already at path before binding (see
 // bindUnix) - a config server that crashed without reaching Close must not
 // fail to restart just because its old socket file is still there - and
-// Close removes it again once the listener is shut down, so neither this run
-// nor the next one ever trips over a stale file either way.
+// Close removes it again at the START of shutdown, while its listener is
+// still open (see closeTransports for why that ordering is load-bearing and
+// not merely tidy), so neither this run nor the next one ever trips over a
+// stale file either way.
 //
 // Every connection accepted on this listener has its kernel-verified peer
 // credentials (uid/gid/pid) captured and stashed into that connection's
@@ -168,7 +170,7 @@ func TCP(addr string, opts ...TCPOption) Option {
 }
 
 // listenerEntry is one listener Serve bound, plus the http.Server serving it
-// and (for a Unix listener) the socket path Close must unlink afterward.
+// and (for a Unix listener) the socket path Close must unlink.
 // Serve appends one of these per configured Unix(...)/TCP(...) spec, in that
 // order (every Unix(...) listener before every TCP(...) listener), and
 // Close/Addrs both read s.entries back in that same order.
@@ -179,9 +181,10 @@ type listenerEntry struct {
 
 	// unixFile identifies the socket file bindUnix created at unixPath, so
 	// shutdown can verify the file still at that path is the same one before
-	// unlinking it (see closeTransports). Nil for a TCP listener, and also
-	// nil when the post-bind stat failed, which is read as "cannot prove
-	// ownership" and leaves the file alone.
+	// unlinking it (see closeTransports, which must make that comparison
+	// while ln below is still open - see removeOwnedSocket's precondition).
+	// Nil for a TCP listener, and also nil when the post-bind stat failed,
+	// which is read as "cannot prove ownership" and leaves the file alone.
 	unixFile os.FileInfo
 }
 
@@ -266,7 +269,9 @@ func bindUnix(spec unixSpec) (net.Listener, os.FileInfo, error) {
 	// on Close by default, with no check that the file still belongs to it,
 	// which is the very deletion described above. Turning that off and doing
 	// the removal in closeTransports lets it be guarded by the identity
-	// captured here.
+	// captured here. closeTransports keeps the stdlib's ORDERING, though -
+	// unlink while the listener is still open - because that is what keeps
+	// this identity meaningful; see removeOwnedSocket's precondition.
 	if ul, ok := ln.(*net.UnixListener); ok {
 		ul.SetUnlinkOnClose(false)
 	}
@@ -479,7 +484,40 @@ func (s *Server) Serve(ctx context.Context) error {
 // this can also be invoked directly by Serve itself, when Serve's post-setup
 // beginListening check finds a concurrent Close already ran.
 //
-// Every entry's http.Server is offered a graceful Shutdown first, all of
+// Every Unix listener's socket file is unlinked FIRST, before anything is
+// shut down, so neither this run nor a restart trips over a stale file left
+// behind (see Unix's doc comment for the other half of this - the same
+// removal also runs before Serve binds, in case a PREVIOUS run's process
+// died without reaching Close at all).
+//
+// The unlink has to come first, rather than as a tidy-up at the end, because
+// that is the ONLY window in which removeOwnedSocket's ownership check means
+// anything. That check compares inodes (os.SameFile) against an identity
+// captured at bind time, and an inode number identifies a file only for as
+// long as that file is still allocated. This listener is what keeps its own
+// socket allocated: while the listener is open the kernel cannot hand that
+// inode number to anything else, so a match can only mean "still mine".
+// Close the listener - which http.Server.Shutdown does immediately, at the
+// very start of its drain, long before it returns - and the socket is freed
+// as soon as its last name goes away, whereupon Linux hands that exact inode
+// number straight back to the next file created in the directory. A restart
+// binding this same path during the drain is precisely that next file, so an
+// ownership check made after the drain compares the successor's socket
+// against our now-meaningless identity, finds the recycled inode number
+// equal, and concludes the successor's live socket is ours to delete. That
+// misidentification is not a rare interleaving; measured on Linux it happens
+// every single time. It is invisible on macOS only because APFS never reuses
+// an inode number, which is exactly why the regression test for this asserts
+// the ORDERING rather than racing for the symptom - see
+// TestCloseUnlinksSocketBeforeDrainingConnections.
+//
+// Unlinking while the listener is still open is also what net.UnixListener's
+// own unlink-on-close does, which bindUnix deliberately turns off (see
+// SetUnlinkOnClose there). Doing the removal here rather than there buys the
+// ownership check net.UnixListener does not make, without giving up the
+// ordering that is what makes such a check possible at all.
+//
+// Every entry's http.Server is offered a graceful Shutdown next, all of
 // them concurrently, sharing ONE bounded deadline (shutdownGrace) rather
 // than one grace period per listener, so Close's total blocking time stays
 // bounded no matter how many listeners this Server has. Shutdown waits for
@@ -521,16 +559,20 @@ func (s *Server) Serve(ctx context.Context) error {
 // above release them and this Wait finds a zero counter and returns at once;
 // if the very first bind failed, entries is empty and the guard at the top of
 // this function returns before the Wait is reached at all.
-//
-// Finally, every Unix listener's socket file is removed, so neither this run
-// nor a restart trips over a stale file left behind (see Unix's doc comment
-// for the other half of this - the same removal also runs before Serve
-// binds, in case a PREVIOUS run's process died without reaching Close at
-// all).
 func (s *Server) closeTransports() {
 	entries := s.snapshotEntries()
 	if len(entries) == 0 {
 		return
+	}
+
+	// While every listener below is still open, and therefore still pinning
+	// its own socket's inode against reuse. See this function's doc comment:
+	// after the Shutdown below this check can no longer tell our socket from
+	// a successor's.
+	for _, e := range entries {
+		if e.unixPath != "" {
+			removeOwnedSocket(e.unixPath, e.unixFile)
+		}
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
@@ -551,26 +593,38 @@ func (s *Server) closeTransports() {
 	}
 
 	s.listenWG.Wait()
-
-	for _, e := range entries {
-		if e.unixPath != "" {
-			removeOwnedSocket(e.unixPath, e.unixFile)
-		}
-	}
 }
 
 // removeOwnedSocket unlinks path only if the file there is still the very one
 // this listener created (identified by owned, captured in bindUnix).
 //
-// The guard exists because a socket path is a rendezvous point that another
-// process can take over. Binding removes whatever is already at the path, so
-// restarting a server on a fixed path means the incoming process replaces the
-// outgoing process's socket file while the outgoing one is still draining,
-// which can take up to shutdownGrace when a long-lived watch stream is open.
-// An unguarded unlink here would then delete the INCOMING server's socket,
-// leaving it listening on a path nothing can dial and every client
-// permanently unable to reconnect. The failure is worse than a leaked file
-// because it strands a healthy server.
+// # Precondition: the caller must still hold the listener open
+//
+// This function is ONLY correct while the listener that created owned is
+// still open. It is not a general-purpose "is this file still mine" helper,
+// and calling it after the listener has been closed is actively dangerous:
+// os.SameFile compares device and inode number, and an inode number is a
+// stable identity only while the inode is still allocated. An open Unix
+// listener holds its own socket's inode allocated; once that listener is
+// closed, unlinking the last name frees the inode, and Linux hands the very
+// same number to the next file created in that directory - which, in the
+// scenario this guard exists for, is the successor's socket. The comparison
+// then returns a false match and this function deletes a live server's
+// socket. On Linux that is not an unlucky interleaving, it is the every-time
+// outcome. See closeTransports, which is the only caller and which is
+// ordered specifically to satisfy this precondition.
+//
+// # Why the guard exists at all
+//
+// A socket path is a rendezvous point that another process can take over.
+// Binding removes whatever is already at the path, so restarting a server on
+// a fixed path means the incoming process replaces the outgoing process's
+// socket file while the outgoing one is still draining, which can take up to
+// shutdownGrace when a long-lived watch stream is open. An unguarded unlink
+// would then delete the INCOMING server's socket, leaving it listening on a
+// path nothing can dial and every client permanently unable to reconnect.
+// The failure is worse than a leaked file because it strands a healthy
+// server.
 //
 // Every uncertain case leaves the file in place. A leftover socket is
 // harmless (the next bind removes it), whereas deleting a live server's

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -840,6 +841,350 @@ func TestRestartOnSamePathKeepsSuccessorSocket(t *testing.T) {
 
 	if _, err := os.Stat(sockPath); err != nil {
 		t.Fatalf("the outgoing server deleted its successor's socket at %s: %v", sockPath, err)
+	}
+
+	// The file surviving is not enough: the successor must still serve on it.
+	client := unixHTTPClient(sockPath)
+	defer client.CloseIdleConnections()
+	vb := getJSON(t, client, "http://unix/v1/values/b")
+	if vb.Name != "b" || string(vb.Bytes) != "v1" {
+		t.Fatalf("valueBody = %+v, want Name=b Bytes=v1 from the surviving server", vb)
+	}
+}
+
+// stallShutdown opens a connection to sockPath that the server accepts but
+// that never completes a request header, so http.Server.Shutdown cannot
+// report the server quiescent and is forced to run out its full
+// shutdownGrace. That widens Close's drain from microseconds into seconds,
+// which is what lets the two tests below observe what has and has not
+// already happened INSIDE the drain rather than racing it.
+//
+// net/http counts such a connection as non-quiescent for the first five
+// seconds after it is accepted: closeIdleConns only reclassifies a StateNew
+// connection (accepted, first request header not yet fully read) as idle
+// once it is more than five seconds old. transportReadHeaderTimeout is 10s,
+// comfortably past shutdownGrace, so the server will not time the half-sent
+// header out first either.
+//
+// The completed request on a SECOND connection is the synchronization, and
+// it is not optional: a listener accepts on a single goroutine in backlog
+// order, so a request that round-trips on a connection dialed LATER proves
+// the accept loop has already taken this one. Without it the stall
+// connection could still be sitting in the kernel backlog when Shutdown
+// closes the listener, where it would hold nothing at all and the tests
+// below would silently stop testing anything.
+func stallShutdown(t *testing.T, sockPath string) net.Conn {
+	t.Helper()
+
+	stall, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial %s to stall shutdown: %v", sockPath, err)
+	}
+	t.Cleanup(func() { _ = stall.Close() })
+
+	// A request line and one header, with no terminating blank line: the
+	// server is now blocked reading the rest of a header that never arrives.
+	if _, err := io.WriteString(stall, "GET /v1/healthz HTTP/1.1\r\nHost: unix\r\n"); err != nil {
+		t.Fatalf("write a partial request header on the stall connection: %v", err)
+	}
+
+	client := unixHTTPClient(sockPath)
+	defer client.CloseIdleConnections()
+	resp, err := client.Get("http://unix/v1/healthz")
+	if err != nil {
+		t.Fatalf("GET /v1/healthz (to confirm the stall connection has been accepted): %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	return stall
+}
+
+// TestCloseUnlinksSocketBeforeDrainingConnections pins the ORDERING inside
+// closeTransports: the Unix socket file must be unlinked while this Server's
+// listener is still open, before Shutdown is ever called, not tidied up
+// afterward.
+//
+// The ordering is the whole correctness argument for removeOwnedSocket. Its
+// ownership check is os.SameFile against an identity captured at bind time,
+// and an inode number identifies a file only while that file is still
+// allocated. An open listener keeps its own socket allocated; a closed one
+// does not, and Linux hands the freed inode number straight to the next file
+// created in that directory - which, during a restart on a fixed path, is
+// the successor's socket. An ownership check made after the listener is
+// closed therefore matches the SUCCESSOR and deletes it, stranding a healthy
+// server on a path no client can dial. See closeTransports and
+// removeOwnedSocket.
+//
+// This test deliberately asserts the ordering rather than that outcome.
+// Reproducing the outcome requires a filesystem that actually recycles inode
+// numbers, which Linux does and macOS does not, so an outcome test passes
+// vacuously on a developer's Mac and only ever fails in CI - see
+// TestRestartDuringPredecessorDrainKeepsSuccessorSocket, which does exactly
+// that and has to skip itself to stay honest about it. The ordering is
+// observable everywhere, so this test is meaningful everywhere.
+//
+// The two outcomes are separated by seconds, not microseconds, which is what
+// makes the assertion deterministic rather than a race: the stall connection
+// holds Shutdown for the full shutdownGrace, so an unlink that happens
+// before the drain shows up within milliseconds, while an unlink that
+// happens after it cannot possibly show up inside the window below.
+func TestCloseUnlinksSocketBeforeDrainingConnections(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	p := mamoritest.NewProvider("udsorder")
+	p.Set("k", "v1")
+
+	sockPath := shortSocketPath(t)
+
+	s, err := New(
+		WithPolicy(AllowAll()),
+		NoAuth(),
+		Bind("b", "udsorder://k"),
+		WithProvider(p),
+		Unix(sockPath, 0o600),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Serve(ctx) }()
+	waitForAddrs(t, s, 1)
+
+	stall := stallShutdown(t, sockPath)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- s.Close() }()
+
+	// Well inside the drain: shutdownGrace is the earliest the stalled
+	// connection can let Shutdown finish, so anything observed before half
+	// of it has elapsed necessarily happened before the drain ended.
+	//
+	// The verdict is recorded rather than reported on the spot, so that the
+	// drain below is always released and Close always allowed to finish. A
+	// t.Fatalf from inside this loop would leave the stalled connection open
+	// and bury the actual diagnosis under goleak's dump of the goroutines
+	// still working on a teardown this test never let complete.
+	observeBy := time.Now().Add(shutdownGrace / 2)
+	var failure string
+	closeReturned := false
+	for {
+		select {
+		case closeErr := <-closeDone:
+			closeReturned = true
+			failure = fmt.Sprintf("Close returned (err=%v) without the socket file at %s ever being observed unlinked during the drain: the unlink is happening AFTER the listener is closed, where removeOwnedSocket's inode check can no longer tell this server's socket from a successor that rebound the path - see closeTransports", closeErr, sockPath)
+		default:
+		}
+		if closeReturned {
+			break
+		}
+		if _, statErr := os.Stat(sockPath); os.IsNotExist(statErr) {
+			break // Unlinked while still draining: the ordering holds.
+		}
+		if time.Now().After(observeBy) {
+			failure = fmt.Sprintf("socket file at %s still present %s into Close, with a stalled connection still draining: want it unlinked before Shutdown, while the listener still pins its inode - see closeTransports", sockPath, shutdownGrace/2)
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Release the drain so Close can finish and this test leaves nothing
+	// behind for goleak, whatever the verdict above turned out to be.
+	_ = stall.Close()
+	if !closeReturned {
+		select {
+		case closeErr := <-closeDone:
+			if closeErr != nil && failure == "" {
+				failure = fmt.Sprintf("Close: %v", closeErr)
+			}
+		case <-time.After(shutdownGrace + transportTestWait):
+			if failure == "" {
+				failure = "Close did not return after the stalled connection was released"
+			}
+		}
+	}
+
+	if failure != "" {
+		t.Fatal(failure)
+	}
+}
+
+// inodeNumbersAreRecycled reports whether the filesystem holding dir hands a
+// freed inode number straight back to the next file created in its place.
+//
+// It performs exactly the sequence closeTransports must never perform: bind a
+// socket, capture its identity, close the listener, drop the name, and bind
+// again on the same path. Linux answers true (every time, in practice);
+// macOS answers false, because APFS allocates inode numbers monotonically and
+// effectively never reuses one.
+//
+// Probing the behavior beats testing runtime.GOOS: what the test below
+// actually depends on is inode recycling, not an operating system name, and a
+// filesystem that stops recycling should skip the test rather than let it
+// pass vacuously.
+func inodeNumbersAreRecycled(t *testing.T, dir string) bool {
+	t.Helper()
+
+	path := filepath.Join(dir, "recycle-probe.sock")
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	listenProbe := func() (net.Listener, os.FileInfo) {
+		t.Helper()
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatalf("inode recycling probe: listen on %s: %v", path, err)
+		}
+		if ul, ok := ln.(*net.UnixListener); ok {
+			// Match bindUnix: the name must outlive the listener, so that
+			// dropping it below is what actually frees the inode.
+			ul.SetUnlinkOnClose(false)
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			_ = ln.Close()
+			t.Fatalf("inode recycling probe: stat %s: %v", path, err)
+		}
+		return ln, fi
+	}
+
+	first, before := listenProbe()
+	_ = first.Close()   // the socket is gone; only the name still holds the inode
+	_ = os.Remove(path) // and now nothing does, so the inode is free to reuse
+
+	second, after := listenProbe()
+	_ = second.Close()
+	_ = os.Remove(path)
+
+	return os.SameFile(before, after)
+}
+
+// TestRestartDuringPredecessorDrainKeepsSuccessorSocket is the end-to-end
+// half of TestCloseUnlinksSocketBeforeDrainingConnections: it reproduces the
+// production failure itself rather than the ordering that causes it.
+//
+// TestRestartOnSamePathKeepsSuccessorSocket already covers the easy
+// interleaving, where the successor binds while the predecessor's listener is
+// still open. That one is safe by construction: the predecessor's inode
+// cannot be recycled while it still holds it, so its ownership check cannot
+// be fooled. The dangerous interleaving is the other one - the predecessor's
+// listener is ALREADY CLOSED (http.Server.Shutdown closes it at the very
+// start of its drain) when the successor binds - and that is what this
+// exercises: the successor gets the predecessor's recycled inode number, and
+// an ownership check made at the end of the drain deletes the successor's
+// live socket.
+//
+// It skips where inode numbers are not recycled, because there the successor
+// can never collide with the predecessor's identity and the test would pass
+// whether or not the bug is present. A test that only fails on Linux CI while
+// passing silently on every developer's Mac is worse than no test, so it says
+// so out loud instead.
+//
+// The outgoing server is given TWO Unix listeners, and the connection that
+// stalls its drain is opened on the OTHER one. That is not incidental. A
+// stalled connection is what makes the drain wide enough to bind a successor
+// inside it, but an accepted AF_UNIX connection takes a reference to the
+// LISTENING socket's path (unix_stream_connect does a path_get on it), so a
+// connection held open on the socket being restarted would keep that socket's
+// inode allocated - and an inode that is never freed is never recycled, which
+// is precisely the collision this test needs to provoke. Stalling one socket
+// to observe the other keeps the two requirements from cancelling out:
+// closeTransports runs ONE shared shutdownGrace across every listener, so a
+// connection parked on the stall socket delays the restart socket's cleanup
+// just as effectively, while leaving its inode free to be handed to the
+// successor.
+func TestRestartDuringPredecessorDrainKeepsSuccessorSocket(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	sockPath := shortSocketPath(t)
+	if !inodeNumbersAreRecycled(t, filepath.Dir(sockPath)) {
+		t.Skip("this filesystem does not recycle inode numbers, so a successor socket can never collide with its predecessor's captured identity here; the ordering this protects is covered on every platform by TestCloseUnlinksSocketBeforeDrainingConnections")
+	}
+	// Deliberately a sibling in the SAME directory: ext4 allocates a new
+	// inode from the parent directory's block group first, so keeping both
+	// sockets together is what makes the successor pick up the inode number
+	// the predecessor just released.
+	stallPath := filepath.Join(filepath.Dir(sockPath), "stall.sock")
+
+	p := mamoritest.NewProvider("udsdrain")
+	p.Set("k", "v1")
+
+	newServer := func(opts ...Option) *Server {
+		t.Helper()
+		s, err := New(append([]Option{
+			WithPolicy(AllowAll()),
+			NoAuth(),
+			Bind("b", "udsdrain://k"),
+			WithProvider(p),
+			Unix(sockPath, 0o600),
+		}, opts...)...)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return s
+	}
+
+	oldSrv := newServer(Unix(stallPath, 0o600))
+	oldCtx, oldCancel := context.WithCancel(context.Background())
+	defer oldCancel()
+	go func() { _ = oldSrv.Serve(oldCtx) }()
+	waitForAddrs(t, oldSrv, 2)
+
+	// Hold the outgoing server in its drain for the full shutdownGrace, so
+	// the successor below binds squarely inside the window where the
+	// predecessor's listener is closed but its cleanup has not run yet.
+	stall := stallShutdown(t, stallPath)
+
+	oldCloseDone := make(chan error, 1)
+	go func() { oldCloseDone <- oldSrv.Close() }()
+
+	// The listener closes at the very start of Shutdown, so the path stops
+	// accepting almost immediately. Waiting for that is what puts the
+	// successor's bind inside the drain rather than before it. The dial can
+	// fail either because nothing is listening on the socket file any more or
+	// because the file itself is already gone (which is what the fixed
+	// ordering produces); either answer means the window is open.
+	deadline := time.Now().Add(transportTestWait)
+	for {
+		conn, dialErr := net.Dial("unix", sockPath)
+		if dialErr != nil {
+			break
+		}
+		_ = conn.Close()
+		if time.Now().After(deadline) {
+			t.Fatalf("the outgoing server was still accepting on %s %s after Close began; expected Shutdown to close its listener promptly", sockPath, transportTestWait)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// The incoming server takes the path over, exactly as a restart does,
+	// while the outgoing one is still draining.
+	newSrv := newServer()
+	newCtx, newCancel := context.WithCancel(context.Background())
+	defer newCancel()
+	go func() { _ = newSrv.Serve(newCtx) }()
+	defer func() { newCancel(); _ = newSrv.Close() }()
+	waitForAddrs(t, newSrv, 1)
+	waitForLookup(t, newSrv, "b", func(v mamori.Value, k mamori.Kind, hasValue, found bool) bool {
+		return found && k == "" && string(v.Bytes) == "v1"
+	})
+
+	// Let the outgoing server finish its teardown. Whatever cleanup it does
+	// on the way out must not touch the path, which now belongs to the
+	// successor.
+	_ = stall.Close()
+	select {
+	case closeErr := <-oldCloseDone:
+		if closeErr != nil {
+			t.Fatalf("closing the outgoing server: %v", closeErr)
+		}
+	case <-time.After(shutdownGrace + transportTestWait):
+		t.Fatal("the outgoing server's Close did not return after the stalled connection was released")
+	}
+
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("the outgoing server deleted its successor's socket at %s while draining: %v", sockPath, err)
 	}
 
 	// The file surviving is not enough: the successor must still serve on it.


### PR DESCRIPTION
A config server restarted on a fixed Unix socket path **deletes its successor's live socket** on Linux, roughly half the time, stranding every client. Latent since #47.

## The bug

`closeTransports` unlinked the socket **after** `Shutdown` had already closed the listener. Once the listener is closed and a successor has unlinked the old name and bound its own, **Linux recycles the freed inode straight into the successor's socket**. `removeOwnedSocket`'s `os.SameFile` check then answers "this is mine", and the outgoing server unlinks the incoming server's live socket.

The `os.SameFile` guard was doing exactly what it was written to do. Its unstated precondition was simply no longer true: an inode is only a stable identity while something still pins it, and the open listener was that pin.

Probe, 2000 iterations each way:

| listener state when the successor binds | collisions |
|---|---|
| still open | **0 / 2000** |
| already closed | **2000 / 2000** |

Not probabilistic once the listener is gone. It is certain.

### Why nobody noticed

**It cannot reproduce on macOS** (0/40). APFS does not recycle inode numbers that way. It reproduces readily on Linux, which is where CI and essentially every deployment runs.

It surfaced as `TestWatchReconnectsOnServerRestartMidWatch` in `providers/mamori` timing out: the successor reports its address correctly while its socket file is gone, so clients retry forever against nothing.

## The fix

Move the unlink loop ahead of the `Shutdown` fan-out, while the listener still pins the inode.

## Results

| measurement | before | after |
|---|---|---|
| `TestWatchReconnectsOnServerRestartMidWatch` (Linux, 61 runs) | 27 failures | **0** |
| `TestCloseUnlinksSocketBeforeDrainingConnections` (30 runs) | 30 failures | **0** |
| `TestRestartDuringPredecessorDrainKeepsSuccessorSocket` (30 runs) | 30 failures | **0** |

Two regression tests, deliberately different in kind:

- an **ordering** assertion, which is the primary one precisely because the symptom is invisible on macOS. It fails against unfixed code on macOS too, so it is not a Linux-only trap. Determinism comes from stalling the drain with an incomplete request header and requiring the unlink within `shutdownGrace/2`; the two outcomes are 2.5s apart, not microseconds.
- an **end-to-end symptom** test, which skips with a stated reason via a runtime inode-recycling probe rather than a `runtime.GOOS` check.

## Behavior change, called out deliberately

**New clients can no longer dial during the drain window.** The socket path disappears when `Close` begins rather than when it finishes.

This is consistent with what draining already means here: `Close` flips `draining` so `GET /v1/readyz` returns 503 specifically to get load balancers to stop routing, and `DrainGrace` exists to hold that state long enough for them to notice. Accepting brand-new connections on a server that has begun shutting down was arguably the wrong behavior anyway. In-flight requests still drain normally under `shutdownGrace`.

Flagging it because it is a real behavior change in a patch release, not because I think it is wrong.

## Notes

- No new dependencies, no public API change. `Close` stays idempotent and still blocks until teardown completes.
- Six doc comments asserted the old ordering and were false; all corrected. `removeOwnedSocket` now states its precondition explicitly.
- Checked for the same hazard elsewhere: `os.SameFile`, `SetUnlinkOnClose`, and non-test `net.Listen("unix", ...)` each appear exactly once, all in this file. `adminhttp.go` is TCP-only and `cmd/mamori` only dials.
- One trap is documented in the tests because it cost real time: an accepted AF_UNIX connection pins the *listener's* inode, so a naive symptom test stalls the very socket it needs freed and passes vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix socket shutdown behavior by removing socket files before connection draining begins.
  * Prevented stale socket cleanup from disrupting a replacement server during restart.
  * Improved reliability when restarting services on the same Unix socket path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->