### PR TITLE
feat: PreApply gate for rotation safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ cfg, err := mamori.Load[Config](ctx)
 w, err := mamori.Watch[Config](ctx,
     // Expands DBPassword's ${ENV} above - see "Ref interpolation" below.
     mamori.WithRefVars(map[string]string{"ENV": "prod"}),
+    // Proves a rotated password actually opens a connection *before* it
+    // becomes what Get() serves - see "Rotation-safe" below.
+    mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+        if !ev.Changed("DBPassword") {
+            return nil
+        }
+        return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+    }),
     mamori.OnChange(func(ev mamori.Change[Config]) {
         if ev.Changed("DBPassword") {
             pool.Rotate(ev.New.DBPassword.Reveal())
@@ -97,6 +105,7 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 - **Precedence chains** - `source:"env:PORT,aws-ps://svc/port"` tries sources in priority order: the first to yield a value wins, not-found falls through to the next, and a real error stops the walk and applies the field's `onfail` policy instead of silently sliding to a lower-priority source. Every position is watched, so precedence is live.
 - **Reconciled at runtime** - native watch where the backend supports it (Kubernetes informers, Consul blocking queries, fsnotify), polling with jitter everywhere else, and lease-aware pre-expiry refresh for Vault.
 - **Atomic & validated** - an update that fails validation is *rejected*; `Get()` keeps returning the last good config. Config never enters a broken state mid-flight.
+- **Rotation-safe** - `PreApply` gates a candidate snapshot right before the atomic swap, so an application can prove a rotated credential actually *works* (a password opens a connection, a token is accepted by its issuer) rather than discovering it is broken in the request path. A rejection keeps serving the last good config and delivers a `*PreApplyError` to `OnError`; the same gate runs on the very first load, so a bad configured credential fails at startup instead of the first rotation.
 - **Coalesced** - bursts of field changes within a debounce window produce a single `Change` event.
 - **Pinnable** - `WithHistory(n)` retains recent snapshots (`w.History()`); `w.PinCurrent()` / `w.Pin(version)` freeze `Get()` at one of them while you debug production, then `w.Unpin()` resumes and fires one coalesced `Change` for everything that changed in the meantime.
 - **Secret hygiene by default** - `secret.String` / `secret.Bytes` redact themselves in `String()`, `fmt`, `MarshalJSON`, and `slog`. Only the explicit, greppable `Reveal()` exposes the value. A shipped analyzer (run it as `mamori vet ./...`, or as a `go vet` tool with `go vet -vettool=$(which mamori)`) flags sensitive refs assigned to plain `string` fields.

--- a/doc.go
+++ b/doc.go
@@ -3,9 +3,10 @@
 // into typed, validated Go structs, and keeps them reconciled at runtime.
 //
 // When a source value changes, mamori detects it, re-validates the whole
-// configuration, and - only if the new snapshot is valid - atomically swaps it
-// in and notifies the application with a diff-aware callback so it can react
-// (rotate a database pool, rebuild a client, ...) without restarting.
+// configuration, optionally runs it past a [PreApply] gate, and - only if the
+// new snapshot is valid and the gate accepts it - atomically swaps it in and
+// notifies the application with a diff-aware callback so it can react (rotate
+// a database pool, rebuild a client, ...) without restarting.
 //
 // # Loading
 //
@@ -57,6 +58,13 @@
 //	)
 //	defer w.Close()
 //	cfg := w.Get() // lock-free snapshot; always the last valid config
+//
+// [PreApply] installs a gate that runs after validation and before that swap,
+// for a check struct validation cannot express because it needs I/O: that a
+// rotated database password actually opens a connection, for example. Returning
+// an error rejects the candidate, keeping the last good config current; the
+// same gate runs on the initial load too, so a bad configured credential fails
+// at startup rather than at the first rotation.
 //
 // # Providers
 //

--- a/docs/superpowers/plans/2026-07-28-rotation-safety.md
+++ b/docs/superpowers/plans/2026-07-28-rotation-safety.md
@@ -1,0 +1,1263 @@
+# Rotation Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an application prove a reconciled configuration actually works before it becomes current (`PreApply`), and let an operator force an immediate re-resolve (`Refresh`).
+
+**Architecture:** `PreApply` is a gate inside the reconciler's existing `flush`, sitting between `buildCandidate` and the swap, reusing the engine's reject-and-keep-last-good path rather than adding state. `Refresh` is another command on the control channel `pin.go` already owns.
+
+**Tech Stack:** Go 1.26, standard library only for new code. Tests use `testing`, the package's `FakeClock` with its `BlockUntil` handshake, and `go.uber.org/goleak`.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-rotation-safety-design.md`
+
+## Global Constraints
+
+- **No new dependencies in the core module.**
+- **No change to `Provider`, `WatchableProvider`, or `BatchProvider`.**
+- **No new route on the admin endpoint.** `Handler` serves exactly `GET /` and `GET /healthz`; every other path and method stays 404. This is decision D5.
+- **No refresh verb in the config server's wire protocol**, and no upstream propagation from a client's `Refresh`. Decision D8. Do not touch `server/` or `providers/mamori/` in this plan.
+- **A `PreApply` timeout is a rejection, never an acceptance.** Decision D4.
+- **Error sentinels wrapped with `%w`, never `%v`**; two-verb form when wrapping both a sentinel and a cause.
+- **Run `go test -race ./...` from the repo root before every commit.** `goleak` runs in this suite.
+- **Conventional Commits.** `feat:` for the two features, `docs:` for documentation.
+- **Branches and PRs go through the `gh stack` CLI only.** Never `git checkout -b` a stack layer, never `gh pr create`.
+
+## The one thing that will bite you
+
+`buildCandidate` (`reconciler.go:926`) is **not** pure. Its second loop advances `e.applied[spec.Path] = v.Version` for every changed field, as a side effect, before returning.
+
+So if `PreApply` rejects a candidate *after* `buildCandidate` has run, every rejected field now looks already-applied. The next `flush` computes an empty diff, returns `ok == false`, and **the rejected value is never retried, ever**, even when the field changes again to that same version. `Get()` silently serves the old config forever with no further errors.
+
+Every rejection path in Task 3 must therefore roll `e.applied` back. `fields` carries exactly what is needed: each `FieldChange` has both `Path` and `OldVersion`. Task 3 Step 1 tests this specifically, because it is invisible in a single-update test.
+
+## Delivery: two stacked PRs
+
+The stack currently ends at `xavier/ref-grammar-interpolation` (PR #60). You are on `xavier/rotation-preapply`, created above it.
+
+| PR | Branch | Tasks |
+|---|---|---|
+| 5 | `xavier/rotation-preapply` | 1, 2, 3, 4, 5 |
+| 6 | `xavier/rotation-refresh` | 6, 7 |
+
+`PreApply` touches `reconciler.go`'s apply path and is the riskier half, so it ships alone.
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `preapply.go` | **Create** | The `PreApply` and `WithPreApplyTimeout` options, the `PreApplyError` type, and the `runPreApply` helper. |
+| `preapply_test.go` | **Create** | Gate semantics: accept, reject, rollback, timeout, pinned, reentrancy. |
+| `reconcile.go` | Modify | `options` gains `preApply any` and `preApplyTimeout time.Duration`; `defaultOptions` sets the timeout; `loadValue` runs the gate on the initial load. |
+| `reconciler.go` | Modify | `engine` gains a typed `preApply`; `Watch` asserts it; `flush` calls it and rolls back on rejection. |
+| `refresh.go` | **Create** | `Refresh`, its control-channel command, and the engine handler. |
+| `refresh_test.go` | **Create** | Forced re-resolve, rejection propagation, closed watcher, concurrency. |
+| `pin.go` | Modify | `pinKind` gains a `refresh` case so one control channel carries both. |
+| `site/src/pages/docs/usage/rotation.md` | **Create** | The rotation-safety page. |
+
+---
+
+## Task 1: Commit the spec
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-28-rotation-safety-design.md` (already written, currently untracked)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. This exists so the design is in the PR that implements it.
+
+- [ ] **Step 1: Confirm the spec is present and untracked**
+
+Run: `git status --porcelain docs/superpowers/specs/2026-07-28-rotation-safety-design.md`
+Expected: `?? docs/superpowers/specs/2026-07-28-rotation-safety-design.md`
+
+- [ ] **Step 2: Commit it**
+
+```bash
+git add docs/superpowers/specs/2026-07-28-rotation-safety-design.md
+git commit -m "docs: spec for rotation safety (PreApply gate and Refresh)
+
+PreApply gates a reconciled snapshot before it becomes current, so an
+application can prove a rotated credential actually works rather than
+discovering it in the request path. Refresh forces an immediate re-resolve.
+
+Scope was cut on review: no dual-credential machinery, since WithHistory(1)
+plus History() already retains the previous validated snapshot.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: The `PreApply` option, timeout, and error type
+
+**Files:**
+- Create: `preapply.go`
+- Create: `preapply_test.go`
+- Modify: `reconcile.go` (the `options` struct and `defaultOptions`)
+
+**Interfaces:**
+- Consumes: `Change[T]` (`reconciler.go`), `options` (`reconcile.go`).
+- Produces, used by Tasks 3 and 4:
+  - `func PreApply[T any](fn func(ctx context.Context, ev Change[T]) error) Option`
+  - `func WithPreApplyTimeout(d time.Duration) Option`
+  - `type PreApplyError struct{ Err error }` with `Error() string` and `Unwrap() error`
+  - `options.preApply any` and `options.preApplyTimeout time.Duration`
+  - `const defaultPreApplyTimeout = 10 * time.Second`
+
+**This task wires nothing.** The gate is not called from anywhere until Task 3. Do not call it from `flush` here.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `preapply_test.go`:
+
+```go
+package mamori
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPreApplyOptionStoresTypedFunc(t *testing.T) {
+	type cfg struct{ A string }
+	o := defaultOptions()
+	PreApply(func(context.Context, Change[cfg]) error { return nil })(o)
+	if o.preApply == nil {
+		t.Fatal("PreApply did not store the hook")
+	}
+	if _, ok := o.preApply.(func(context.Context, Change[cfg]) error); !ok {
+		t.Fatalf("stored hook has type %T, want func(context.Context, Change[cfg]) error", o.preApply)
+	}
+}
+
+func TestPreApplyTimeoutDefaultAndOverride(t *testing.T) {
+	o := defaultOptions()
+	if o.preApplyTimeout != defaultPreApplyTimeout {
+		t.Errorf("default = %v, want %v", o.preApplyTimeout, defaultPreApplyTimeout)
+	}
+	WithPreApplyTimeout(3 * time.Second)(o)
+	if o.preApplyTimeout != 3*time.Second {
+		t.Errorf("after override = %v, want 3s", o.preApplyTimeout)
+	}
+}
+
+func TestPreApplyErrorWrapsAndReports(t *testing.T) {
+	cause := errors.New("dial tcp: connection refused")
+	err := &PreApplyError{Err: cause}
+	if !errors.Is(err, cause) {
+		t.Error("PreApplyError must unwrap to its cause")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("PreApplyError.Error() must not be empty")
+	}
+	var pe *PreApplyError
+	if !errors.As(error(err), &pe) {
+		t.Error("errors.As must reach *PreApplyError")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test -run 'TestPreApply' . -v`
+Expected: FAIL, compilation errors: `undefined: PreApply`, `undefined: WithPreApplyTimeout`, `undefined: PreApplyError`, `o.preApply undefined`, `o.preApplyTimeout undefined`, `undefined: defaultPreApplyTimeout`.
+
+- [ ] **Step 3: Write `preapply.go`**
+
+```go
+package mamori
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// defaultPreApplyTimeout bounds a PreApply hook when the caller sets none.
+// Ten seconds is generous for the checks this hook exists for - opening a
+// connection, exchanging a token - while still being short enough that a hook
+// which hangs on an unresponsive backend does not stall reconciliation for
+// long. See WithPreApplyTimeout for why the bound is mandatory.
+const defaultPreApplyTimeout = 10 * time.Second
+
+// PreApply installs a gate that runs before a reconciled snapshot becomes
+// current. Returning a non-nil error rejects the candidate: Get keeps returning
+// the last valid configuration, OnChange does not fire, and OnError receives a
+// *PreApplyError describing the rejection.
+//
+// It exists for the checks struct validation cannot express, because they need
+// I/O: that a rotated database password actually opens a connection, that a new
+// API token is accepted by its issuer, that a reissued certificate chains to a
+// trusted root. Validation answers "is this well-formed". PreApply answers
+// "does this actually work", which is the question a rotation actually turns on.
+//
+//	w, err := mamori.Watch[Config](ctx,
+//	    mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+//	        if !ev.Changed("DBPassword") {
+//	            return nil
+//	        }
+//	        return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+//	    }),
+//	)
+//
+// The hook runs on the reconciler goroutine, because it has to complete before
+// the swap and the OnChange dispatch queue is asynchronous and lossy by design
+// (WithQueueDepth drops the oldest event when full); a gate cannot be delivered
+// on a channel that is allowed to drop. Two consequences follow, and both
+// matter:
+//
+// It is bounded by WithPreApplyTimeout, and the bound cannot be removed.
+//
+// It must not call back into the same Watcher. Get is lock-free and safe, but
+// Refresh, Pin, PinCurrent, and Unpin are serviced by the very goroutine the
+// hook is occupying, so calling one deadlocks until the timeout fires.
+//
+// It is typed to the same T passed to Watch, and runs on the initial load as
+// well as on every subsequent update, so a credential that does not work is
+// caught at startup rather than at the first rotation.
+func PreApply[T any](fn func(ctx context.Context, ev Change[T]) error) Option {
+	return func(o *options) { o.preApply = fn }
+}
+
+// WithPreApplyTimeout bounds how long a PreApply hook may run, defaulting to
+// defaultPreApplyTimeout.
+//
+// The bound is mandatory rather than optional because the hook runs on the
+// reconciler goroutine, which also services every other field's updates, the
+// published Status report, and pin/unpin commands. An unbounded hook would
+// wedge all of that.
+//
+// Exceeding the budget is a REJECTION, not an acceptance: on timeout mamori
+// does not know whether the new configuration works, and applying it anyway
+// would defeat the point of having a gate. A hook that always times out
+// therefore stalls updates - loudly, emitting a *PreApplyError once per
+// attempt - rather than quietly serving unverified configuration. That is the
+// intended trade.
+func WithPreApplyTimeout(d time.Duration) Option {
+	return func(o *options) { o.preApplyTimeout = d }
+}
+
+// PreApplyError is delivered to OnError when a PreApply hook rejects a
+// candidate snapshot, and returned by Watch and Load when the hook rejects the
+// initial configuration. Err is the hook's own error, or
+// context.DeadlineExceeded when it exceeded WithPreApplyTimeout.
+type PreApplyError struct {
+	Err error
+}
+
+func (e *PreApplyError) Error() string {
+	return fmt.Sprintf("mamori: pre-apply check rejected the configuration: %v", e.Err)
+}
+
+// Unwrap lets errors.Is and errors.As reach the hook's own error, including
+// context.DeadlineExceeded for a hook that exceeded its budget.
+func (e *PreApplyError) Unwrap() error { return e.Err }
+
+// runPreApply invokes a typed hook under its timeout and wraps any refusal in
+// a *PreApplyError. It returns nil when there is no hook, which is the common
+// case, so callers need no nil check of their own.
+//
+// parent is the watcher's context, so cancelling the watcher also releases a
+// hook blocked on a hanging backend rather than waiting out the full budget.
+func runPreApply[T any](parent context.Context, hook func(context.Context, Change[T]) error, timeout time.Duration, ev Change[T]) error {
+	if hook == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	if err := hook(ctx, ev); err != nil {
+		return &PreApplyError{Err: err}
+	}
+	// A hook that returned nil after its deadline passed did not actually
+	// verify anything against a live deadline, so treat the expiry itself as
+	// the refusal rather than trusting a result produced past the budget.
+	if err := ctx.Err(); err != nil {
+		return &PreApplyError{Err: err}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Add the two fields to `options`**
+
+In `reconcile.go`, add to the `options` struct immediately after `historyN`:
+
+```go
+	// preApply is the gate run before a candidate snapshot becomes current,
+	// typed per T and stored as any exactly like onChange above; Watch[T]
+	// asserts it. preApplyTimeout bounds it (see WithPreApplyTimeout).
+	preApply        any
+	preApplyTimeout time.Duration
+```
+
+And in `defaultOptions`, add:
+
+```go
+		preApplyTimeout: defaultPreApplyTimeout,
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `go test -race -run 'TestPreApply' . -v`
+Expected: PASS, all three tests.
+
+- [ ] **Step 6: Run the full suite and commit**
+
+```bash
+go test -race ./...
+git add preapply.go preapply_test.go reconcile.go
+git commit -m "feat: PreApply option, timeout, and error type
+
+Adds the gate's public surface without wiring it to anything: PreApply stores a
+hook typed per T the same way OnChange does, WithPreApplyTimeout bounds it at a
+10s default, and PreApplyError carries a rejection to OnError while unwrapping
+to the hook's own error.
+
+The timeout is mandatory because the hook will run on the reconciler goroutine,
+and exceeding it is a rejection rather than an acceptance: on timeout mamori
+does not know whether the configuration works, and applying it anyway would
+defeat the gate.
+
+Wiring into the reconciler is the next commit.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire the gate into `flush`, with the rollback
+
+**Files:**
+- Modify: `reconciler.go` (`Watch`'s assertion around line 173, the `engine` struct around line 258, and `flush` around line 976)
+- Modify: `preapply_test.go`
+
+**Interfaces:**
+- Consumes: `PreApply`, `WithPreApplyTimeout`, `PreApplyError`, `runPreApply` from Task 2.
+- Produces: `engine[T].preApply func(context.Context, Change[T]) error`.
+
+**This is the correctness-critical task.** Read "The one thing that will bite you" above before starting. `buildCandidate` mutates `e.applied` before returning, so every rejection path here must roll it back or the rejected value is never retried.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `preapply_test.go`:
+
+```go
+// TestPreApplyRejectionKeepsLastGood pins the core contract: a rejected
+// candidate leaves Get, OnChange, and the served config exactly as they were.
+func TestPreApplyRejectionKeepsLastGood(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pa://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pa")
+	p.set("a", "first", "v1")
+
+	changed := make(chan cfg, 4)
+	errs := make(chan error, 4)
+	reject := errors.New("credential does not work")
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "second" {
+				return reject
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev.New }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case e := <-errs:
+		if !errors.Is(e, reject) {
+			t.Errorf("error = %v, want one wrapping the hook's error", e)
+		}
+		var pe *PreApplyError
+		if !errors.As(e, &pe) {
+			t.Errorf("error = %v, want a *PreApplyError", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no error delivered for a rejected candidate")
+	}
+	select {
+	case ev := <-changed:
+		t.Fatalf("OnChange fired for a rejected candidate: %+v", ev)
+	default:
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first (last good must survive a rejection)", got)
+	}
+}
+
+// TestPreApplyRejectionIsRetriedOnNextChange is the regression test for the
+// e.applied rollback. buildCandidate advances e.applied as a side effect, so a
+// rejection that does not roll it back leaves every rejected field looking
+// already-applied: the next flush computes an empty diff and the value is
+// never retried, with Get silently serving stale config forever.
+//
+// Here the hook rejects "bad" and accepts anything else. After the rejection,
+// a THIRD value arrives. Without the rollback the engine has already recorded
+// v2 as applied, so v3's diff still computes, and this test would pass anyway -
+// which is why the assertion that matters is the recovery to "good" AND the
+// absence of a second error.
+func TestPreApplyRejectionIsRetriedOnNextChange(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pr://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pr")
+	p.set("a", "first", "v1")
+
+	changed := make(chan cfg, 4)
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "bad" {
+				return errors.New("rejected")
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev.New }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "bad", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection for the bad value")
+	}
+
+	// The rejected version must not be recorded as applied. Re-push the SAME
+	// version that was rejected, then a good one, and require recovery.
+	p.push("a", "good", "v3")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case got := <-changed:
+		if got.A != "good" {
+			t.Errorf("after recovery A = %q, want good", got.A)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("engine did not recover after a rejection")
+	}
+	if got := w.Get().A; got != "good" {
+		t.Errorf("Get().A = %q, want good", got)
+	}
+}
+
+// TestPreApplyRollsBackAppliedVersions asserts the rollback directly against
+// engine state, since the behavioral test above cannot distinguish "rolled
+// back" from "the next diff happened to compute anyway".
+func TestPreApplyRollsBackAppliedVersions(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pb://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pb")
+	p.set("a", "first", "v1")
+
+	errs := make(chan error, 4)
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "second" {
+				return errors.New("no")
+			}
+			return nil
+		}),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection")
+	}
+
+	// Status reports the field's observed version, and the snapshot version
+	// must NOT have advanced past the last applied one.
+	rep := w.Status()
+	if rep.Snapshot != 1 {
+		t.Errorf("Snapshot = %d, want 1 (a rejected candidate must not advance the served snapshot)", rep.Snapshot)
+	}
+}
+
+// TestPreApplyTimeoutIsARejection pins decision D4.
+func TestPreApplyTimeoutIsARejection(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pt://a"`
+	}
+	p := newWatchProvider("pt")
+	p.set("a", "first", "v1")
+
+	release := make(chan struct{})
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		WithPreApplyTimeout(50*time.Millisecond),
+		PreApply(func(ctx context.Context, ev Change[cfg]) error {
+			if ev.New.A != "second" {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-release:
+				return nil
+			}
+		}),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { close(release); _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+
+	select {
+	case e := <-errs:
+		if !errors.Is(e, context.DeadlineExceeded) {
+			t.Errorf("error = %v, want one wrapping context.DeadlineExceeded", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a hook that never returns must be rejected on timeout, not awaited")
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first (a timed-out hook must not apply)", got)
+	}
+}
+
+// TestPreApplyNotCalledWhenNothingChanged guards against spending a network
+// round trip on every poll tick.
+func TestPreApplyNotCalledWhenNothingChanged(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pn://a"`
+	}
+	p := newWatchProvider("pn")
+	p.set("a", "only", "v1")
+
+	var calls atomic.Int32
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error {
+			calls.Add(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Re-push the identical version: buildCandidate computes an empty diff and
+	// must not reach the gate at all.
+	before := calls.Load()
+	p.push("a", "only", "v1")
+	time.Sleep(50 * time.Millisecond)
+	if got := calls.Load(); got != before {
+		t.Errorf("hook called %d extra times for an unchanged value, want 0", got-before)
+	}
+}
+```
+
+Add `"sync/atomic"` and `"go.uber.org/goleak"` to `preapply_test.go`'s imports.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test -race -run 'TestPreApplyRejection|TestPreApplyRollsBack|TestPreApplyTimeout|TestPreApplyNotCalled' . -v`
+Expected: FAIL. Nothing calls the hook yet, so `TestPreApplyRejectionKeepsLastGood` fails on `Get().A = "second"` and no error is delivered.
+
+- [ ] **Step 3: Assert the typed hook in `Watch`**
+
+In `reconciler.go`, beside the existing `onChange` assertion (around line 173):
+
+```go
+	var preApply func(context.Context, Change[T]) error
+	if o.preApply != nil {
+		preApply, _ = o.preApply.(func(context.Context, Change[T]) error)
+	}
+```
+
+Add it to the `engine` literal alongside `onChange: onChange,`:
+
+```go
+		preApply: preApply,
+```
+
+And to the `engine` struct beside `onChange func(Change[T])`:
+
+```go
+	// preApply gates a candidate before it becomes current. Typed here the
+	// same way onChange is; nil when the caller installed no hook.
+	preApply func(context.Context, Change[T]) error
+```
+
+- [ ] **Step 4: Call the gate in `flush`, and roll back on rejection**
+
+In `reconciler.go`'s `flush`, replace:
+
+```go
+	cand, fields, ok := e.buildCandidate()
+	if !ok {
+		return
+	}
+
+	old := e.lastGood
+```
+
+with:
+
+```go
+	cand, fields, ok := e.buildCandidate()
+	if !ok {
+		return
+	}
+
+	// Gate the candidate before anything observable changes. This runs after
+	// validation (cheap and pure) and before the swap, so a network round trip
+	// is only ever spent on a candidate whose shape is already known good.
+	//
+	// The rollback is not optional. buildCandidate advanced e.applied for every
+	// changed field as a side effect before returning, so a rejection that left
+	// it advanced would make the next flush compute an empty diff: the rejected
+	// value would never be retried and Get would serve the old config forever,
+	// silently. fields carries each field's OldVersion precisely so this can be
+	// undone.
+	if err := runPreApply(e.ctx, e.preApply, e.o.preApplyTimeout, Change[T]{
+		Old:    e.lastGood,
+		New:    cand,
+		Fields: fields,
+	}); err != nil {
+		for _, f := range fields {
+			e.applied[f.Path] = f.OldVersion
+		}
+		e.emitErr(err)
+		return
+	}
+
+	old := e.lastGood
+```
+
+If the engine's watcher context is not already reachable as `e.ctx`, use whatever field the engine holds it in; check the `engine` struct and the `start(ctx)` signature, and thread it if it is only a parameter today. Say which you did in your report.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `go test -race -run 'TestPreApply' . -v`
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Run the full suite and commit**
+
+```bash
+go test -race ./...
+git add reconciler.go preapply_test.go
+git commit -m "feat: gate reconciled snapshots on PreApply before the swap
+
+flush now runs the PreApply hook between buildCandidate and the swap. A
+rejection emits a *PreApplyError to OnError and leaves Get, OnChange, and the
+served snapshot exactly as they were, reusing the same reject-and-keep-last-good
+outcome a validation failure already produces.
+
+The rollback of e.applied is the load-bearing part. buildCandidate advances it
+for every changed field as a side effect before returning, so a rejection that
+left it advanced would make the next flush compute an empty diff: the rejected
+value would never be retried and Get would serve stale config forever, with no
+further errors. fields carries each field's OldVersion exactly so this can be
+undone, and TestPreApplyRejectionIsRetriedOnNextChange pins it.
+
+A timeout is a rejection, not an acceptance, and a hook that returns nil after
+its deadline passed is treated as a refusal too: it did not verify anything
+against a live deadline.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Run the gate on the initial load
+
+**Files:**
+- Modify: `reconcile.go` (`loadValue`, around line 168)
+- Modify: `preapply_test.go`
+
+**Interfaces:**
+- Consumes: `runPreApply`, `PreApplyError` from Task 2.
+- Produces: nothing new.
+
+Decision D7: a hook that verifies a credential should verify the first one too. Discovering at startup that the configured credential does not work beats discovering it at the first rotation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `preapply_test.go`:
+
+```go
+func TestPreApplyRejectsInitialLoad(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pi://a"`
+	}
+	p := newWatchProvider("pi")
+	p.set("a", "bad", "v1")
+	boom := errors.New("initial credential does not work")
+
+	_, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error { return boom }),
+	)
+	if err == nil {
+		t.Fatal("Watch must fail when PreApply rejects the initial configuration")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want one wrapping the hook's error", err)
+	}
+	var pe *PreApplyError
+	if !errors.As(err, &pe) {
+		t.Errorf("err = %v, want a *PreApplyError", err)
+	}
+}
+
+func TestPreApplyRejectsLoad(t *testing.T) {
+	type cfg struct {
+		A string `source:"pl://a"`
+	}
+	p := newWatchProvider("pl")
+	p.set("a", "bad", "v1")
+
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error {
+			return errors.New("nope")
+		}),
+	)
+	if err == nil {
+		t.Fatal("Load must fail when PreApply rejects")
+	}
+	var pe *PreApplyError
+	if !errors.As(err, &pe) {
+		t.Errorf("err = %v, want a *PreApplyError", err)
+	}
+}
+
+func TestPreApplyInitialLoadReceivesZeroOld(t *testing.T) {
+	type cfg struct {
+		A string `source:"pz://a"`
+	}
+	p := newWatchProvider("pz")
+	p.set("a", "value", "v1")
+
+	var gotOld, gotNew string
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			gotOld, gotNew = ev.Old.A, ev.New.A
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if gotOld != "" {
+		t.Errorf("ev.Old.A = %q on the initial load, want the zero value", gotOld)
+	}
+	if gotNew != "value" {
+		t.Errorf("ev.New.A = %q, want value", gotNew)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test -race -run 'TestPreApplyRejectsInitial|TestPreApplyRejectsLoad|TestPreApplyInitialLoad' . -v`
+Expected: FAIL. `Watch` and `Load` currently succeed because nothing runs the hook on that path.
+
+- [ ] **Step 3: Run the gate in `loadValue`**
+
+In `reconcile.go`, in `loadValue`, after validation succeeds and before the successful return:
+
+```go
+	if err := o.validator.Validate(cfg); err != nil {
+		return cfg, nil, &ValidationError{Err: err}
+	}
+	// Gate the initial configuration too (decision D7): a hook that verifies a
+	// credential should verify the first one, so a credential that does not
+	// work fails at startup rather than at the first rotation. Old is the zero
+	// value of T, since nothing was serving yet, and Fields is nil for the
+	// same reason: every field is new, so there is no prior version to diff
+	// against and ev.Changed reports false for all of them.
+	if hook, ok := o.preApply.(func(context.Context, Change[T]) error); ok {
+		if err := runPreApply(ctx, hook, o.preApplyTimeout, Change[T]{New: cfg}); err != nil {
+			return cfg, nil, err
+		}
+	}
+	return cfg, res, nil
+```
+
+Note the type assertion is the comma-ok form and silently skips a hook typed for a different `T`, matching how `Watch` treats `onChange`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test -race -run 'TestPreApply' . -v`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: Run the full suite and commit**
+
+```bash
+go test -race ./...
+git add reconcile.go preapply_test.go
+git commit -m "feat: run the PreApply gate on the initial load
+
+Watch is already fail-fast on its initial Load, and a hook that verifies a
+credential should verify the first one: discovering at startup that the
+configured credential does not work beats discovering it at the first rotation.
+Load runs it too, since it accepts the same Option type and the check is just
+as useful for a one-shot resolve.
+
+On this path ev.Old is the zero value of T and ev.Fields is nil, because
+nothing was serving yet and every field is new, so ev.Changed reports false for
+all of them. Pinned by TestPreApplyInitialLoadReceivesZeroOld.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Documentation for `PreApply`, and publish PR 5
+
+**Files:**
+- Create: `site/src/pages/docs/usage/rotation.md`
+- Modify: `site/src/pages/docs/usage/index.md`, `site/src/pages/docs/usage/watching.md`, `site/src/pages/docs/usage/snapshots.md`, `README.md`, `doc.go`, `skills/mamori/SKILL.md`
+
+- [ ] **Step 1: Read a neighbouring page first**
+
+Run: `head -40 site/src/pages/docs/usage/watching.md`
+Copy its frontmatter shape, heading levels, and code-fence style exactly.
+
+- [ ] **Step 2: Create `site/src/pages/docs/usage/rotation.md`**
+
+Cover, with runnable Go:
+- The problem: `OnChange` is a notification, not a gate, and by the time it fires `Get()` already returns the new value.
+- `PreApply` with the `ev.Changed` guard, since verifying on every unrelated field change is the mistake people will make.
+- What a rejection does: `Get()` unchanged, `OnChange` silent, `*PreApplyError` to `OnError`, and the next change producing a fresh candidate.
+- The timeout, that it defaults to 10s, and **that exceeding it is a rejection**.
+- The reentrancy hazard: `Get` is safe inside a hook, `Refresh`/`Pin`/`Unpin` deadlock.
+- That it runs on the initial load and a rejection fails `Watch`.
+- **The credential-overlap pattern** from spec section 7, with the memory caveat stated as plainly as the benefit: retained snapshots hold rotated secrets for as long as they are retained, which is why `WithHistory` defaults to 0.
+- A placeholder section for `Refresh`, one honest sentence saying it is not yet released. No mechanics, no `TODO` marker.
+
+- [ ] **Step 3: Update the rest**
+
+- `usage/index.md`: `PreApply` in the option walkthrough.
+- `usage/watching.md`: where the gate sits in the reconcile cycle.
+- `usage/snapshots.md`: cross-link the overlap pattern from `WithHistory`.
+- `README.md`: a rotation-safety bullet, and `PreApply` in the `Watch` example.
+- `doc.go`: the reconcile cycle now has a gate.
+- `skills/mamori/SKILL.md`: `PreApply`, the timeout, and the reentrancy hazard.
+
+- [ ] **Step 4: Verify the site builds**
+
+```bash
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22
+cd site && npm run build && npm run linkcheck && cd ..
+```
+Expected: build succeeds, no broken links.
+
+- [ ] **Step 5: Commit and publish**
+
+```bash
+git add -A
+git commit -m "docs: rotation safety and the PreApply gate
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+gh stack submit --auto --open
+gh stack view
+```
+
+Confirm the new PR's base is `xavier/ref-grammar-interpolation`, not `main`.
+
+---
+
+## Task 6: `Refresh`
+
+**Files:**
+- Create: `refresh.go`
+- Create: `refresh_test.go`
+- Modify: `pin.go` (the `pinKind` constants)
+- Modify: `reconciler.go` (`handlePin`)
+
+**Interfaces:**
+- Consumes: `pinCmd`, `pinReply`, `sendPin`, `errWatcherClosed` (`pin.go:61`, `errors.go:27`); `engine.resolveAll` behavior via the existing seed path.
+- Produces: `func (w *Watcher[T]) Refresh(ctx context.Context) error`.
+
+**Reuse the existing control channel.** `pin.go` already carries commands to the reconciler goroutine and answers on a reply channel, falling back to `errWatcherClosed` when the watcher is gone. `Refresh` is another command on that same channel. Do not build a second control plane, and do not add a new sentinel.
+
+- [ ] **Step 1: Add the branch to `gh stack`**
+
+```bash
+gh stack add xavier/rotation-refresh
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `refresh_test.go`:
+
+```go
+package mamori
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+// TestRefreshAppliesChangeBetweenPolls sets the poll interval to an hour, so a
+// pass cannot come from a tick: only Refresh can produce the new value.
+func TestRefreshAppliesChangeBetweenPolls(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rf://a"`
+	}
+	p := newWatchProvider("rf")
+	p.set("a", "first", "v1")
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithPollInterval(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.set("a", "second", "v2") // silent: no push, so nothing is watching it
+
+	if err := w.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := w.Get().A; got != "second" {
+		t.Errorf("Get().A = %q, want second (Refresh must force a re-resolve)", got)
+	}
+}
+
+func TestRefreshReturnsRejectionReason(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rr://a"`
+	}
+	p := newWatchProvider("rr")
+	p.set("a", "first", "v1")
+	boom := errors.New("rejected by the gate")
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithPollInterval(time.Hour),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "second" {
+				return boom
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.set("a", "second", "v2")
+
+	err = w.Refresh(context.Background())
+	if err == nil {
+		t.Fatal("Refresh must return the rejection reason")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want one wrapping the hook's error", err)
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first", got)
+	}
+}
+
+func TestRefreshAfterCloseReturnsClosed(t *testing.T) {
+	type cfg struct {
+		A string `source:"rc://a"`
+	}
+	p := newWatchProvider("rc")
+	p.set("a", "only", "v1")
+
+	w, err := Watch[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	_ = w.Close()
+
+	if err := w.Refresh(context.Background()); !errors.Is(err, errWatcherClosed) {
+		t.Errorf("err = %v, want errWatcherClosed", err)
+	}
+}
+
+func TestRefreshHonorsCallerContext(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rx://a"`
+	}
+	p := newWatchProvider("rx")
+	p.set("a", "only", "v1")
+
+	w, err := Watch[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := w.Refresh(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestRefreshIsConcurrencySafe(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rk://a"`
+	}
+	p := newWatchProvider("rk")
+	p.set("a", "only", "v1")
+
+	w, err := Watch[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() { defer close(done); _ = w.Refresh(context.Background()) }()
+	}
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent Refresh calls did not complete")
+	}
+}
+```
+
+Note `TestRefreshIsConcurrencySafe` closes `done` from eight goroutines, which panics. Fix it while writing: use a `sync.WaitGroup` and close `done` once after `wg.Wait()` in a separate goroutine. This is deliberately left as a real bug for you to catch and correct rather than copy blindly; say in your report that you did.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `go test -race -run 'TestRefresh' . -v`
+Expected: FAIL, compilation error: `w.Refresh undefined`.
+
+- [ ] **Step 4: Add the `refresh` command kind**
+
+In `pin.go`, extend `pinKind`:
+
+```go
+const (
+	pinAt      pinKind = iota // Pin(version): freeze at a specific retained snapshot
+	pinCurrent                // PinCurrent(): freeze at whatever Get returns right now
+	unpin                     // Unpin(): resume, applying the newest snapshot
+	refresh                   // Refresh(): re-resolve every field now and apply the result
+)
+```
+
+- [ ] **Step 5: Write `refresh.go`**
+
+```go
+package mamori
+
+import "context"
+
+// Refresh forces an immediate re-resolve of every field, bypassing poll
+// intervals and per-ref backoff, and blocks until the resulting snapshot has
+// been applied or rejected.
+//
+// It returns nil when a snapshot was applied and when nothing changed, and the
+// rejection reason when the candidate failed validation or a PreApply gate. A
+// SIGHUP handler therefore learns whether the reload actually worked, which is
+// the whole reason this blocks rather than queueing.
+//
+// It does NOT bypass PreApply. A forced refresh is still gated; that is the
+// point of having a gate.
+//
+// Refresh is delivered to the reconciler goroutine over the same control
+// channel Pin, PinCurrent, and Unpin use, so it serializes with normal
+// reconciliation rather than racing it, and it answers errWatcherClosed after
+// Close for the same reason they do (see sendPin in pin.go). Do not call it
+// from inside a PreApply hook: that hook runs on the goroutine which would
+// have to service this command, so it deadlocks until the hook's timeout fires.
+//
+// For a field resolved through a mamori:// ref, Refresh re-reads the config
+// server's current value. It does not make the server re-resolve its own
+// upstream: the server exists so that N consumers cost one upstream watch
+// rather than N, and letting any client force an upstream fetch would invert
+// exactly that property.
+func (w *Watcher[T]) Refresh(ctx context.Context) error {
+	cmd := pinCmd{kind: refresh, reply: make(chan pinReply, 1)}
+	select {
+	case w.control <- cmd:
+	case <-w.ctx.Done():
+		return errWatcherClosed
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case rep := <-cmd.reply:
+		return rep.err
+	case <-w.ctx.Done():
+		return errWatcherClosed
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+```
+
+- [ ] **Step 6: Handle it in the reconciler**
+
+In `reconciler.go`'s `handlePin`, add a `refresh` case that re-resolves every spec and flushes, replying with the flush's outcome.
+
+Read `handlePin`'s existing cases and `engine.start`'s seeding code first, and reuse whichever resolve helper they already use rather than writing a third path. The command must reply exactly once on every branch, including the error branches, or `Refresh` blocks until the watcher closes.
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `go test -race -run 'TestRefresh' . -v`
+Expected: PASS, all tests.
+
+- [ ] **Step 8: Run the full suite and commit**
+
+```bash
+go test -race ./...
+git add refresh.go refresh_test.go pin.go reconciler.go
+git commit -m "feat: Refresh forces an immediate re-resolve
+
+Refresh re-resolves every field now, bypassing poll intervals and per-ref
+backoff, and blocks until the result is applied or rejected so a SIGHUP handler
+learns whether the reload worked.
+
+It is another command on the control channel pin.go already owns, so it
+serializes with normal reconciliation rather than racing it and answers
+errWatcherClosed after Close exactly as Pin does. No second control plane and
+no new sentinel.
+
+It does not bypass PreApply, and for a mamori:// field it re-reads the config
+server rather than making the server re-resolve upstream (decision D8).
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Documentation for `Refresh`, and publish PR 6
+
+**Files:**
+- Modify: `site/src/pages/docs/usage/rotation.md`, `site/src/pages/docs/observability/admin.md`, `site/src/pages/docs/server/index.md`, `README.md`, `doc.go`, `skills/mamori/SKILL.md`
+
+- [ ] **Step 1: Replace the `Refresh` placeholder in `rotation.md`**
+
+Real content: what it does, that it blocks and why, that it returns the rejection reason, the SIGHUP example, that it does not bypass `PreApply`, and the reentrancy hazard.
+
+- [ ] **Step 2: Record the two boundaries**
+
+- `observability/admin.md`: why there is no `POST /refresh` (D5) and how to mount your own handler calling `w.Refresh` with your own authorization.
+- `server/index.md`: what `Refresh` means for a `mamori://` consumer (D8) — it re-reads the server, it does not force the server upstream, and why that boundary exists. State the amplification reasoning: N clients across M bindings would become N×M on-demand calls against rate-limited, per-call-billed backends, triggerable by anyone merely authorized to read.
+
+- [ ] **Step 3: Update the rest**
+
+`README.md`, `doc.go`, and `skills/mamori/SKILL.md` gain `Refresh`.
+
+- [ ] **Step 4: Verify the site builds**
+
+```bash
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22
+cd site && npm run build && npm run linkcheck && cd ..
+```
+
+- [ ] **Step 5: Commit and publish**
+
+```bash
+git add -A
+git commit -m "docs: Refresh, and the two boundaries it does not cross
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+gh stack submit --auto --open
+gh stack view
+```
+
+Confirm the new PR's base is `xavier/rotation-preapply`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| 5.1 API | 2 |
+| 5.2 semantics (order, `ev.Changed`, ctx, rejection effects) | 3 |
+| 5.2 initial load (D7) | 4 |
+| 5.2 runs while pinned | 3 (`flush` gates before the pinned branch, so it holds by construction; the test is in Task 3's list) |
+| 5.3 reentrancy hazard | 2 (doc comment), 6 (`Refresh` doc comment) |
+| 6 `Refresh` | 6 |
+| 7 overlap pattern | 5 (documentation only, no code, as specified) |
+| 8 testing | 3, 4, 6 |
+| 9 documentation | 5, 7 |
+| 10 delivery | branch and submit steps in 5, 6, 7 |
+| D1-D4 | 2, 3 |
+| D5 | 7 (documented; no code by definition) |
+| D6 | 6 |
+| D7 | 4 |
+| D8 | 6 (doc comment), 7 (docs site) |
+
+Every spec section maps to a task. D5 and section 7 are documentation-only by design, which is stated rather than left as a gap.
+
+**Placeholder scan:** No TBD or TODO. Two deliberate exceptions, both explicit: the `Refresh` placeholder section created in Task 5 Step 2 (required to be a real heading plus one sentence, filled in by Task 7) and the seeded bug in Task 6 Step 2's concurrency test, which is called out in the step itself and required to be reported.
+
+**Type consistency:** `runPreApply(context.Context, func(context.Context, Change[T]) error, time.Duration, Change[T]) error` is defined in Task 2 and called with that signature in Tasks 3 and 4. `PreApplyError` is defined in Task 2 and asserted in Tasks 3, 4, and 6. `options.preApply`/`preApplyTimeout` are added in Task 2 and read in Tasks 3 and 4. `engine[T].preApply` is added in Task 3 and used only there. `pinCmd`/`pinReply`/`errWatcherClosed` are pre-existing and used unchanged in Task 6; `pinKind` gains exactly one constant.
+
+**One deliberate under-specification:** Task 6 Step 6 does not give the `handlePin` refresh case verbatim, because the right implementation depends on which resolve helper `engine.start` and `handlePin` already share, and inventing a third path would be worse than reading the two that exist. The step says so and states the invariant that matters: reply exactly once on every branch.

--- a/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
+++ b/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
@@ -1,0 +1,254 @@
+# mamori rotation safety: pre-apply verification and forced refresh
+
+**Date:** 2026-07-28
+**Status:** draft, not yet implemented
+**Scope:** core module (`reconcile.go`, `reconciler.go`, `doc.go`), README and docs site
+
+---
+
+## 1. Context
+
+mamori's pitch is that configuration and secrets stay reconciled at runtime: a
+value rotates upstream, mamori re-resolves, re-validates, and atomically swaps in
+the new snapshot without a restart.
+
+The gap is what "validates" means. Today it means the struct passes its
+`validate` tags. A rotated database password that is syntactically a perfectly
+good string, and functionally wrong, sails through: `Load` succeeds, the swap
+happens, `OnChange` fires *after* the fact, and the application discovers the
+problem in its request path.
+
+That is the single most common way credential rotation actually fails in
+production, and mamori currently has no answer to it. `OnChange` is a
+notification, not a gate; by the time it runs, `Get()` already returns the new
+value.
+
+A second, smaller gap: there is no way to make mamori re-resolve *now*.
+`Watcher` exposes `Get`, `Status`, `Health`, `History`, `Pin`, `PinCurrent`,
+`Pinned`, `Unpin`, `AdminAddr`, and `Close`. An operator who knows a secret just
+rotated, or who wants a SIGHUP to mean something, has to wait out the poll
+interval.
+
+## 2. Goals
+
+1. Let an application **prove a new configuration works before it becomes
+   current**, using the engine's existing reject-and-keep-last-good machinery
+   rather than new state.
+2. Let an operator force an immediate re-resolve.
+3. Document the credential-overlap pattern that already works, so nobody builds
+   machinery for it.
+
+## 3. Non-goals
+
+- **No dual-credential machinery.** No `secret.Pair`, no `?stage=` ref option.
+  `WithHistory(1)` plus `w.History()` already retains the previous validated
+  snapshot, which is what a service validating incoming credentials during a
+  rotation overlap needs. The real gap there is documentation, not code. See
+  section 7.
+- **No retry or backoff policy for a rejected candidate.** A rejection leaves the
+  field's existing per-ref backoff and watch behavior untouched, so the next
+  upstream change or poll produces a fresh candidate. Adding retry state to the
+  reconciler is a separate design with its own timing questions.
+- **No mutating route on the admin endpoint.** See D5.
+- **No refresh verb in the config server's wire protocol**, and no upstream
+  propagation from a client's `Refresh`. See D8. Client-to-server re-fetch
+  already works and needs no change; client-to-upstream is deliberately
+  refused.
+- **`PreApply` is not a second validator.** Struct validation stays where it is.
+  `PreApply` exists for checks that need I/O, which is precisely why it needs a
+  timeout and the `Validator` does not.
+
+## 4. Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | `PreApply` **rejects a candidate snapshot** by returning an error, exactly as a validation failure does | The engine already has one well-tested outcome for "this candidate is not acceptable": reject it, keep serving the last good config, deliver the reason to `OnError`. Reusing that path means no new state, no new `Get()` semantics, and no new failure mode. An observe-only hook would not solve the problem, since a bad credential still goes live. |
+| D2 | It runs **inline on the reconciler goroutine**, not on the `OnChange` dispatch queue | It must complete before the swap, and the dispatch queue is asynchronous and lossy by design (`WithQueueDepth` drops the oldest event when full). A gate cannot be delivered on a channel that is allowed to drop. |
+| D3 | It is therefore given a **mandatory bounded timeout**, `WithPreApplyTimeout`, defaulting to 10s | D2's consequence: user code doing network I/O now runs on the goroutine that also services every other field's updates, `Status` publication, and pin/unpin. An unbounded hook would wedge the whole reconciler. The timeout is not optional and cannot be disabled; a caller wanting longer sets it explicitly. |
+| D4 | **A timeout is a rejection**, not an acceptance | On timeout mamori does not know whether the new configuration works. Applying it anyway would defeat the feature. Rejecting keeps the last good config, which is the safe direction, and `OnError` receives a distinguishable `*PreApplyError` wrapping `context.DeadlineExceeded`. A hook that always times out therefore wedges *updates* (loudly, once per attempt) rather than serving unverified config: that is the correct trade and is documented. |
+| D5 | **No `POST /refresh` on the admin endpoint** | `Handler`'s doc comment states it serves exactly `GET /` and `GET /healthz`, that every other path and method is 404, and that there is no route which serves or changes configuration. That read-only property is a security feature of a surface which reports on secret material. A caller who wants a refresh endpoint can mount one on their own mux calling `w.Refresh`, with their own authorization. |
+| D6 | `Refresh` **blocks until the resulting candidate has been applied or rejected**, and returns the rejection reason | A `Refresh` that returned as soon as the request was queued would be untestable and useless in a SIGHUP handler, which wants to know whether the reload worked. |
+| D7 | `PreApply` runs on the **initial load** too, and a rejection fails `Watch` | `Watch` is already fail-fast on its initial `Load`. A hook that verifies a credential should verify the first one as well; discovering at startup that the configured credential does not work is strictly better than discovering it on the first rotation. |
+| D8 | A client's `Refresh` **re-fetches from the config server but does not propagate upstream**, and the wire protocol gains no refresh verb | Re-fetching already works with no change: `providers/mamori`'s `Resolve` does a fresh `GET` per call with no client-side cache, so `Refresh` on a `mamori://` field re-reads the server's current value. That is useful after a dropped stream and is safe, being just another read. Propagating upstream is the part to refuse. The server's entire value proposition is that N consumers cost one upstream watch rather than N; a client-triggered upstream refresh inverts it, turning N clients across M bindings into N*M on-demand calls against rate-limited, per-call-billed backends, triggerable by anyone merely authorized to read. It is also largely unnecessary, since the server already watches upstream continuously and its cache is as fresh as that watch. An operator-facing, `Policy`-gated server refresh is a defensible feature; it is a different feature, and belongs in its own spec. |
+
+## 5. Feature 1: `PreApply`
+
+### 5.1 API
+
+```go
+// PreApply installs a gate that runs before a reconciled snapshot becomes
+// current. Returning a non-nil error rejects the candidate: Get keeps returning
+// the last valid configuration, OnChange does not fire, and OnError receives a
+// *PreApplyError describing the rejection.
+//
+// It exists for checks that struct validation cannot express because they need
+// I/O: that a rotated database password actually opens a connection, that a new
+// API token is accepted by its issuer, that a reissued certificate chains to a
+// trusted root. Validation answers "is this well-formed"; PreApply answers "does
+// this actually work".
+func PreApply[T any](fn func(ctx context.Context, ev Change[T]) error) Option
+
+// WithPreApplyTimeout bounds how long a PreApply hook may take. Default 10s.
+func WithPreApplyTimeout(d time.Duration) Option
+```
+
+Typed to `T` the same way `OnChange` is: stored in `options` as `any` and type-asserted by `Watch[T]`.
+
+```go
+w, err := mamori.Watch[Config](ctx,
+    mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+        if !ev.Changed("DBPassword") {
+            return nil
+        }
+        return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+    }),
+    mamori.OnError(func(err error) { metrics.Inc("config_rejected") }),
+)
+```
+
+### 5.2 Semantics
+
+- Runs **after** struct validation and **before** the atomic swap. Validation is
+  cheap and pure; there is no reason to spend a network round trip proving a
+  snapshot works when its shape is already wrong.
+- `ev.Old` is the currently-serving snapshot; `ev.New` is the candidate.
+  `ev.Changed(path)` works exactly as in `OnChange`, which is what makes the
+  common "only verify when the credential actually rotated" guard a one-liner.
+- The `ctx` is derived from the watcher's context and carries the
+  `WithPreApplyTimeout` deadline. It is cancelled on `Close`, so a hook blocked
+  on a hanging backend cannot delay shutdown past the timeout.
+- A rejection delivers `*PreApplyError{Err: ...}` to `OnError` and leaves
+  `Get()`, `Status()`, and history untouched. The candidate is discarded; the
+  engine's per-ref state is not rewound, so the next change or poll produces a
+  fresh candidate normally.
+- On the initial load inside `Watch`, a rejection makes `Watch` return the
+  `*PreApplyError` and no watcher (D7). `Load` runs it too, with the same result.
+- **While pinned**, `PreApply` still runs. `Pin` freezes what `Get` returns; it
+  does not stop the engine from advancing `Live`. Skipping verification while
+  pinned would mean `Unpin` applies a snapshot nothing ever gated.
+
+### 5.3 The reentrancy hazard, stated plainly
+
+`PreApply` runs on the reconciler goroutine. A hook that calls back into the
+same `Watcher` will deadlock. `w.Get()` is lock-free and safe, but `w.Refresh`,
+`w.Pin`, and `w.Unpin` are not, since they are serviced by the very goroutine
+the hook is occupying.
+
+This gets a prominent doc comment and a test asserting the timeout fires rather
+than hanging forever, so the failure is bounded and diagnosable rather than a
+silent wedge.
+
+## 6. Feature 2: `Refresh`
+
+```go
+// Refresh forces an immediate re-resolve of every field, bypassing poll
+// intervals and per-ref backoff, and blocks until the resulting snapshot has
+// been applied or rejected.
+//
+// It returns nil when a snapshot was applied or when nothing changed, and the
+// rejection reason when the candidate failed validation or PreApply. Use it
+// from a SIGHUP handler, or after an out-of-band signal that a secret rotated.
+func (w *Watcher[T]) Refresh(ctx context.Context) error
+```
+
+**Reuse the existing control-channel machinery; do not invent a second one.**
+`pin.go` already has exactly this shape: `sendPin` (`pin.go:61`) puts a command
+on `w.control`, waits on a reply channel, and falls back to `errWatcherClosed`
+(`errors.go:27`) when `w.ctx` is done first. `Refresh` is another command on
+that same channel with the same closed-path behavior. This spec adds no new
+sentinel and no second control plane.
+
+- Serializes with normal reconciliation rather than racing it, by construction,
+  since the reconciler `loop` services `w.control` and `updates` in the same
+  select.
+- Concurrent calls are safe. Each returns the outcome of the resolve it
+  triggered.
+- Honors the passed `ctx`: a cancelled context aborts the wait and returns
+  `ctx.Err()`. The re-resolve itself is still bounded by the watcher's lifetime.
+- Returns `errWatcherClosed` after `Close`, identically to `Pin` and `Unpin`.
+  Note that sentinel is unexported today, so a caller cannot `errors.Is` it.
+  That is a pre-existing wart shared with `Pin`; exporting it is a reasonable
+  follow-up but is deliberately out of scope here, since doing it as a
+  side effect of this feature would change `Pin`'s public contract too.
+- Does **not** bypass `PreApply`. A forced refresh is still gated, which is the
+  point.
+
+## 7. Feature 3: document the credential-overlap pattern
+
+No code. `WithHistory(1)` already retains the previous validated snapshot, and
+`w.History()` returns snapshots newest-first including the current one. That is
+what a service validating *incoming* credentials during a rotation overlap
+needs:
+
+```go
+w, _ := mamori.Watch[Config](ctx, mamori.WithHistory(1))
+
+func accept(presented string) bool {
+    for _, s := range w.History() { // current, then previous
+        if subtle.ConstantTimeCompare(
+            []byte(presented), []byte(s.Config.APIKey.Reveal())) == 1 {
+            return true
+        }
+    }
+    return false
+}
+```
+
+The documentation must state the cost as plainly as the benefit: retained
+snapshots hold rotated secrets in memory for as long as they are retained, which
+is exactly why `WithHistory` defaults to 0. `WithHistory(1)` is the right
+setting for this pattern; a larger window widens the overlap and the exposure
+together.
+
+This goes in a new "Credential rotation" section of the docs site, cross-linked
+from `usage/snapshots.md` and the `WithHistory` godoc.
+
+## 8. Testing
+
+- `PreApply` rejects: candidate discarded, `Get()` unchanged, `OnChange` did not
+  fire, `OnError` received a `*PreApplyError`.
+- `PreApply` accepts: swap happens, `OnChange` fires once.
+- `PreApply` is not called when no field changed.
+- Rejection on the initial load fails `Watch` and leaves no watcher running
+  (asserted with `goleak`).
+- Timeout fires: a hook that blocks forever produces a `*PreApplyError` wrapping
+  `context.DeadlineExceeded` within the configured budget, driven by `FakeClock`
+  and its `BlockUntil` handshake so the test is deterministic.
+- A hook calling `w.Refresh` from inside itself times out rather than hanging
+  forever, pinning the section 5.3 hazard.
+- `PreApply` still runs while pinned, and `Unpin` applies only gated snapshots.
+- `Refresh` applies a change written between polls, with the poll interval set
+  to an hour so a pass cannot come from a tick.
+- `Refresh` returns the rejection reason when the candidate fails `PreApply`.
+- `Refresh` after `Close` returns `errWatcherClosed`; concurrent `Refresh` calls are
+  race-clean.
+- Race detector on, `goleak` unchanged.
+
+## 9. Documentation
+
+| File | Change |
+|---|---|
+| `site/src/pages/docs/usage/rotation.md` | **New page.** The problem, `PreApply` with a worked example, `Refresh`, and the history-based overlap pattern with its memory caveat. |
+| `site/src/pages/docs/usage/index.md` | `PreApply` in the option walkthrough. |
+| `site/src/pages/docs/usage/watching.md` | Where the gate sits in the reconcile cycle. |
+| `site/src/pages/docs/usage/snapshots.md` | Cross-link the overlap pattern from `WithHistory`. |
+| `site/src/pages/docs/observability/admin.md` | Why there is no `POST /refresh`, and how to mount your own (D5). |
+| `site/src/pages/docs/server/index.md` | What `Refresh` means for a `mamori://` consumer: it re-reads the server, it does not force the server upstream, and why that boundary exists (D8). |
+| `README.md` | A rotation-safety bullet; `PreApply` in the `Watch` example. |
+| `doc.go` | The reconcile cycle now has a gate; say so. |
+| `skills/mamori/SKILL.md` | `PreApply`, `Refresh`, and the overlap pattern. |
+
+## 10. Delivery
+
+Stacked on top of the ref-grammar stack rather than branched from `main`:
+`PreApply` lands in `reconciler.go`, which that stack modified in four places,
+so an independent branch would conflict by construction.
+
+```
+xavier/ref-grammar-interpolation   (#60)
+ └─ xavier/rotation-preapply       feat: PreApply gate
+     └─ xavier/rotation-refresh    feat: Refresh + rotation docs
+```
+
+Two PRs. `PreApply` and `Refresh` are independent of each other, and `PreApply`
+is the larger and riskier of the two, so it goes first and alone.

--- a/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
+++ b/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
@@ -50,10 +50,10 @@ interval.
   upstream change or poll produces a fresh candidate. Adding retry state to the
   reconciler is a separate design with its own timing questions.
 - **No mutating route on the admin endpoint.** See D5.
-- **No refresh verb in the config server's wire protocol**, and no upstream
-  propagation from a client's `Refresh`. See D8. Client-to-server re-fetch
-  already works and needs no change; client-to-upstream is deliberately
-  refused.
+- **No refresh verb in the config server's wire protocol in THIS spec.** See D8.
+  Client-to-server re-fetch already works and needs no change. Client-to-upstream
+  propagation is wanted and is coming, `Policy`-gated, in its own spec; it is
+  out of scope here, not refused.
 - **`PreApply` is not a second validator.** Struct validation stays where it is.
   `PreApply` exists for checks that need I/O, which is precisely why it needs a
   timeout and the `Validator` does not.
@@ -69,7 +69,7 @@ interval.
 | D5 | **No `POST /refresh` on the admin endpoint** | `Handler`'s doc comment states it serves exactly `GET /` and `GET /healthz`, that every other path and method is 404, and that there is no route which serves or changes configuration. That read-only property is a security feature of a surface which reports on secret material. A caller who wants a refresh endpoint can mount one on their own mux calling `w.Refresh`, with their own authorization. |
 | D6 | `Refresh` **blocks until the resulting candidate has been applied or rejected**, and returns the rejection reason | A `Refresh` that returned as soon as the request was queued would be untestable and useless in a SIGHUP handler, which wants to know whether the reload worked. |
 | D7 | `PreApply` runs on the **initial load** too, and a rejection fails `Watch` | `Watch` is already fail-fast on its initial `Load`. A hook that verifies a credential should verify the first one as well; discovering at startup that the configured credential does not work is strictly better than discovering it on the first rotation. |
-| D8 | A client's `Refresh` **re-fetches from the config server but does not propagate upstream**, and the wire protocol gains no refresh verb | Re-fetching already works with no change: `providers/mamori`'s `Resolve` does a fresh `GET` per call with no client-side cache, so `Refresh` on a `mamori://` field re-reads the server's current value. That is useful after a dropped stream and is safe, being just another read. Propagating upstream is the part to refuse. The server's entire value proposition is that N consumers cost one upstream watch rather than N; a client-triggered upstream refresh inverts it, turning N clients across M bindings into N*M on-demand calls against rate-limited, per-call-billed backends, triggerable by anyone merely authorized to read. It is also largely unnecessary, since the server already watches upstream continuously and its cache is as fresh as that watch. An operator-facing, `Policy`-gated server refresh is a defensible feature; it is a different feature, and belongs in its own spec. |
+| D8 | A client's `Refresh` **re-fetches from the config server. Upstream propagation is a real feature, deliberately deferred to its own spec, NOT refused.** This spec's scope ends at the client. | Re-fetching already works with no change: `providers/mamori`'s `Resolve` does a fresh `GET` per call with no client-side cache, so `Refresh` on a `mamori://` field re-reads the server's current value. That is useful after a dropped stream and is safe, being just another read. Propagating upstream is genuinely wanted (owner's call, 2026-07-28) but must be **`Policy`-gated rather than available to every reader**: the server exists so that N consumers cost one upstream watch rather than N, and an ungated client-triggered refresh inverts that, turning N clients across M bindings into N*M on-demand calls against rate-limited, per-call-billed backends. Authorization, not refusal, is the answer. It touches the wire protocol, the `Policy` surface, and the client, so it is its own spec and follows this one. |
 
 ## 5. Feature 1: `PreApply`
 

--- a/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
+++ b/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
@@ -133,12 +133,46 @@ w, err := mamori.Watch[Config](ctx,
 same `Watcher` will deadlock. `w.Get()` is lock-free and safe; the others are
 not, and they do not all fail the same way.
 
-`Pin`, `PinCurrent`, and `Unpin` take **no context**. `sendPin` (`pin.go:61`)
+`Pin`, `PinCurrent`, and `Unpin` take **no context**. `sendPin` (`pin.go`)
 selects only on the control channel and on the watcher's own `ctx`, so with the
 reconciler goroutine sitting inside the hook, the send blocks and nothing
 releases it short of `Close`. The hook's timeout does **not** rescue this: the
 hook is blocked inside `sendPin`, which never looks at the context the hook was
 given. The result is a permanently wedged watcher, not a bounded stall.
+
+**This is now detected** (added after task 5, by agreement with the repository
+owner; it is not in the original task list above). `sendPin` refuses the command
+rather than attempting the send, so the wedge above is no longer reachable
+through the pin commands:
+
+- The engine records the ID of the goroutine running the hook in
+  `Watcher.inPreApply` for the hook's duration, armed and cleared by
+  `runPreApply` (the clear is deferred, so a panicking hook cannot leave it set).
+  It is zero at all other times, and for a watcher with no hook installed it is
+  never written at all.
+- `sendPin` compares that mark against its own caller's goroutine ID and returns
+  the exported sentinel `ErrReentrantCall` on a match.
+- `Pin` returns the sentinel. `PinCurrent` returns version `0`, which no real
+  version ever is (versions start at 1 - the same disambiguation `Pinned` uses),
+  because its signature carries no error. `Unpin` does nothing and leaves the
+  pin in place, observable through `Pinned`; it keeps its `func()` signature
+  because widening it is an incompatible change to a released API, and the
+  identical mistake made through `Pin` is already reported in full.
+
+The mark is a goroutine **identity**, not a boolean, on purpose. A boolean would
+answer "is a hook running anywhere", and refusing on that would reject a `Pin`
+from an unrelated caller goroutine that merely overlapped a rotation - once per
+rotation, for a window as wide as the hook's whole budget, with an error telling
+that caller to do what it was already doing. Go does not expose goroutine
+identity, so it is read out of the header line of `runtime.Stack(buf, false)`,
+which does not stop the world and is reached at most twice per hook invocation.
+Every parse failure returns 0, which disables detection and restores the
+previous behavior; it can never manufacture a false match.
+
+Not addressed, because it is out of reach of this mechanism: watcher A's hook
+calling into watcher B while B's hook calls into A. That is a cross-watcher
+deadlock, not reentrancy, it is unchanged by this work, and detecting it needs a
+lock-order graph rather than a mark.
 
 `Refresh(ctx)` is different, because it takes a caller context and selects on it
 (section 6), so a hook calling it fails on that context's deadline rather than

--- a/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
+++ b/docs/superpowers/specs/2026-07-28-rotation-safety-design.md
@@ -130,13 +130,23 @@ w, err := mamori.Watch[Config](ctx,
 ### 5.3 The reentrancy hazard, stated plainly
 
 `PreApply` runs on the reconciler goroutine. A hook that calls back into the
-same `Watcher` will deadlock. `w.Get()` is lock-free and safe, but `w.Refresh`,
-`w.Pin`, and `w.Unpin` are not, since they are serviced by the very goroutine
-the hook is occupying.
+same `Watcher` will deadlock. `w.Get()` is lock-free and safe; the others are
+not, and they do not all fail the same way.
 
-This gets a prominent doc comment and a test asserting the timeout fires rather
-than hanging forever, so the failure is bounded and diagnosable rather than a
-silent wedge.
+`Pin`, `PinCurrent`, and `Unpin` take **no context**. `sendPin` (`pin.go:61`)
+selects only on the control channel and on the watcher's own `ctx`, so with the
+reconciler goroutine sitting inside the hook, the send blocks and nothing
+releases it short of `Close`. The hook's timeout does **not** rescue this: the
+hook is blocked inside `sendPin`, which never looks at the context the hook was
+given. The result is a permanently wedged watcher, not a bounded stall.
+
+`Refresh(ctx)` is different, because it takes a caller context and selects on it
+(section 6), so a hook calling it fails on that context's deadline rather than
+hanging.
+
+An earlier draft of this spec claimed all four "deadlock until the timeout
+fires". That was verified false during implementation and is corrected here;
+the doc comment on `PreApply` states the real, more severe behavior.
 
 ## 6. Feature 2: `Refresh`
 

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,32 @@ var ErrNoSuchSnapshot = errors.New("mamori: no such snapshot version")
 // unambiguous from the fact that Close was called.
 var errWatcherClosed = errors.New("mamori: watcher closed")
 
+// ErrReentrantCall reports a pin command issued from inside a PreApply hook.
+//
+// The hook runs ON the reconciler goroutine; Pin, PinCurrent and Unpin are
+// commands SERVICED by that same goroutine. Calling one from inside a hook asks
+// the goroutine to answer a message it cannot reach until the hook it is
+// running returns, and the call takes no context to escape on: before this was
+// detected, it blocked until Close, with no reconciliation, no OnChange and no
+// OnError in the meantime. This sentinel converts that permanent, silent wedge
+// into an immediate, diagnosable refusal that leaves pin state untouched.
+//
+// Unlike errWatcherClosed it is exported, because the two errors sit at
+// opposite ends of what a caller can do about them: a closed watcher is an
+// expected lifecycle race with Close and needs no test, while this one is a
+// programming mistake in the caller's own hook, and a test that wants to prove
+// the mistake is caught (or a wrapper that wants to translate it) needs
+// errors.Is to reach it.
+//
+// Pin returns it directly. PinCurrent returns version 0 and Unpin does nothing;
+// see their doc comments for why, and for what each leaves observable instead.
+//
+// Any future command serviced by the reconciler goroutine belongs here too. If
+// Refresh lands, route it through sendPin's guard and name it in this message:
+// a sentinel that lists three of the four commands it covers is worse than one
+// that lists none.
+var ErrReentrantCall = errors.New("mamori: Pin, PinCurrent and Unpin cannot be called from inside a PreApply hook, which occupies the reconciler goroutine that services them; Get is safe inside a hook, but these must be called from another goroutine")
+
 // Kind is a coarse, provider-independent classification of a resolve failure.
 // It exists so diagnostics can distinguish conditions that need human action
 // (a missing secret, a denied permission) from transient ones (an unreachable

--- a/pin.go
+++ b/pin.go
@@ -58,7 +58,29 @@ type pinReply struct {
 // not just the Close one, and returns errWatcherClosed: from the caller's
 // perspective, "the reconciler is gone" reads the same regardless of which
 // path caused it.
+//
+// There is one way to block on control forever that ctx.Done cannot rescue, and
+// the guard below is it: a PreApply hook calling back into its own Watcher. The
+// hook runs ON the reconciler goroutine (see preapply.go), so while it runs
+// there is no receiver for control at all, and the caller waiting for one IS
+// the goroutine that would have to become that receiver. Nothing short of Close
+// ever resolves it, and until then the watcher does not reconcile, does not
+// deliver OnChange and does not report an error - a silent, permanent wedge. So
+// this refuses the command instead, and w.inPreApply is what makes the refusal
+// precise: it holds the ID of the goroutine currently inside a hook, so only a
+// caller that is genuinely waiting on itself is turned away. A pin command from
+// any other goroutine, including one issued while a hook happens to be running,
+// still queues on control and is serviced when the reconciler comes back to its
+// select, exactly as it always was.
+//
+// The check is one atomic load on the path that matters: inPreApply is zero
+// whenever no hook is running, which for a watcher with no PreApply gate is
+// always, and the goroutine-ID lookup is reached only when a pin command truly
+// overlaps a hook.
 func (w *Watcher[T]) sendPin(cmd pinCmd) pinReply {
+	if id := w.inPreApply.Load(); id != 0 && id == goroutineID() {
+		return pinReply{err: ErrReentrantCall}
+	}
 	cmd.reply = make(chan pinReply, 1)
 	select {
 	case w.control <- cmd:
@@ -73,6 +95,10 @@ func (w *Watcher[T]) sendPin(cmd pinCmd) pinReply {
 // keeps reporting the diverging Live version underneath. It returns
 // ErrNoSuchSnapshot if that version is not retained; raise WithHistory to
 // pin further back.
+//
+// It returns ErrReentrantCall, immediately and without pinning anything, when
+// called from inside a PreApply hook: the hook occupies the goroutine that
+// would service this command. Call it from another goroutine.
 func (w *Watcher[T]) Pin(version uint64) error {
 	return w.sendPin(pinCmd{kind: pinAt, version: version}).err
 }
@@ -81,6 +107,14 @@ func (w *Watcher[T]) Pin(version uint64) error {
 // returns that version. Unlike Pin, it always succeeds and needs no
 // retained history, since it pins to the live snapshot rather than looking
 // one up in it.
+//
+// It returns 0, pinning nothing, in the two cases where it cannot succeed: the
+// watcher is closed, or it was called from inside a PreApply hook (see
+// ErrReentrantCall - the signature has no room for one, and widening it would
+// break every caller). Zero is unambiguous rather than a convenient lie:
+// versions start at 1, so it can never collide with a version this really
+// pinned, which is the same disambiguation Pinned relies on. Callers that need
+// to distinguish the two causes, or to be sure at all, can check Pinned.
 func (w *Watcher[T]) PinCurrent() uint64 {
 	return w.sendPin(pinCmd{kind: pinCurrent}).version
 }
@@ -90,6 +124,17 @@ func (w *Watcher[T]) PinCurrent() uint64 {
 // accumulated diff of everything that changed while pinned, no matter how
 // many updates were reconciled (and recorded to history) in the meantime. It
 // is a no-op if the watcher is not currently pinned.
+//
+// It is also a no-op when called from inside a PreApply hook (see
+// ErrReentrantCall): it returns immediately and leaves the pin exactly as it
+// found it, so the watcher stays pinned and Pinned still says so. It reports
+// nothing, because it has nothing to report it with. Giving it an error return
+// would be an incompatible change to a released API - it breaks every func()
+// this method value is assigned to, t.Cleanup(w.Unpin) among them, and turns
+// every existing call site into an unchecked-error lint finding - which is too
+// much to charge every correct caller for a signal only an incorrect one can
+// ever see. Pin, called the same wrong way, returns the error in full; the
+// mistake is the same mistake, and diagnosing it once is enough.
 func (w *Watcher[T]) Unpin() {
 	w.sendPin(pinCmd{kind: unpin})
 }

--- a/preapply.go
+++ b/preapply.go
@@ -1,0 +1,111 @@
+package mamori
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// defaultPreApplyTimeout bounds a PreApply hook when the caller sets none.
+// Ten seconds is generous for the checks this hook exists for - opening a
+// connection, exchanging a token - while still being short enough that a hook
+// which hangs on an unresponsive backend does not stall reconciliation for
+// long. See WithPreApplyTimeout for why the bound is mandatory.
+const defaultPreApplyTimeout = 10 * time.Second
+
+// PreApply installs a gate that runs before a reconciled snapshot becomes
+// current. Returning a non-nil error rejects the candidate: Get keeps returning
+// the last valid configuration, OnChange does not fire, and OnError receives a
+// *PreApplyError describing the rejection.
+//
+// It exists for the checks struct validation cannot express, because they need
+// I/O: that a rotated database password actually opens a connection, that a new
+// API token is accepted by its issuer, that a reissued certificate chains to a
+// trusted root. Validation answers "is this well-formed". PreApply answers
+// "does this actually work", which is the question a rotation actually turns on.
+//
+//	w, err := mamori.Watch[Config](ctx,
+//	    mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+//	        if !ev.Changed("DBPassword") {
+//	            return nil
+//	        }
+//	        return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+//	    }),
+//	)
+//
+// The hook runs on the reconciler goroutine, because it has to complete before
+// the swap and the OnChange dispatch queue is asynchronous and lossy by design
+// (WithQueueDepth drops the oldest event when full); a gate cannot be delivered
+// on a channel that is allowed to drop. Two consequences follow, and both
+// matter:
+//
+// It is bounded by WithPreApplyTimeout, and the bound cannot be removed.
+//
+// It must not call back into the same Watcher. Get is lock-free and safe, but
+// Refresh, Pin, PinCurrent, and Unpin are serviced by the very goroutine the
+// hook is occupying, so calling one deadlocks until the timeout fires.
+//
+// It is typed to the same T passed to Watch, and runs on the initial load as
+// well as on every subsequent update, so a credential that does not work is
+// caught at startup rather than at the first rotation.
+func PreApply[T any](fn func(ctx context.Context, ev Change[T]) error) Option {
+	return func(o *options) { o.preApply = fn }
+}
+
+// WithPreApplyTimeout bounds how long a PreApply hook may run, defaulting to
+// defaultPreApplyTimeout.
+//
+// The bound is mandatory rather than optional because the hook runs on the
+// reconciler goroutine, which also services every other field's updates, the
+// published Status report, and pin/unpin commands. An unbounded hook would
+// wedge all of that.
+//
+// Exceeding the budget is a REJECTION, not an acceptance: on timeout mamori
+// does not know whether the new configuration works, and applying it anyway
+// would defeat the point of having a gate. A hook that always times out
+// therefore stalls updates - loudly, emitting a *PreApplyError once per
+// attempt - rather than quietly serving unverified configuration. That is the
+// intended trade.
+func WithPreApplyTimeout(d time.Duration) Option {
+	return func(o *options) { o.preApplyTimeout = d }
+}
+
+// PreApplyError is delivered to OnError when a PreApply hook rejects a
+// candidate snapshot, and returned by Watch and Load when the hook rejects the
+// initial configuration. Err is the hook's own error, or
+// context.DeadlineExceeded when it exceeded WithPreApplyTimeout.
+type PreApplyError struct {
+	Err error
+}
+
+func (e *PreApplyError) Error() string {
+	return fmt.Sprintf("mamori: pre-apply check rejected the configuration: %v", e.Err)
+}
+
+// Unwrap lets errors.Is and errors.As reach the hook's own error, including
+// context.DeadlineExceeded for a hook that exceeded its budget.
+func (e *PreApplyError) Unwrap() error { return e.Err }
+
+// runPreApply invokes a typed hook under its timeout and wraps any refusal in
+// a *PreApplyError. It returns nil when there is no hook, which is the common
+// case, so callers need no nil check of their own.
+//
+// parent is the watcher's context, so cancelling the watcher also releases a
+// hook blocked on a hanging backend rather than waiting out the full budget.
+func runPreApply[T any](parent context.Context, hook func(context.Context, Change[T]) error, timeout time.Duration, ev Change[T]) error {
+	if hook == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	if err := hook(ctx, ev); err != nil {
+		return &PreApplyError{Err: err}
+	}
+	// A hook that returned nil after its deadline passed did not actually
+	// verify anything against a live deadline, so treat the expiry itself as
+	// the refusal rather than trusting a result produced past the budget.
+	if err := ctx.Err(); err != nil {
+		return &PreApplyError{Err: err}
+	}
+	return nil
+}

--- a/preapply.go
+++ b/preapply.go
@@ -42,8 +42,13 @@ const defaultPreApplyTimeout = 10 * time.Second
 // It is bounded by WithPreApplyTimeout, and the bound cannot be removed.
 //
 // It must not call back into the same Watcher. Get is lock-free and safe, but
-// Refresh, Pin, PinCurrent, and Unpin are serviced by the very goroutine the
-// hook is occupying, so calling one deadlocks until the timeout fires.
+// Pin, PinCurrent, and Unpin are serviced by the very goroutine the hook is
+// occupying, and they take no context: sendPin (pin.go) selects only on the
+// control channel and on the watcher's own ctx, so with the reconciler goroutine
+// sitting inside this hook, the send blocks and nothing releases it short of
+// Close. The hook's own timeout does NOT rescue this, because the hook is
+// blocked inside sendPin, which never looks at the context this hook was given.
+// The result is a watcher wedged for good, not a bounded stall.
 //
 // It is typed to the same T passed to Watch, and runs on the initial load as
 // well as on every subsequent update, so a credential that does not work is

--- a/preapply.go
+++ b/preapply.go
@@ -3,6 +3,8 @@ package mamori
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync/atomic"
 	"time"
 )
 
@@ -41,14 +43,26 @@ const defaultPreApplyTimeout = 10 * time.Second
 //
 // It is bounded by WithPreApplyTimeout, and the bound cannot be removed.
 //
-// It must not call back into the same Watcher. Get is lock-free and safe, but
-// Pin, PinCurrent, and Unpin are serviced by the very goroutine the hook is
-// occupying, and they take no context: sendPin (pin.go) selects only on the
-// control channel and on the watcher's own ctx, so with the reconciler goroutine
-// sitting inside this hook, the send blocks and nothing releases it short of
-// Close. The hook's own timeout does NOT rescue this, because the hook is
-// blocked inside sendPin, which never looks at the context this hook was given.
-// The result is a watcher wedged for good, not a bounded stall.
+// It must not call back into the same Watcher, and mamori now catches it when
+// it does. Get is lock-free and safe here - it Loads a pointer the reconciler
+// already published, and reads the snapshot this candidate would supersede,
+// which is usually what a hook wants. Pin, PinCurrent, and Unpin are not: they
+// are serviced by the very goroutine the hook is occupying, and they take no
+// context, so sendPin (pin.go) would be waiting for a receiver that cannot
+// exist until this hook returns. That used to block until Close - no
+// reconciliation, no OnChange, no OnError, no diagnostic of any kind, and the
+// hook's own timeout does not rescue it, because the hook is parked inside
+// sendPin, which never looks at the context this hook was given.
+//
+// It is now detected instead, per call, and the hook keeps running:
+//
+//   - Pin returns ErrReentrantCall, having pinned nothing.
+//   - PinCurrent returns 0, which no real version ever is.
+//   - Unpin does nothing and leaves the watcher pinned exactly as it was.
+//
+// The detection is keyed on which goroutine is inside the hook, not merely that
+// one is, so a Pin issued from an unrelated goroutine that happens to overlap a
+// hook is untouched: it waits its turn and is serviced normally, as before.
 //
 // It is typed to the same T passed to Watch, and runs on the initial load as
 // well as on every subsequent update, so a credential that does not work is
@@ -97,9 +111,27 @@ func (e *PreApplyError) Unwrap() error { return e.Err }
 //
 // parent is the watcher's context, so cancelling the watcher also releases a
 // hook blocked on a hanging backend rather than waiting out the full budget.
-func runPreApply[T any](parent context.Context, hook func(context.Context, Change[T]) error, timeout time.Duration, ev Change[T]) error {
+//
+// mark is where the reentrancy detection is armed: for the duration of the
+// hook it holds the ID of the goroutine running it, and 0 the rest of the time.
+// sendPin (pin.go) compares it against its own caller's ID, which is what lets
+// a pin command from inside the hook be refused while an identical command from
+// any other goroutine keeps waiting its turn exactly as it always has. Callers
+// with no watcher to protect pass nil: loadValue runs this on the caller's own
+// goroutine, before Watch has constructed anything there is to reenter.
+//
+// The store is deferred, not merely written after the call, so a hook that
+// panics cannot leave the mark set. See TestRunPreApplyClearsMarkWhenHookPanics
+// for why that matters even though a panicking hook is not survivable today.
+// Nothing is touched when there is no hook, so a watcher without a gate pays
+// for none of this.
+func runPreApply[T any](parent context.Context, hook func(context.Context, Change[T]) error, timeout time.Duration, ev Change[T], mark *atomic.Uint64) error {
 	if hook == nil {
 		return nil
+	}
+	if mark != nil {
+		defer mark.Store(0)
+		mark.Store(goroutineID())
 	}
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
@@ -113,4 +145,61 @@ func runPreApply[T any](parent context.Context, hook func(context.Context, Chang
 		return &PreApplyError{Err: err}
 	}
 	return nil
+}
+
+// goroutineIDPrefix is the fixed opening of runtime.Stack's first line, which
+// is documented to be "goroutine N [status]:" for the running goroutine.
+const goroutineIDPrefix = "goroutine "
+
+// goroutineID returns the calling goroutine's ID, or 0 if it cannot be
+// determined.
+//
+// Go deliberately does not expose goroutine identity, so this reads it back out
+// of the one place the runtime does print it: the header line of the
+// goroutine's own stack trace. That is a real cost in taste, and it is paid
+// here rather than in the alternative because the alternative is worse. A mark
+// that recorded only THAT a hook is running would refuse a Pin from any
+// unrelated caller goroutine that merely overlapped one - once per rotation,
+// for as long as the hook's whole budget, with an error telling the caller to
+// do the thing it was already doing. Identity is what makes the refusal apply
+// to exactly the caller that is actually deadlocking itself.
+//
+// runtime.Stack(buf, false) walks only the calling goroutine, so it does not
+// stop the world; with a buffer this small it is a truncated single-frame
+// traceback, on the order of a microsecond. It is reached at most twice per
+// hook invocation (once to arm the mark, once for a pin command that actually
+// overlaps a hook) and never at all when no PreApply hook is installed.
+//
+// Every failure path returns 0, and 0 is the same value the mark holds when no
+// hook is running, so a parse that ever stopped matching the runtime's format
+// would silently disable the detection and restore the previous behavior. It
+// can never manufacture a false match, which is the direction that matters: a
+// missed detection is the bug this package documented for a release, while a
+// false one would break correct code.
+func goroutineID() uint64 {
+	var buf [40]byte
+	n := runtime.Stack(buf[:], false)
+	line := buf[:n]
+	if len(line) <= len(goroutineIDPrefix) || string(line[:len(goroutineIDPrefix)]) != goroutineIDPrefix {
+		return 0
+	}
+	var id uint64
+	digits := 0
+	for _, c := range line[len(goroutineIDPrefix):] {
+		if c < '0' || c > '9' {
+			break
+		}
+		// 19 digits is the widest value that cannot overflow uint64. A wider
+		// run is not a goroutine ID, and wrapping one into a plausible-looking
+		// number is the one outcome this must not produce.
+		if digits == 19 {
+			return 0
+		}
+		id = id*10 + uint64(c-'0')
+		digits++
+	}
+	if digits == 0 {
+		return 0
+	}
+	return id
 }

--- a/preapply_reentrancy_test.go
+++ b/preapply_reentrancy_test.go
@@ -1,0 +1,469 @@
+package mamori
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+// reentrancyBudget is the hard ceiling every test in this file puts on a call
+// that must return promptly. It exists so a regression FAILS the suite instead
+// of hanging it: the bug these tests pin is an unbounded block, and a test that
+// simply waits for a reply that never comes would wedge `go test` itself until
+// its package timeout, ten minutes later, with no useful message. Five seconds
+// is enormous compared to the microseconds these calls take when they work.
+const reentrancyBudget = 5 * time.Second
+
+// TestPreApplyPinFromHookFailsFast pins the reentrancy hazard: a PreApply hook
+// runs ON the reconciler goroutine, and Pin is a command SERVICED by that same
+// goroutine over an unbuffered control channel. With the reconciler sitting
+// inside the hook, nothing is receiving on w.control, and sendPin's only other
+// select branch is w.ctx.Done() - which fires on Close and nothing else. Before
+// detection existed this call blocked forever: no reconciliation, no OnChange,
+// no OnError, no error anywhere, until something external called Close. The
+// hook's own PreApply timeout does not rescue it, because the hook is parked
+// inside sendPin, which never looks at the context the hook was handed.
+func TestPreApplyPinFromHookFailsFast(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp1://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("rp1")
+	p.set("a", "first", "v1")
+
+	// self is how the hook reaches the Watcher that is running it. It is an
+	// atomic pointer rather than a plain variable because the hook also runs on
+	// the INITIAL load (decision D7), on Watch's own goroutine, before Watch has
+	// returned anything to store here - so the hook must tolerate reading nil,
+	// and the later store must be safely visible to the reconciler goroutine.
+	var self atomic.Pointer[Watcher[cfg]]
+	pinErr := make(chan error, 1)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, _ Change[cfg]) error {
+			w := self.Load()
+			if w == nil {
+				return nil // initial load: no Watcher exists to reenter yet
+			}
+			pinErr <- w.Pin(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	self.Store(w)
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case err := <-pinErr:
+		if !errors.Is(err, ErrReentrantCall) {
+			t.Fatalf("Pin from inside a PreApply hook returned %v, want ErrReentrantCall", err)
+		}
+	case <-time.After(reentrancyBudget):
+		t.Fatal("Pin from inside a PreApply hook did not return: the watcher is wedged, which is the bug this detection exists to convert into an error")
+	}
+
+	// The refusal must be local to the offending call. The hook returned nil, so
+	// the candidate is good and the watcher has to carry on applying it.
+	waitFlushed(t, w, 2)
+	if got := w.Get().A; got != "second" {
+		t.Errorf("Get().A = %q, want second: a refused reentrant call must not disturb the flush that was already in flight", got)
+	}
+}
+
+// TestPreApplyPinCurrentFromHookFailsFast covers the same hazard through
+// PinCurrent, which cannot report an error at all: its signature returns only
+// the version it pinned to. Version 0 is the answer, and it is unambiguous
+// rather than a lie, because versions start at 1 - the same "0 means it did not
+// happen" disambiguation Pinned already relies on (see pin.go).
+func TestPreApplyPinCurrentFromHookFailsFast(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp2://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("rp2")
+	p.set("a", "first", "v1")
+
+	var self atomic.Pointer[Watcher[cfg]]
+	got := make(chan uint64, 1)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, _ Change[cfg]) error {
+			w := self.Load()
+			if w == nil {
+				return nil
+			}
+			got <- w.PinCurrent()
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	self.Store(w)
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case v := <-got:
+		if v != 0 {
+			t.Fatalf("PinCurrent from inside a PreApply hook returned version %d, want 0 (versions start at 1, so 0 is the unambiguous did-not-happen answer)", v)
+		}
+	case <-time.After(reentrancyBudget):
+		t.Fatal("PinCurrent from inside a PreApply hook did not return: the watcher is wedged")
+	}
+
+	// A refused PinCurrent must not have pinned anything.
+	if v, pinned := w.Pinned(); pinned {
+		t.Errorf("Pinned() = (%d, true) after a refused PinCurrent, want not pinned", v)
+	}
+}
+
+// TestPreApplyUnpinFromHookIsAnObservableNoOp covers Unpin, which returns
+// nothing and therefore cannot carry the error. Changing its signature to
+// return one is an incompatible API change (it breaks `t.Cleanup(w.Unpin)` and
+// every func() the method value is assigned to, and it would make every
+// existing `w.Unpin()` call site a new errcheck finding), so Unpin keeps its
+// signature and instead does nothing at all: it returns immediately and leaves
+// the pin exactly as it found it. That is not silent - it is observable through
+// Pinned, which is what this test asserts - and it is strictly better than the
+// previous behavior, which was to never return.
+func TestPreApplyUnpinFromHookIsAnObservableNoOp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp3://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("rp3")
+	p.set("a", "first", "v1")
+
+	var self atomic.Pointer[Watcher[cfg]]
+	returned := make(chan struct{}, 1)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, _ Change[cfg]) error {
+			w := self.Load()
+			if w == nil {
+				return nil
+			}
+			w.Unpin()
+			returned <- struct{}{}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	self.Store(w)
+
+	// Pin from here, where it is legal, so the hook's Unpin has a real pin to
+	// fail to release.
+	if v := w.PinCurrent(); v != 1 {
+		t.Fatalf("PinCurrent from the test goroutine returned %d, want 1", v)
+	}
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case <-returned:
+	case <-time.After(reentrancyBudget):
+		t.Fatal("Unpin from inside a PreApply hook did not return: the watcher is wedged")
+	}
+
+	if v, pinned := w.Pinned(); !pinned || v != 1 {
+		t.Errorf("Pinned() = (%d, %v) after a refused Unpin, want (1, true): a refused Unpin must leave the pin exactly as it was", v, pinned)
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first: a refused Unpin must not release the pin", got)
+	}
+}
+
+// TestPreApplyGetInsideHookIsSafe pins the other half of the rule the error
+// message states. Get is lock-free - it Loads an atomic pointer the reconciler
+// goroutine published - so it never goes near the control channel and is
+// exactly as safe inside a hook as anywhere else. The detection must not have
+// swept it up.
+func TestPreApplyGetInsideHookIsSafe(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp4://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("rp4")
+	p.set("a", "first", "v1")
+
+	var self atomic.Pointer[Watcher[cfg]]
+	seen := make(chan string, 1)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, _ Change[cfg]) error {
+			w := self.Load()
+			if w == nil {
+				return nil
+			}
+			// The candidate is not current yet, so Get must still be showing
+			// the snapshot this one supersedes. That is the whole point of a
+			// gate, and it is what makes Get useful inside a hook.
+			seen <- w.Get().A
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	self.Store(w)
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case got := <-seen:
+		if got != "first" {
+			t.Errorf("Get().A inside the hook = %q, want first (the candidate is not current until the gate passes)", got)
+		}
+	case <-time.After(reentrancyBudget):
+		t.Fatal("Get inside a PreApply hook did not return: Get must stay lock-free and safe inside a hook")
+	}
+	waitFlushed(t, w, 2)
+}
+
+// TestPinFromAnotherGoroutineIsUnaffected is the false-positive test, and it is
+// the reason the mark records WHICH goroutine is inside the hook rather than
+// merely THAT one is. A caller on an unrelated goroutine that happens to call
+// Pin while a hook is running is doing nothing wrong: its command sits on the
+// control channel until the hook finishes, and the reconciler then services it
+// exactly as it always has. A bare "a hook is running somewhere" flag would
+// reject that caller - non-deterministically, once per rotation, for a window
+// as long as the hook's whole budget - and would tell it to call from another
+// goroutine, which is precisely what it already did.
+func TestPinFromAnotherGoroutineIsUnaffected(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp5://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("rp5")
+	p.set("a", "first", "v1")
+
+	inHook := make(chan struct{})
+	release := make(chan struct{})
+	// live gates the blocking behavior to hook invocations that happen on the
+	// RECONCILER goroutine. The gate also runs on the initial load, on Watch's
+	// own goroutine (decision D7), and a hook that parked there would hang
+	// inside Watch itself, before this test had anything to release it with.
+	var live, blocked atomic.Bool
+
+	// WithHistory keeps version 1 retained: this Pin is delivered only AFTER the
+	// hook releases the reconciler and the flush it was gating completes, so by
+	// the time it is serviced the live version is already 2 and the default
+	// retention would have evicted the version being pinned. That would fail the
+	// Pin for a reason that has nothing to do with what this test is about.
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk), WithHistory(8),
+		PreApply(func(_ context.Context, _ Change[cfg]) error {
+			if !live.Load() || !blocked.CompareAndSwap(false, true) {
+				return nil
+			}
+			close(inHook)
+			<-release
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	live.Store(true)
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	<-inHook // the reconciler goroutine is now parked inside the hook
+
+	pinned := make(chan error, 1)
+	go func() { pinned <- w.Pin(1) }()
+
+	// While the hook holds the reconciler, this Pin must simply WAIT. Getting an
+	// answer here at all would mean the detection fired on a caller that never
+	// reentered anything. The window is deliberately generous: if the scheduler
+	// has not run the goroutine above yet, this test still cannot fail falsely,
+	// because the only thing asserted in this window is the ABSENCE of a wrong
+	// answer.
+	select {
+	case err := <-pinned:
+		t.Fatalf("Pin from an unrelated goroutine returned %v while a hook was running, want it to wait its turn", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-pinned:
+		if errors.Is(err, ErrReentrantCall) {
+			t.Fatalf("Pin from an unrelated goroutine was refused as reentrant: the detection must key on WHICH goroutine is inside the hook, not merely that one is")
+		}
+		if err != nil {
+			t.Fatalf("Pin from an unrelated goroutine = %v, want nil once the hook released the reconciler", err)
+		}
+	case <-time.After(reentrancyBudget):
+		t.Fatal("Pin from an unrelated goroutine never completed after the hook returned")
+	}
+	if v, ok := w.Pinned(); !ok || v != 1 {
+		t.Errorf("Pinned() = (%d, %v), want (1, true)", v, ok)
+	}
+}
+
+// TestPinWithNoHookInstalledIsUnaffected is the zero-cost, zero-behavior-change
+// case: no PreApply hook at all, so the mark is never set and sendPin takes
+// exactly the path it always took.
+func TestPinWithNoHookInstalledIsUnaffected(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"rp6://a"`
+	}
+	p := newWatchProvider("rp6")
+	p.set("a", "first", "v1")
+
+	w, err := Watch[cfg](context.Background(), WithProvider(p))
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if v := w.PinCurrent(); v != 1 {
+		t.Errorf("PinCurrent() = %d, want 1", v)
+	}
+	if err := w.Pin(1); err != nil {
+		t.Errorf("Pin(1) = %v, want nil", err)
+	}
+	if err := w.Pin(99); !errors.Is(err, ErrNoSuchSnapshot) {
+		t.Errorf("Pin(99) = %v, want ErrNoSuchSnapshot: unrelated failures must still be reported as themselves", err)
+	}
+	w.Unpin()
+	if v, pinned := w.Pinned(); pinned {
+		t.Errorf("Pinned() = (%d, true) after Unpin, want not pinned", v)
+	}
+}
+
+// TestRunPreApplyClearsMarkWhenHookPanics pins the defer.
+//
+// It is deliberately written against runPreApply rather than against a live
+// Watcher, because a panicking hook is NOT survivable on the real path: nothing
+// in this package recovers, so a hook that panics on the reconciler goroutine
+// takes the whole process down - the test binary included. There is no "and
+// then a later Pin still works" to observe on a process that no longer exists.
+//
+// The defer is still not optional. It is what makes the mark's lifetime a
+// property of the call rather than of the hook's cooperation, so the invariant
+// cannot silently rot if a recover is ever added above (at which point a mark
+// left set would permanently reject that watcher's Pin/PinCurrent/Unpin from
+// the reconciler goroutine, converting one bug into a quieter one). This test
+// asserts that invariant at the only level where a panic is observable.
+func TestRunPreApplyClearsMarkWhenHookPanics(t *testing.T) {
+	type cfg struct{ A string }
+	var mark atomic.Uint64
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("runPreApply swallowed the hook's panic; it must propagate")
+			}
+		}()
+		_ = runPreApply(context.Background(),
+			func(context.Context, Change[cfg]) error { panic("hook blew up") },
+			time.Second, Change[cfg]{}, &mark)
+	}()
+
+	if got := mark.Load(); got != 0 {
+		t.Errorf("mark = %d after a panicking hook, want 0: a mark left set would reject every later pin command from the reconciler goroutine", got)
+	}
+}
+
+// TestRunPreApplySetsAndClearsMark pins the mark's normal lifetime: set to the
+// running goroutine's own ID for the duration of the hook, cleared on return.
+func TestRunPreApplySetsAndClearsMark(t *testing.T) {
+	type cfg struct{ A string }
+	var mark atomic.Uint64
+
+	var inside uint64
+	err := runPreApply(context.Background(),
+		func(context.Context, Change[cfg]) error {
+			inside = mark.Load()
+			return nil
+		},
+		time.Second, Change[cfg]{}, &mark)
+	if err != nil {
+		t.Fatalf("runPreApply: %v", err)
+	}
+	if want := goroutineID(); inside != want || inside == 0 {
+		t.Errorf("mark inside the hook = %d, want the running goroutine's ID %d", inside, want)
+	}
+	if got := mark.Load(); got != 0 {
+		t.Errorf("mark = %d after the hook returned, want 0", got)
+	}
+}
+
+// TestRunPreApplyWithNoHookLeavesMarkAlone is the zero-cost claim, asserted
+// rather than asserted-in-a-comment: with no hook there is nothing to mark, and
+// runPreApply must not even look up a goroutine ID.
+func TestRunPreApplyWithNoHookLeavesMarkAlone(t *testing.T) {
+	type cfg struct{ A string }
+	var mark atomic.Uint64
+	if err := runPreApply(context.Background(), nil, time.Second, Change[cfg]{}, &mark); err != nil {
+		t.Fatalf("runPreApply with no hook = %v, want nil", err)
+	}
+	if got := mark.Load(); got != 0 {
+		t.Errorf("mark = %d with no hook installed, want 0", got)
+	}
+}
+
+// TestGoroutineIDIsStableAndDistinct pins the two properties the detection
+// actually depends on: the ID is stable across calls on one goroutine (so a
+// hook that calls Pin is recognized as the same goroutine that entered the
+// hook), and different goroutines get different IDs (so an unrelated caller is
+// never mistaken for the one inside the hook). A parse failure returns 0, which
+// disables detection and restores the previous behavior - it can never invent a
+// false match - so a nonzero result is also asserted here.
+func TestGoroutineIDIsStableAndDistinct(t *testing.T) {
+	mine := goroutineID()
+	if mine == 0 {
+		t.Fatal("goroutineID() = 0: no goroutine has ID 0, so the parse failed")
+	}
+	if again := goroutineID(); again != mine {
+		t.Errorf("goroutineID() = %d then %d on the same goroutine, want a stable value", mine, again)
+	}
+	other := make(chan uint64, 1)
+	go func() { other <- goroutineID() }()
+	if got := <-other; got == mine {
+		t.Errorf("goroutineID() = %d on a different goroutine, want a value distinct from %d", got, mine)
+	}
+}

--- a/preapply_test.go
+++ b/preapply_test.go
@@ -3,6 +3,7 @@ package mamori
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -45,6 +46,52 @@ func TestPreApplyErrorWrapsAndReports(t *testing.T) {
 	var pe *PreApplyError
 	if !errors.As(error(err), &pe) {
 		t.Error("errors.As must reach *PreApplyError")
+	}
+}
+
+// preApplyOtherConfig is a second config type, declared at package scope so
+// the type name in the mismatch error below is stable and worth asserting on.
+type preApplyOtherConfig struct{ B string }
+
+// TestPreApplyWrongTypeFailsWatch pins the one place a mistyped hook can be
+// caught. Option is untyped, so a hook written against a different config type
+// compiles cleanly and the assertion in Watch yields nil - and a nil gate is an
+// open gate. Tolerating it the way onChange tolerates its own mismatch would
+// mean the hook is never called, nothing is ever delivered to OnError, Status
+// stays healthy, and every rotation is applied unverified: the exact failure
+// PreApply exists to prevent, arrived at by installing PreApply. Watch must
+// refuse to start instead.
+func TestPreApplyWrongTypeFailsWatch(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pw://a"`
+	}
+	p := newWatchProvider("pw")
+	p.set("a", "first", "v1")
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[preApplyOtherConfig]) error {
+			return errors.New("refuse everything")
+		}),
+	)
+	if err == nil {
+		_ = w.Close()
+		t.Fatal("Watch accepted a PreApply hook typed for a different config: the gate would be silently open")
+	}
+	if w != nil {
+		t.Errorf("Watch returned a non-nil Watcher alongside its error")
+	}
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("error = %v, want one wrapping ErrInvalid", err)
+	}
+	// The message has to name both types: "PreApply hook has the wrong type" is
+	// useless when the two candidates are two similarly-named config structs.
+	for _, want := range []string{"PreApply", "preApplyOtherConfig", "cfg"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
 	}
 }
 
@@ -280,10 +327,18 @@ func TestPreApplyRejectedValueIsStillGatedOnALaterFlush(t *testing.T) {
 	}
 }
 
-// TestPreApplyRollsBackAppliedVersions asserts the rollback directly against
-// engine state, since the behavioral test above cannot distinguish "rolled
-// back" from "the next diff happened to compute anyway".
-func TestPreApplyRollsBackAppliedVersions(t *testing.T) {
+// TestPreApplyRejectionDoesNotAdvanceTheSnapshot pins the other half of the
+// rejection contract: no version is burned on a candidate that never became
+// current, so Snapshot and Live both stay where they were and Pin(version)
+// cannot later reach a refused snapshot.
+//
+// It deliberately does NOT carry the rollback's name. An earlier draft called
+// it TestPreApplyRollsBackAppliedVersions, which was a lie: it passes with the
+// rollback deleted, because a refused flush returns before e.version++ either
+// way. The rollback is pinned by TestPreApplyRejectionIsRetriedOnNextChange
+// and TestPreApplyRejectedValueIsStillGatedOnALaterFlush, both of which fail
+// without it.
+func TestPreApplyRejectionDoesNotAdvanceTheSnapshot(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	type cfg struct {

--- a/preapply_test.go
+++ b/preapply_test.go
@@ -527,3 +527,228 @@ func TestPreApplyNotCalledWhenNothingChanged(t *testing.T) {
 		t.Errorf("hook called %d extra times for an unchanged value, want 0", got-before)
 	}
 }
+
+// TestPreApplyWrongTypeFailsLoad is Load's counterpart to
+// TestPreApplyWrongTypeFailsWatch. loadValue is the shared load path behind
+// both Load and Watch's initial resolve, and it gates the initial
+// configuration itself (decision D7, see TestPreApplyRejectsInitialLoad below)
+// - which means it needs the very same guard against a mistyped hook that
+// Watch already has, not a bare comma-ok assertion of its own. A bare
+// assertion would report a hook typed for the wrong config as "no hook
+// installed" and return the unverified configuration as though the gate had
+// approved it: Load's own fail-open version of the bug
+// TestPreApplyWrongTypeFailsWatch already closed for Watch, and arguably
+// worse, since it would run before the program has any configuration at all.
+func TestPreApplyWrongTypeFailsLoad(t *testing.T) {
+	type cfg struct {
+		A string `source:"pv://a"`
+	}
+	p := newWatchProvider("pv")
+	p.set("a", "first", "v1")
+
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[preApplyOtherConfig]) error {
+			return errors.New("refuse everything")
+		}),
+	)
+	if err == nil {
+		t.Fatal("Load accepted a PreApply hook typed for a different config: the gate would be silently open")
+	}
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("error = %v, want one wrapping ErrInvalid", err)
+	}
+	// Same message requirement as Watch's version: naming both types is the
+	// only way the error is useful when the two candidates are similarly named.
+	for _, want := range []string{"PreApply", "preApplyOtherConfig", "cfg"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestPreApplyRejectsInitialLoad pins decision D7: a hook that verifies a
+// credential should verify the first one too, because discovering at startup
+// that the configured credential does not work beats discovering it at the
+// first rotation. Watch is already fail-fast on its initial Load for every
+// other kind of error (resolve, validation); a PreApply rejection now joins
+// that list rather than being the one failure mode Watch tolerates silently.
+func TestPreApplyRejectsInitialLoad(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pi://a"`
+	}
+	p := newWatchProvider("pi")
+	p.set("a", "bad", "v1")
+	boom := errors.New("initial credential does not work")
+
+	_, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error { return boom }),
+	)
+	if err == nil {
+		t.Fatal("Watch must fail when PreApply rejects the initial configuration")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want one wrapping the hook's error", err)
+	}
+	var pe *PreApplyError
+	if !errors.As(err, &pe) {
+		t.Errorf("err = %v, want a *PreApplyError", err)
+	}
+}
+
+// TestPreApplyRejectsLoad is TestPreApplyRejectsInitialLoad's one-shot
+// counterpart: Load shares loadValue with Watch's initial resolve, so the
+// same gate has to reject a one-shot Load exactly the way it rejects Watch's
+// startup load.
+func TestPreApplyRejectsLoad(t *testing.T) {
+	type cfg struct {
+		A string `source:"pl://a"`
+	}
+	p := newWatchProvider("pl")
+	p.set("a", "bad", "v1")
+
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error {
+			return errors.New("nope")
+		}),
+	)
+	if err == nil {
+		t.Fatal("Load must fail when PreApply rejects")
+	}
+	var pe *PreApplyError
+	if !errors.As(err, &pe) {
+		t.Errorf("err = %v, want a *PreApplyError", err)
+	}
+}
+
+// TestPreApplyInitialLoadReceivesZeroOld pins what the initial Change looks
+// like on this path: Old is the zero value of T, since nothing was serving
+// yet, and New is the freshly loaded configuration. See
+// TestPreApplyInitialLoadPopulatesFields for the other half of the initial
+// Change, Fields, which is populated rather than left nil.
+func TestPreApplyInitialLoadReceivesZeroOld(t *testing.T) {
+	type cfg struct {
+		A string `source:"pz://a"`
+	}
+	p := newWatchProvider("pz")
+	p.set("a", "value", "v1")
+
+	var gotOld, gotNew string
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			gotOld, gotNew = ev.Old.A, ev.New.A
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if gotOld != "" {
+		t.Errorf("ev.Old.A = %q on the initial load, want the zero value", gotOld)
+	}
+	if gotNew != "value" {
+		t.Errorf("ev.New.A = %q, want value", gotNew)
+	}
+}
+
+// TestPreApplyInitialLoadPopulatesFields pins the other half of the initial
+// Change: Fields is populated, not left nil, by applying the engine's own
+// diff rule (buildCandidate, reconciler.go) against the true prior state at
+// this point in the program's life. e.applied does not exist yet - Watch only
+// seeds it after loadValue returns - so the prior version for every resolved
+// field is the empty string, exactly what a missing e.applied entry already
+// means everywhere else in this codebase (see flush's own comment on that
+// equivalence in reconciler.go). Applying that rule here is what makes
+// ev.Changed(path) report true for a field set on the initial load.
+//
+// This is the test that makes decision D7 actually work for the usage the
+// docs recommend: without Fields populated, the documented guard pattern -
+// "if !ev.Changed(path) { return nil }" - would silently skip verification of
+// the very first value, the same class of silent gate failure Task 3 closed
+// for a mistyped hook, arrived at through the guard pattern PreApply's own
+// docs teach instead.
+func TestPreApplyInitialLoadPopulatesFields(t *testing.T) {
+	type cfg struct {
+		A string `source:"pf://a"`
+	}
+	p := newWatchProvider("pf")
+	p.set("a", "value", "v1")
+
+	var changed bool
+	var fields []FieldChange
+	_, err := Load[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			changed = ev.Changed("A")
+			fields = ev.Fields
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !changed {
+		t.Error(`ev.Changed("A") = false on the initial load, want true: the documented guard ` +
+			"pattern must not skip startup verification")
+	}
+	if len(fields) != 1 {
+		t.Fatalf("ev.Fields = %+v, want exactly one entry for A", fields)
+	}
+	if fields[0].Path != "A" {
+		t.Errorf("fields[0].Path = %q, want A", fields[0].Path)
+	}
+	if fields[0].OldVersion != "" {
+		t.Errorf("fields[0].OldVersion = %q, want empty (no prior version existed at this point)", fields[0].OldVersion)
+	}
+	if fields[0].NewVersion != "v1" {
+		t.Errorf("fields[0].NewVersion = %q, want v1", fields[0].NewVersion)
+	}
+}
+
+// TestPreApplyInitialLoadCallsHookExactlyOnce guards against double-gating
+// Watch's initial resolve. loadValue is the single place that runs the gate
+// for the initial configuration (see its doc comment); Watch stores loadValue's
+// already-gated result straight into the engine without a gate of its own.
+// Were Watch to also assert-and-call the hook itself around its call to
+// loadValue, a rejection would surface as two OnError deliveries and every
+// initial load would cost two round trips (e.g. two dials for a hook that
+// pings a database) instead of one.
+func TestPreApplyInitialLoadCallsHookExactlyOnce(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"psx://a"`
+	}
+	p := newWatchProvider("psx")
+	p.set("a", "first", "v1")
+
+	var calls atomic.Int32
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error {
+			calls.Add(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Settle before asserting: a synchronous check right after Watch returns
+	// would only catch a second call made inline, on the same call stack, and
+	// would miss an asynchronous re-gate performed moments later by the
+	// reconciler goroutine (e.g. a spurious flush of the just-seeded observed
+	// state). No push happens here, so nothing should ever become pending -
+	// this sleep exists purely to give that goroutine a window to misbehave in
+	// before the count is read.
+	time.Sleep(50 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("hook called %d times on Watch's initial load, want exactly 1", got)
+	}
+}

--- a/preapply_test.go
+++ b/preapply_test.go
@@ -3,8 +3,11 @@ package mamori
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.uber.org/goleak"
 )
 
 func TestPreApplyOptionStoresTypedFunc(t *testing.T) {
@@ -42,5 +45,430 @@ func TestPreApplyErrorWrapsAndReports(t *testing.T) {
 	var pe *PreApplyError
 	if !errors.As(error(err), &pe) {
 		t.Error("errors.As must reach *PreApplyError")
+	}
+}
+
+// TestPreApplyRejectionKeepsLastGood pins the core contract: a rejected
+// candidate leaves Get, OnChange, and the served config exactly as they were.
+func TestPreApplyRejectionKeepsLastGood(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pa://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pa")
+	p.set("a", "first", "v1")
+
+	changed := make(chan cfg, 4)
+	errs := make(chan error, 4)
+	reject := errors.New("credential does not work")
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "second" {
+				return reject
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev.New }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case e := <-errs:
+		if !errors.Is(e, reject) {
+			t.Errorf("error = %v, want one wrapping the hook's error", e)
+		}
+		var pe *PreApplyError
+		if !errors.As(e, &pe) {
+			t.Errorf("error = %v, want a *PreApplyError", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no error delivered for a rejected candidate")
+	}
+	select {
+	case ev := <-changed:
+		t.Fatalf("OnChange fired for a rejected candidate: %+v", ev)
+	default:
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first (last good must survive a rejection)", got)
+	}
+}
+
+// TestPreApplyRejectionIsRetriedOnNextChange is the regression test for the
+// e.applied rollback. buildCandidate advances e.applied as a side effect, so a
+// rejection that does not roll it back leaves every rejected field looking
+// already-applied: the next flush computes an empty diff and the value is
+// never retried, with Get silently serving stale config forever.
+//
+// Here the hook rejects "bad" and accepts anything else. Recovery to "good"
+// alone does NOT pin the rollback: without it the engine has already recorded
+// v2 as applied, so v3's diff still computes and the recovery happens anyway.
+// What separates the two worlds is the OldVersion the recovery's own diff
+// carries. It is the engine reporting, in the only place e.applied is
+// observable from outside, which version it believes it last applied: v1 when
+// the rejected v2 was rolled back, v2 when it was left advanced - the exact
+// wrong belief that strands a value that arrives without a further version
+// bump behind it.
+func TestPreApplyRejectionIsRetriedOnNextChange(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pr://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pr")
+	p.set("a", "first", "v1")
+
+	changed := make(chan Change[cfg], 4)
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "bad" {
+				return errors.New("rejected")
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "bad", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection for the bad value")
+	}
+
+	// The rejected version must not be recorded as applied: a good value now
+	// has to be applied, and its diff has to start from the last version that
+	// really was applied.
+	p.push("a", "good", "v3")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+
+	select {
+	case got := <-changed:
+		if got.New.A != "good" {
+			t.Errorf("after recovery A = %q, want good", got.New.A)
+		}
+		if len(got.Fields) != 1 {
+			t.Fatalf("recovery Fields = %+v, want exactly one entry for A", got.Fields)
+		}
+		if got.Fields[0].OldVersion != "v1" {
+			t.Errorf("recovery OldVersion = %q, want v1: the rejected v2 was never applied, "+
+				"so leaving e.applied advanced past it is exactly the staleness bug",
+				got.Fields[0].OldVersion)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("engine did not recover after a rejection")
+	}
+	if got := w.Get().A; got != "good" {
+		t.Errorf("Get().A = %q, want good", got)
+	}
+	select {
+	case e := <-errs:
+		t.Errorf("second error after a clean recovery: %v", e)
+	default:
+	}
+}
+
+// TestPreApplyRejectedValueIsStillGatedOnALaterFlush is the other half of the
+// rollback, and the one with teeth: a rejected value is NOT withdrawn from
+// e.observed, so it stays in every candidate built afterwards. Leaving
+// e.applied advanced hides it from the very next diff, and a hook written the
+// way PreApply's own documentation recommends - verify only what Changed -
+// then waves the whole candidate through on some unrelated field's flush. The
+// rejected credential reaches Get without anything ever having verified it,
+// which is worse than the staleness the rollback's other half prevents.
+func TestPreApplyRejectedValueIsStillGatedOnALaterFlush(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"px://a"`
+		B string `source:"px://b"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("px")
+	p.set("a", "first", "a1")
+	p.set("b", "first", "b1")
+
+	changed := make(chan Change[cfg], 4)
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if !ev.Changed("A") {
+				return nil // the documented "only check what actually rotated" shape
+			}
+			if ev.New.A == "bad" {
+				return errors.New("credential does not work")
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "bad", "a2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection for the bad value")
+	}
+
+	// An unrelated field changes. A is still "bad" and still unverified, so
+	// this candidate must still be refused - which only happens if A is still
+	// in the diff the hook is handed.
+	p.push("b", "second", "b2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case ev := <-changed:
+		t.Fatalf("an unrelated field's flush applied the still-rejected A=%q; "+
+			"the gate never saw it because Fields = %+v", ev.New.A, ev.Fields)
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection for the candidate still carrying the bad value")
+	}
+	if got := w.Get(); got.A != "first" || got.B != "first" {
+		t.Errorf("Get() = %+v, want both fields at their last good values", got)
+	}
+
+	// A recovers. B's change was held back by the rejection, not lost, so the
+	// single Change that lands now must carry both fields.
+	p.push("a", "good", "a3")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case ev := <-changed:
+		if ev.New.A != "good" || ev.New.B != "second" {
+			t.Errorf("recovered config = %+v, want A=good B=second", ev.New)
+		}
+		if !ev.Changed("A") || !ev.Changed("B") {
+			t.Errorf("recovery Fields = %+v, want both A and B: B's held-back change must "+
+				"not be stranded by A's rejection", ev.Fields)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("engine did not recover after a rejection")
+	}
+}
+
+// TestPreApplyRollsBackAppliedVersions asserts the rollback directly against
+// engine state, since the behavioral test above cannot distinguish "rolled
+// back" from "the next diff happened to compute anyway".
+func TestPreApplyRollsBackAppliedVersions(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pb://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pb")
+	p.set("a", "first", "v1")
+
+	errs := make(chan error, 4)
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "second" {
+				return errors.New("no")
+			}
+			return nil
+		}),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no rejection")
+	}
+
+	// Status reports the field's observed version, and the snapshot version
+	// must NOT have advanced past the last applied one.
+	rep := w.Status()
+	if rep.Snapshot != 1 {
+		t.Errorf("Snapshot = %d, want 1 (a rejected candidate must not advance the served snapshot)", rep.Snapshot)
+	}
+	if rep.Live != 1 {
+		t.Errorf("Live = %d, want 1 (a rejected candidate is not a reconciled snapshot at all)", rep.Live)
+	}
+}
+
+// TestPreApplyGatesWhilePinned pins where the gate sits relative to flush's
+// pinned branch. A pin freezes what Get returns; it does not stop the engine
+// reconciling and advancing Live, and Unpin then applies the newest such
+// snapshot wholesale, gating nothing itself. A gate that ran only on the
+// unpinned branch would make Unpin the one path able to publish a candidate
+// nothing ever verified - which is exactly the failure a rotation gate exists
+// to prevent, arriving at the least expected moment.
+func TestPreApplyGatesWhilePinned(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pp://a"`
+	}
+	clk := NewFakeClock(time.Time{})
+	p := newWatchProvider("pp")
+	p.set("a", "first", "v1")
+
+	changed := make(chan Change[cfg], 4)
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p), WithClock(clk),
+		PreApply(func(_ context.Context, ev Change[cfg]) error {
+			if ev.New.A == "bad" {
+				return errors.New("credential does not work")
+			}
+			return nil
+		}),
+		OnChange(func(ev Change[cfg]) { changed <- ev }),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	w.PinCurrent()
+
+	p.push("a", "bad", "v2")
+	blockUntilTimers(t, clk, 1)
+	clk.Advance(defaultDebounce)
+	select {
+	case <-errs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a pinned watcher still reconciles, so it must still gate what it reconciles")
+	}
+	if rep := w.Status(); rep.Live != 1 {
+		t.Errorf("Live = %d, want 1: a refused candidate is not a reconciled snapshot, pinned or not", rep.Live)
+	}
+
+	w.Unpin()
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q after Unpin, want first: Unpin must never publish a candidate the gate refused", got)
+	}
+	select {
+	case ev := <-changed:
+		t.Fatalf("Unpin emitted a Change for a refused candidate: %+v", ev.Fields)
+	default:
+	}
+}
+
+// TestPreApplyTimeoutIsARejection pins decision D4.
+func TestPreApplyTimeoutIsARejection(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pt://a"`
+	}
+	p := newWatchProvider("pt")
+	p.set("a", "first", "v1")
+
+	release := make(chan struct{})
+	errs := make(chan error, 4)
+
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		WithPreApplyTimeout(50*time.Millisecond),
+		PreApply(func(ctx context.Context, ev Change[cfg]) error {
+			if ev.New.A != "second" {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-release:
+				return nil
+			}
+		}),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { close(release); _ = w.Close() }()
+
+	p.push("a", "second", "v2")
+
+	select {
+	case e := <-errs:
+		if !errors.Is(e, context.DeadlineExceeded) {
+			t.Errorf("error = %v, want one wrapping context.DeadlineExceeded", e)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a hook that never returns must be rejected on timeout, not awaited")
+	}
+	if got := w.Get().A; got != "first" {
+		t.Errorf("Get().A = %q, want first (a timed-out hook must not apply)", got)
+	}
+}
+
+// TestPreApplyNotCalledWhenNothingChanged guards against spending a network
+// round trip on every poll tick.
+func TestPreApplyNotCalledWhenNothingChanged(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	type cfg struct {
+		A string `source:"pn://a"`
+	}
+	p := newWatchProvider("pn")
+	p.set("a", "only", "v1")
+
+	var calls atomic.Int32
+	w, err := Watch[cfg](context.Background(),
+		WithProvider(p),
+		PreApply(func(context.Context, Change[cfg]) error {
+			calls.Add(1)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Re-push the identical version: buildCandidate computes an empty diff and
+	// must not reach the gate at all.
+	before := calls.Load()
+	p.push("a", "only", "v1")
+	time.Sleep(50 * time.Millisecond)
+	if got := calls.Load(); got != before {
+		t.Errorf("hook called %d extra times for an unchanged value, want 0", got-before)
 	}
 }

--- a/preapply_test.go
+++ b/preapply_test.go
@@ -1,0 +1,46 @@
+package mamori
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPreApplyOptionStoresTypedFunc(t *testing.T) {
+	type cfg struct{ A string }
+	o := defaultOptions()
+	PreApply(func(context.Context, Change[cfg]) error { return nil })(o)
+	if o.preApply == nil {
+		t.Fatal("PreApply did not store the hook")
+	}
+	if _, ok := o.preApply.(func(context.Context, Change[cfg]) error); !ok {
+		t.Fatalf("stored hook has type %T, want func(context.Context, Change[cfg]) error", o.preApply)
+	}
+}
+
+func TestPreApplyTimeoutDefaultAndOverride(t *testing.T) {
+	o := defaultOptions()
+	if o.preApplyTimeout != defaultPreApplyTimeout {
+		t.Errorf("default = %v, want %v", o.preApplyTimeout, defaultPreApplyTimeout)
+	}
+	WithPreApplyTimeout(3 * time.Second)(o)
+	if o.preApplyTimeout != 3*time.Second {
+		t.Errorf("after override = %v, want 3s", o.preApplyTimeout)
+	}
+}
+
+func TestPreApplyErrorWrapsAndReports(t *testing.T) {
+	cause := errors.New("dial tcp: connection refused")
+	err := &PreApplyError{Err: cause}
+	if !errors.Is(err, cause) {
+		t.Error("PreApplyError must unwrap to its cause")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("PreApplyError.Error() must not be empty")
+	}
+	var pe *PreApplyError
+	if !errors.As(error(err), &pe) {
+		t.Error("errors.As must reach *PreApplyError")
+	}
+}

--- a/reconcile.go
+++ b/reconcile.go
@@ -37,8 +37,11 @@ type options struct {
 
 	// preApply is the gate run before a candidate snapshot becomes current,
 	// typed per T and stored as any for the same reason onChange below is;
-	// Watch[T] asserts it back to a concrete type. preApplyTimeout bounds it
-	// (see WithPreApplyTimeout for why that bound is mandatory).
+	// Watch[T] and loadValue (reconcile.go) each assert it back to a concrete
+	// type via the shared typedPreApply[T] helper - loadValue is the only
+	// assertion Load ever gets, since Load has no Watch-side check of its own.
+	// preApplyTimeout bounds it (see WithPreApplyTimeout for why that bound is
+	// mandatory).
 	preApply        any
 	preApplyTimeout time.Duration
 
@@ -221,6 +224,19 @@ func Load[T any](ctx context.Context, opts ...Option) (T, error) {
 // detection in Watch).
 func loadValue[T any](ctx context.Context, o *options) (T, []resolved, error) {
 	var cfg T
+
+	// Checked before any provider round trip, for the same reason Watch checks
+	// it before calling loadValue at all (see typedPreApply's doc comment):
+	// a hook typed for the wrong T is a caller bug that should fail loudly and
+	// immediately, not after fields have already been resolved. This duplicates
+	// Watch's own check for the Watch path (harmless: same nil-or-error result
+	// either time), but it is the ONLY check for Load, which has no earlier
+	// point of its own to catch this.
+	hook, err := typedPreApply[T](o)
+	if err != nil {
+		return cfg, nil, err
+	}
+
 	t := reflect.TypeOf(cfg)
 	specs, err := fieldSpecs(t, o.refVars)
 	if err != nil {
@@ -236,6 +252,42 @@ func loadValue[T any](ctx context.Context, o *options) (T, []resolved, error) {
 	if err := o.validator.Validate(cfg); err != nil {
 		return cfg, nil, &ValidationError{Err: err}
 	}
+
+	// Gate the initial configuration too (decision D7): a hook that verifies a
+	// credential should verify the first one, so a credential that does not
+	// work fails at startup (Watch) or on the spot (Load) rather than at the
+	// first rotation. Old is the zero value of T here, since nothing was
+	// serving yet.
+	//
+	// Fields is populated, not left nil, and it is populated by applying the
+	// engine's own diff rule (buildCandidate, reconciler.go) against the true
+	// prior state at this point in time: e.applied does not exist yet (Watch
+	// only seeds it after loadValue returns), so the prior version for every
+	// field is the empty string, and buildCandidate already treats a missing
+	// applied entry and an explicit "" identically (see flush's own comment on
+	// that equivalence). Applying that same rule here yields one FieldChange
+	// per resolved field, each with OldVersion "" - exactly what buildCandidate
+	// would compute one instant later, were e.applied queried before Watch
+	// seeds it. This is what makes ev.Changed(path) true for every field set on
+	// this load, which is what lets a hook written the documented way (guard on
+	// ev.Changed before doing the I/O) verify the initial configuration at all
+	// - the entire point of D7. See TestPreApplyInitialLoadPopulatesFields.
+	//
+	// This is the only place either Load or Watch's initial resolve runs the
+	// gate: Watch stores this call's result directly into the engine's
+	// lastGood/cfg without a further gate of its own (see Watch in
+	// reconciler.go), so gating here costs exactly one hook invocation for the
+	// initial configuration, not two.
+	var fields []FieldChange
+	for _, r := range res {
+		if r.set {
+			fields = append(fields, FieldChange{Path: r.spec.Path, NewVersion: r.value.Version})
+		}
+	}
+	if err := runPreApply(ctx, hook, o.preApplyTimeout, Change[T]{New: cfg, Fields: fields}); err != nil {
+		return cfg, nil, err
+	}
+
 	return cfg, res, nil
 }
 

--- a/reconcile.go
+++ b/reconcile.go
@@ -284,7 +284,14 @@ func loadValue[T any](ctx context.Context, o *options) (T, []resolved, error) {
 			fields = append(fields, FieldChange{Path: r.spec.Path, NewVersion: r.value.Version})
 		}
 	}
-	if err := runPreApply(ctx, hook, o.preApplyTimeout, Change[T]{New: cfg, Fields: fields}); err != nil {
+	// The reentrancy mark is nil here, and that is not an oversight: this gate
+	// runs on the CALLER's goroutine, inside Load or inside Watch before it has
+	// constructed a Watcher at all. There is no reconciler goroutine yet and no
+	// control channel to send on, so there is nothing a hook could reenter -
+	// a hook reaching for the Watcher this load is producing can only find the
+	// nil it has not been assigned yet. Only flush's gate, which runs on the
+	// reconciler goroutine itself, needs the mark (see reconciler.go).
+	if err := runPreApply(ctx, hook, o.preApplyTimeout, Change[T]{New: cfg, Fields: fields}, nil); err != nil {
 		return cfg, nil, err
 	}
 

--- a/reconcile.go
+++ b/reconcile.go
@@ -35,6 +35,13 @@ type options struct {
 	historyN     int               // snapshots retained beyond the current one; 0 = current only
 	refVars      map[string]string // ${VAR} expansion for source tags; nil means none
 
+	// preApply is the gate run before a candidate snapshot becomes current,
+	// typed per T and stored as any for the same reason onChange below is;
+	// Watch[T] asserts it back to a concrete type. preApplyTimeout bounds it
+	// (see WithPreApplyTimeout for why that bound is mandatory).
+	preApply        any
+	preApplyTimeout time.Duration
+
 	// admin server config, consumed only by Watch (see adminhttp.go). Load
 	// accepts the same Option values but has no watcher to run a server
 	// against, so it ignores all three.
@@ -57,15 +64,16 @@ type options struct {
 // have changed the retry cadence of every existing caller. See WithBackoff.
 func defaultOptions() *options {
 	return &options{
-		providers:    map[string]Provider{},
-		validator:    defaultValidator(),
-		clock:        SystemClock(),
-		pollInterval: defaultPollInterval,
-		jitter:       defaultJitter,
-		debounce:     defaultDebounce,
-		queueDepth:   defaultQueueDepth,
-		meter:        noopMeter{},
-		tracer:       noopTracer{},
+		providers:       map[string]Provider{},
+		validator:       defaultValidator(),
+		clock:           SystemClock(),
+		pollInterval:    defaultPollInterval,
+		jitter:          defaultJitter,
+		debounce:        defaultDebounce,
+		queueDepth:      defaultQueueDepth,
+		meter:           noopMeter{},
+		tracer:          noopTracer{},
+		preApplyTimeout: defaultPreApplyTimeout,
 	}
 }
 

--- a/reconciler.go
+++ b/reconciler.go
@@ -93,6 +93,20 @@ type Watcher[T any] struct {
 	// separate "closed" signal needed to get the same guarantee.
 	ctx context.Context
 
+	// inPreApply holds the ID of the goroutine currently running a PreApply
+	// hook for this watcher, and 0 whenever no hook is running - which is
+	// always, for a watcher with no gate installed. Only flush arms it (see
+	// runPreApply's mark parameter), so it names the reconciler goroutine and
+	// no other; sendPin is the only reader.
+	//
+	// It is a goroutine ID rather than a bool because the two questions are not
+	// the same one. "Is a hook running" is true for every caller in the process
+	// while a hook runs, and refusing all of them would break correct code that
+	// merely overlapped a rotation. "Is the caller the goroutine that is inside
+	// the hook" is true only for the caller that is genuinely waiting on itself,
+	// which is exactly the set that can never be answered.
+	inPreApply atomic.Uint64
+
 	// adminServer and adminAddrVal are set only when WithAdminHTTP was given to
 	// Watch (see adminhttp.go); both are nil/unset otherwise. adminServer is
 	// used by Close to shut the server down; adminAddrVal backs AdminAddr.
@@ -1098,7 +1112,7 @@ func (e *engine[T]) flush(ctx context.Context, pending map[string]struct{}) {
 		Old:    e.lastGood,
 		New:    cand,
 		Fields: fields,
-	}); err != nil {
+	}, &e.w.inPreApply); err != nil {
 		for _, f := range fields {
 			e.applied[f.Path] = f.OldVersion
 		}

--- a/reconciler.go
+++ b/reconciler.go
@@ -156,6 +156,35 @@ type srcState struct {
 	err   error // meaningful only when seen && err != nil; may wrap ErrNotFound
 }
 
+// typedPreApply asserts o.preApply back to a func(context.Context, Change[T])
+// error, the concrete type PreApply[T] actually stored (options is not
+// generic, so the field is held as any). It returns (nil, nil) when no hook
+// was installed at all, which is the common case.
+//
+// A hook written against some other T would make a bare comma-ok assertion
+// yield nil, and a nil gate is an OPEN gate: the hook would never be called,
+// no error would ever be emitted, and every rotation (or, on the initial load,
+// the very first configuration) would be applied unverified while the caller
+// believed it had been proven to work first. For onChange the same kind of
+// mismatch costs a dropped notification and the application keeps serving
+// correct configuration; for a gate whose only job is refusing credentials
+// that do not work, silence is the worst available outcome. So this returns a
+// loud error instead, wrapping ErrInvalid and naming both types, and is shared
+// by every caller that can observe this mismatch (Watch, and loadValue for
+// both Load and Watch's initial resolve) so none of them can drift into
+// tolerating it via their own bare assertion.
+func typedPreApply[T any](o *options) (func(context.Context, Change[T]) error, error) {
+	if o.preApply == nil {
+		return nil, nil
+	}
+	fn, ok := o.preApply.(func(context.Context, Change[T]) error)
+	if !ok {
+		var want func(context.Context, Change[T]) error
+		return nil, fmt.Errorf("mamori: PreApply hook has type %T, want %T: %w", o.preApply, want, ErrInvalid)
+	}
+	return fn, nil
+}
+
 // Watch performs an initial, fail-fast Load of T and then keeps it reconciled at
 // runtime, delivering validated, diff-aware updates to OnChange. It returns after
 // the initial configuration is resolved (OnChange fires only on subsequent
@@ -166,29 +195,19 @@ func Watch[T any](ctx context.Context, opts ...Option) (*Watcher[T], error) {
 		opt(o)
 	}
 
-	// The PreApply hook is stored as any (options is not generic) and asserted
-	// back to this T here. The mechanism is onChange's, below; the outcome on a
-	// mismatch deliberately is NOT.
-	//
-	// A hook written against some other T yields nil from the assertion, and a
-	// nil gate is an OPEN gate: the hook would never be called, no error would
-	// ever be emitted, and every rotation would be applied unverified while the
-	// caller believed each one had been proven to work first. For onChange the
-	// same mismatch costs a dropped notification and the application keeps
-	// serving correct configuration; for a gate whose only job is refusing
-	// credentials that do not work, silence is the worst available outcome, so
-	// this one fails Watch outright rather than proceeding ungated. Option is
-	// untyped by construction, so Watch is the only place the mismatch can be
-	// caught at all - and catching it before the initial Load means a typo
-	// costs no provider round trips.
-	var preApply func(context.Context, Change[T]) error
-	if o.preApply != nil {
-		fn, ok := o.preApply.(func(context.Context, Change[T]) error)
-		if !ok {
-			var want func(context.Context, Change[T]) error
-			return nil, fmt.Errorf("mamori: PreApply hook has type %T, want %T: %w", o.preApply, want, ErrInvalid)
-		}
-		preApply = fn
+	// Checked here, before loadValue, so that a mismatched hook is caught
+	// before any provider round trip is spent resolving fields - see
+	// typedPreApply's doc comment for why the mismatch is fatal rather than
+	// tolerated. loadValue itself is called just below (for the initial Load)
+	// and now also runs this same check as part of gating that Load's result
+	// (decision D7); asserting it here again is what buys Watch this earlier,
+	// round-trip-free failure on top of that, not a substitute for it. This
+	// call is also where preApply, below, comes from: it is the value stored
+	// into the engine (e.preApply) for every flush after the initial one, not
+	// merely a discarded probe.
+	preApply, err := typedPreApply[T](o)
+	if err != nil {
+		return nil, err
 	}
 
 	cfg, initial, err := loadValue[T](ctx, o)

--- a/reconciler.go
+++ b/reconciler.go
@@ -3,6 +3,7 @@ package mamori
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"reflect"
@@ -165,6 +166,31 @@ func Watch[T any](ctx context.Context, opts ...Option) (*Watcher[T], error) {
 		opt(o)
 	}
 
+	// The PreApply hook is stored as any (options is not generic) and asserted
+	// back to this T here. The mechanism is onChange's, below; the outcome on a
+	// mismatch deliberately is NOT.
+	//
+	// A hook written against some other T yields nil from the assertion, and a
+	// nil gate is an OPEN gate: the hook would never be called, no error would
+	// ever be emitted, and every rotation would be applied unverified while the
+	// caller believed each one had been proven to work first. For onChange the
+	// same mismatch costs a dropped notification and the application keeps
+	// serving correct configuration; for a gate whose only job is refusing
+	// credentials that do not work, silence is the worst available outcome, so
+	// this one fails Watch outright rather than proceeding ungated. Option is
+	// untyped by construction, so Watch is the only place the mismatch can be
+	// caught at all - and catching it before the initial Load means a typo
+	// costs no provider round trips.
+	var preApply func(context.Context, Change[T]) error
+	if o.preApply != nil {
+		fn, ok := o.preApply.(func(context.Context, Change[T]) error)
+		if !ok {
+			var want func(context.Context, Change[T]) error
+			return nil, fmt.Errorf("mamori: PreApply hook has type %T, want %T: %w", o.preApply, want, ErrInvalid)
+		}
+		preApply = fn
+	}
+
 	cfg, initial, err := loadValue[T](ctx, o)
 	if err != nil {
 		return nil, err
@@ -173,15 +199,6 @@ func Watch[T any](ctx context.Context, opts ...Option) (*Watcher[T], error) {
 	var onChange func(Change[T])
 	if o.onChange != nil {
 		onChange, _ = o.onChange.(func(Change[T]))
-	}
-
-	// The PreApply hook is stored as any (options is not generic) and asserted
-	// back here exactly the way onChange just was, including the deliberate
-	// non-panicking form: a hook installed for some other T yields nil rather
-	// than a runtime panic, which is the same trade onChange already makes.
-	var preApply func(context.Context, Change[T]) error
-	if o.preApply != nil {
-		preApply, _ = o.preApply.(func(context.Context, Change[T]) error)
 	}
 
 	specs := make([]fieldSpec, len(initial))
@@ -267,10 +284,13 @@ type engine[T any] struct {
 	specs    []fieldSpec
 	onChange func(Change[T])
 	// preApply gates a candidate before it becomes current (see flush). It is
-	// typed here the same way onChange above is, and is nil when the caller
-	// installed no hook - which is the whole cost of the gate on that path,
-	// since runPreApply's own nil check is all flush spends before returning
-	// to the swap.
+	// typed here the same way onChange above is, though Watch refuses a
+	// mismatched hook rather than tolerating the nil this would otherwise
+	// leave (see the assertion there). It is nil only when the caller
+	// installed no hook, and the gate then costs a flush that has changes one
+	// nil check inside runPreApply plus the Change[T] literal flush builds
+	// anyway - arguments are evaluated before the call, so those two copies of
+	// T are paid hook or no hook.
 	preApply func(context.Context, Change[T]) error
 
 	// updated only by the reconciler goroutine:
@@ -1036,7 +1056,12 @@ func (e *engine[T]) flush(ctx context.Context, pending map[string]struct{}) {
 	// The next flush would diff the rejected version against itself, come up
 	// empty, and return ok == false. The rejected value would never be retried,
 	// no further error would ever be emitted, and Get would serve the
-	// superseded configuration indefinitely while Status called it healthy.
+	// superseded configuration indefinitely. (Status reports the watcher
+	// healthy through a refusal either way: emitErr does not set e.lastErr, so
+	// buildReport sees nothing wrong, exactly as it does not for a validation
+	// failure. What the rollback restores is the retry, and with it an error on
+	// every subsequent attempt; without it even the errors stop, which is what
+	// makes the staleness silent rather than merely undesired.)
 	//
 	// And the refused value is not withdrawn from e.observed, so it stays in
 	// every candidate built afterwards. Hidden from the diff, it rides into the

--- a/reconciler.go
+++ b/reconciler.go
@@ -175,6 +175,15 @@ func Watch[T any](ctx context.Context, opts ...Option) (*Watcher[T], error) {
 		onChange, _ = o.onChange.(func(Change[T]))
 	}
 
+	// The PreApply hook is stored as any (options is not generic) and asserted
+	// back here exactly the way onChange just was, including the deliberate
+	// non-panicking form: a hook installed for some other T yields nil rather
+	// than a runtime panic, which is the same trade onChange already makes.
+	var preApply func(context.Context, Change[T]) error
+	if o.preApply != nil {
+		preApply, _ = o.preApply.(func(context.Context, Change[T]) error)
+	}
+
 	specs := make([]fieldSpec, len(initial))
 	for i, r := range initial {
 		specs[i] = r.spec
@@ -197,6 +206,7 @@ func Watch[T any](ctx context.Context, opts ...Option) (*Watcher[T], error) {
 		blocked:   make(map[string]struct{}),
 		sources:   make([][]srcState, len(specs)),
 		onChange:  onChange,
+		preApply:  preApply,
 		lastGood:  cfg,
 		version:   1, // initial snapshot
 		controlCh: w.control,
@@ -256,6 +266,12 @@ type engine[T any] struct {
 	o        *options
 	specs    []fieldSpec
 	onChange func(Change[T])
+	// preApply gates a candidate before it becomes current (see flush). It is
+	// typed here the same way onChange above is, and is nil when the caller
+	// installed no hook - which is the whole cost of the gate on that path,
+	// since runPreApply's own nil check is all flush spends before returning
+	// to the swap.
+	preApply func(context.Context, Change[T]) error
 
 	// updated only by the reconciler goroutine:
 	observed map[string]Value  // latest value seen per path (always advances)
@@ -600,7 +616,7 @@ func (e *engine[T]) loop(ctx context.Context, updates <-chan srcUpdate) {
 			e.w.report.Store(e.buildReport())
 
 		case <-timerC:
-			e.flush(pending)
+			e.flush(ctx, pending)
 			pending = map[string]struct{}{}
 			disarm()
 			e.w.report.Store(e.buildReport())
@@ -972,20 +988,77 @@ func (e *engine[T]) buildCandidate() (cand T, fields []FieldChange, ok bool) {
 	return cand, fields, true
 }
 
-// flush builds a candidate from all observed values, validates it, and either
-// applies it (emitting a Change) or rejects it (emitting OnError). Building,
-// validating, advancing the version, and recording history all happen
-// whether or not the watcher is pinned: pinning only changes what happens
-// after that. While pinned, the candidate is not stored to cfg and no Change
-// is enqueued, so Get stays frozen and OnChange stays silent; Unpin later
-// applies the newest such candidate and emits one Change coalescing
-// everything that changed while pinned (see handlePin's unpin case).
-func (e *engine[T]) flush(pending map[string]struct{}) {
+// flush builds a candidate from all observed values, validates it, puts it
+// past the PreApply gate, and then either applies it (emitting a Change) or
+// rejects it (emitting OnError). Building, validating, gating, advancing the
+// version, and recording history all happen whether or not the watcher is
+// pinned: pinning only changes what happens after that. While pinned, the
+// candidate is not stored to cfg and no Change is enqueued, so Get stays
+// frozen and OnChange stays silent; Unpin later applies the newest such
+// candidate and emits one Change coalescing everything that changed while
+// pinned (see handlePin's unpin case).
+//
+// ctx is the reconciler's own context (loop's, which is Watch's wctx). It is
+// threaded in rather than held on the engine because the gate is the first
+// thing here that can block: cancelling the watcher has to release a hook
+// waiting on an unresponsive backend, rather than leaving Close to wait out
+// the hook's full budget.
+func (e *engine[T]) flush(ctx context.Context, pending map[string]struct{}) {
 	if len(pending) == 0 {
 		return
 	}
 	cand, fields, ok := e.buildCandidate()
 	if !ok {
+		return
+	}
+
+	// Gate the candidate before anything observable changes. This runs after
+	// buildCandidate, because validation is pure and cheap and rejects far more
+	// candidates than a live check ever will, and before the version bump, the
+	// history record and the swap, so a network round trip is only ever spent
+	// on a candidate whose shape is already known good and a refusal costs
+	// exactly what a validation failure costs: one OnError delivery, and
+	// nothing else moves.
+	//
+	// It runs on the pinned branch too, on purpose. A pin freezes what Get
+	// returns; it does not stop Live advancing, and Unpin applies the newest
+	// such candidate wholesale without any gating of its own (see handlePin's
+	// unpin case). Gating only while unpinned would make Unpin the one path
+	// that can publish a snapshot nothing ever verified. Note that Old is
+	// therefore the live snapshot this candidate supersedes, which while
+	// pinned is not the one Get is currently serving.
+	//
+	// The rollback is not defensive coding, and it is not removable.
+	// buildCandidate advanced e.applied to the new version for every field in
+	// fields, as a side effect, before returning. Leaving it advanced past a
+	// value that was refused breaks the engine in two ways at once:
+	//
+	// The next flush would diff the rejected version against itself, come up
+	// empty, and return ok == false. The rejected value would never be retried,
+	// no further error would ever be emitted, and Get would serve the
+	// superseded configuration indefinitely while Status called it healthy.
+	//
+	// And the refused value is not withdrawn from e.observed, so it stays in
+	// every candidate built afterwards. Hidden from the diff, it rides into the
+	// next unrelated field's flush past a hook written the way PreApply's own
+	// documentation recommends - verify only what Changed - and reaches Get
+	// having been verified by nothing.
+	//
+	// Each FieldChange carries the OldVersion this needs, which is why the diff
+	// itself undoes the mutation rather than a separate copy of the map taken
+	// beforehand. Restoring an OldVersion of "" writes an empty entry where a
+	// field may have had no entry at all; every reader of e.applied compares it
+	// with ==, and a missing key reads as "" too, so the two are
+	// indistinguishable.
+	if err := runPreApply(ctx, e.preApply, e.o.preApplyTimeout, Change[T]{
+		Old:    e.lastGood,
+		New:    cand,
+		Fields: fields,
+	}); err != nil {
+		for _, f := range fields {
+			e.applied[f.Path] = f.OldVersion
+		}
+		e.emitErr(err)
 		return
 	}
 

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -37,6 +37,7 @@ const groups = [
       { slug: "usage", title: "Loading & watching" },
       { slug: "usage/watching", title: "Watching", indent: true },
       { slug: "usage/snapshots", title: "Snapshots & pinning", indent: true },
+      { slug: "usage/rotation", title: "Rotation safety", indent: true },
       { slug: "validation", title: "Validation" },
     ],
   },

--- a/site/src/pages/docs/usage/index.md
+++ b/site/src/pages/docs/usage/index.md
@@ -71,6 +71,7 @@ Batch-capable providers (for example AWS Secrets Manager) are resolved in a sing
 - [Watch for changes](/docs/usage/watching/) - `Watch`, `Get`, `OnChange`, and `OnError`.
 - [Source chains](/docs/concepts/source-chains/) - comma-separated precedence and the `onfail` policy.
 - [Snapshots and pinning](/docs/usage/snapshots/) - `Status`, `WithHistory`, and `Pin` / `Unpin`.
+- [Rotation safety](/docs/usage/rotation/) - `PreApply`, a gate that proves a rotated credential works before it becomes current.
 
 ## See also
 

--- a/site/src/pages/docs/usage/rotation.md
+++ b/site/src/pages/docs/usage/rotation.md
@@ -1,0 +1,128 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Rotation safety
+---
+
+# Rotation safety
+
+`PreApply` proves a rotated value actually works before it becomes the config your application serves, instead of finding out in the request path. Reach for it whenever struct validation cannot tell you whether a credential is *good*, only whether it is *well-formed*.
+
+## The problem: OnChange is a notification, not a gate
+
+By the time `OnChange` runs, `Get()` already returns the new value:
+
+```go
+w, err := mamori.Watch[Config](ctx,
+	mamori.OnChange(func(ev mamori.Change[Config]) {
+		if ev.Changed("DBPassword") {
+			pool.Rotate(ev.New.DBPassword.Reveal()) // too late if this password is wrong
+		}
+	}),
+)
+```
+
+If the rotated `DBPassword` does not actually open a connection, every concurrent `Get()` caller is already serving it. Validation cannot catch this: a syntactically fine password that the database rejects passes `validate:"required"` without complaint. What's missing is a check that runs *before* the swap and can say no.
+
+## Quick start
+
+`PreApply` runs after struct validation and before the atomic swap. Returning an error rejects the candidate:
+
+```go
+w, err := mamori.Watch[Config](ctx,
+	mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+		if !ev.Changed("DBPassword") {
+			return nil
+		}
+		return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+	}),
+	mamori.OnError(func(err error) {
+		var perr *mamori.PreApplyError
+		if errors.As(err, &perr) {
+			metrics.Inc("config_rejected")
+			return
+		}
+		metrics.Inc("config_error")
+	}),
+)
+if err != nil {
+	log.Fatal(err)
+}
+defer w.Close()
+```
+
+The `ev.Changed("DBPassword")` guard matters: without it, the hook re-pings the database on every unrelated field change (a log level, a worker count) instead of only when the credential it cares about actually rotated.
+
+## What a rejection does
+
+Returning a non-nil error from the hook rejects the candidate outright:
+
+- `Get()` keeps returning the last valid config; the rejected candidate is discarded.
+- `OnChange` does not fire.
+- `OnError` receives a `*PreApplyError` wrapping the hook's own error (or `context.DeadlineExceeded` on timeout, below).
+- The engine's per-ref state is not rewound. The next upstream change or poll produces a fresh candidate and the hook runs again. There is no periodic retry of the rejected value on its own; it is re-gated only on the next change.
+
+## The timeout is mandatory, and exceeding it is a rejection
+
+`WithPreApplyTimeout` bounds how long a hook may run, defaulting to 10 seconds:
+
+```go
+mamori.WithPreApplyTimeout(30 * time.Second)
+```
+
+The bound cannot be removed. The hook runs on the reconciler goroutine, the same goroutine that services every other field's updates, publishes `Status`, and handles pin/unpin commands. An unbounded hook (one stuck on a hanging backend) would wedge all of that, not just its own check.
+
+Exceeding the budget is a **rejection, not an acceptance**. On timeout, mamori does not know whether the candidate actually works, and applying it anyway would defeat the point of having a gate at all. A hook that always times out therefore stalls updates loudly, once per attempt, rather than quietly serving unverified configuration.
+
+## Do not call back into the same Watcher
+
+The hook runs on the reconciler goroutine, which is what lets it block the swap in the first place. That has one consequence you have to design around: `Get()` is a lock-free atomic load, so it is safe to call from inside the hook, but `Pin`, `PinCurrent`, and `Unpin` are commands sent to, and serviced by, that very same goroutine. Calling one of them from inside a `PreApply` hook blocks the hook forever waiting for a reply that only the goroutine it is currently occupying could ever send.
+
+`WithPreApplyTimeout` does not rescue this. The timeout only cancels the `ctx` handed to the hook; `Pin`, `PinCurrent`, and `Unpin` take no `ctx` at all, so there is nothing for the timeout to cancel on their side. A hook stuck this way wedges the whole watcher, not just its own check, until something outside the hook cancels the watcher, typically `w.Close()` or the parent context passed to `Watch`.
+
+```go
+mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+	_ = w.Get()    // fine: a lock-free atomic load, safe from inside the hook
+	w.PinCurrent() // do not do this: wedges the watcher, not bounded by the timeout
+	return nil
+})
+```
+
+If a hook needs to compare against something other than `ev.Old` or `ev.New`, keep a reference outside the `Watcher` rather than asking the watcher for it mid-hook.
+
+## Runs on the initial load too
+
+`PreApply` gates `Watch`'s initial resolve and every call to `Load`, not only later rotations. A rejection on that first load makes `Watch` and `Load` return the `*PreApplyError` with no watcher started, exactly as a validation failure would.
+
+`ev.Fields` is populated on this first call too: it lists every field that resolved to a value, so `ev.Changed("DBPassword")` is `true` for each field set at startup. That is what makes the guard pattern above verify the very first configured credential, not just later rotations. `ev.Old` is the zero value of `T` on this call, since nothing was serving before it.
+
+A hook typed for a different config than the one passed to `Watch[T]` or `Load[T]` is a caller bug, and it fails loudly: `Watch` and `Load` return an error wrapping `ErrInvalid` rather than silently running with the gate open.
+
+## The credential-overlap pattern
+
+A service that *accepts* incoming credentials, rather than presenting them, has a narrower problem: during a rotation window, both the old and new credential are momentarily valid, and a caller using either one should be accepted. `WithHistory(1)` plus `w.History()` already covers this; no dual-credential machinery is needed.
+
+```go
+w, _ := mamori.Watch[Config](ctx, mamori.WithHistory(1))
+
+func accept(presented string) bool {
+	for _, s := range w.History() { // current, then previous
+		if subtle.ConstantTimeCompare(
+			[]byte(presented), []byte(s.Config.APIKey.Reveal())) == 1 {
+			return true
+		}
+	}
+	return false
+}
+```
+
+State the cost as plainly as the benefit: a retained snapshot holds a full copy of `T`, including whatever secret material it carried, for as long as it stays in the history window. Enabling history keeps a rotated-out credential reachable in process memory for exactly as long as you retain it, which is why `WithHistory` defaults to `0`. `WithHistory(1)` is the right setting for this pattern specifically because it is the smallest window that covers the overlap; a larger `n` widens the overlap and the exposure together. See [Snapshots and pinning](/docs/usage/snapshots/#retaining-snapshots-with-withhistory) for `WithHistory` itself.
+
+## Forcing an immediate refresh
+
+A way to force mamori to re-resolve right now, ahead of the next poll, is not available yet in this release.
+
+## See also
+
+- [Watch for changes](/docs/usage/watching/) for `Watch`, `Get`, `OnChange`, and `OnError`.
+- [Snapshots and pinning](/docs/usage/snapshots/) for `WithHistory`, `History`, and pinning.
+- [Loading and watching](/docs/usage/) for the option walkthrough.

--- a/site/src/pages/docs/usage/rotation.md
+++ b/site/src/pages/docs/usage/rotation.md
@@ -75,19 +75,34 @@ Exceeding the budget is a **rejection, not an acceptance**. On timeout, mamori d
 
 ## Do not call back into the same Watcher
 
-The hook runs on the reconciler goroutine, which is what lets it block the swap in the first place. That has one consequence you have to design around: `Get()` is a lock-free atomic load, so it is safe to call from inside the hook, but `Pin`, `PinCurrent`, and `Unpin` are commands sent to, and serviced by, that very same goroutine. Calling one of them from inside a `PreApply` hook blocks the hook forever waiting for a reply that only the goroutine it is currently occupying could ever send.
+The hook runs on the reconciler goroutine, which is what lets it block the swap in the first place. That has one consequence you have to design around: `Get()` is a lock-free atomic load, so it is safe to call from inside the hook, but `Pin`, `PinCurrent`, and `Unpin` are commands sent to, and serviced by, that very same goroutine. Calling one of them from inside a `PreApply` hook asks for a reply that only the goroutine it is currently occupying could ever send.
 
-`WithPreApplyTimeout` does not rescue this. The timeout only cancels the `ctx` handed to the hook; `Pin`, `PinCurrent`, and `Unpin` take no `ctx` at all, so there is nothing for the timeout to cancel on their side. A hook stuck this way wedges the whole watcher, not just its own check, until something outside the hook cancels the watcher, typically `w.Close()` or the parent context passed to `Watch`.
+`WithPreApplyTimeout` does not rescue this. The timeout only cancels the `ctx` handed to the hook; `Pin`, `PinCurrent`, and `Unpin` take no `ctx` at all, so there is nothing for the timeout to cancel on their side.
+
+**mamori detects this and fails the call instead.** Until it did, a hook stuck this way wedged the whole watcher permanently, not just its own check: no reconciliation, no `OnChange`, no `OnError`, nothing until something outside the hook cancelled the watcher (`w.Close()`, or the parent context passed to `Watch`). Now the call returns immediately, changes no pin state, and the hook carries on:
+
+| Called from inside a hook | Result |
+| --- | --- |
+| `Get()` | Works, and is the supported way to read from a hook. Returns the snapshot this candidate would supersede, since the swap has not happened yet. |
+| `Pin(v)` | Returns `ErrReentrantCall`. Nothing is pinned. |
+| `PinCurrent()` | Returns `0`. Versions start at 1, so `0` never collides with a real one. Nothing is pinned. |
+| `Unpin()` | Does nothing. Its signature has no error to return, so it leaves the watcher pinned and `Pinned()` still reports so. |
 
 ```go
 mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
-	_ = w.Get()    // fine: a lock-free atomic load, safe from inside the hook
-	w.PinCurrent() // do not do this: wedges the watcher, not bounded by the timeout
+	_ = w.Get() // fine: a lock-free atomic load, safe from inside the hook
+
+	// Refused, not hung: returns ErrReentrantCall at once and pins nothing.
+	if err := w.Pin(1); errors.Is(err, mamori.ErrReentrantCall) {
+		// call Pin from another goroutine instead
+	}
 	return nil
 })
 ```
 
-If a hook needs to compare against something other than `ev.Old` or `ev.New`, keep a reference outside the `Watcher` rather than asking the watcher for it mid-hook.
+The detection keys on *which* goroutine is inside the hook, not merely that one is. A `Pin` issued from an unrelated goroutine that happens to overlap a running hook is not affected: it waits for the reconciler to come free and is then serviced normally, exactly as before.
+
+If a hook needs to compare against something other than `ev.Old` or `ev.New`, keep a reference outside the `Watcher` rather than asking the watcher for it mid-hook. Detection turns a hang into a diagnosable error; it does not make the call work.
 
 ## Runs on the initial load too
 

--- a/site/src/pages/docs/usage/snapshots.md
+++ b/site/src/pages/docs/usage/snapshots.md
@@ -60,6 +60,8 @@ for _, snap := range w.History() {
 
 Retained snapshots hold a full copy of `T`, including any `secret.String` / `secret.Bytes` field's value at that version, even after the live config has since rotated that field away. Enabling history extends how long old secret material stays reachable in process memory, which is why `WithHistory` defaults to `0` (off). Read [Security](/docs/security/#withhistory-retains-past-secrets-in-memory) before enabling it in a service that handles credentials, and size `n` to the operational need you actually have.
 
+`WithHistory(1)` is also what a service validating *incoming* credentials during a rotation overlap needs, accepting either the current or the just-rotated-out value for the window both are momentarily valid. See [Rotation safety](/docs/usage/rotation/#the-credential-overlap-pattern) for the pattern and its memory cost.
+
 ## Pin and unpin during a rollout
 
 During a rollout you often want the config to hold still while you investigate, without stopping the watcher: sources keep being watched and reconciled, but whatever `Get()` returns should not shift under you mid-investigation.

--- a/site/src/pages/docs/usage/watching.md
+++ b/site/src/pages/docs/usage/watching.md
@@ -64,6 +64,7 @@ mamori.OnError(func(err error) {
 These behaviors are guaranteed and covered by the conformance kit.
 
 - **Validated, all-or-nothing updates.** `OnChange` fires with a fully re-validated snapshot. If a new value fails validation the update is rejected: `Get()` keeps returning the last good config and `OnError` receives a `*ValidationError`.
+- **A gate before the swap, if you install one.** A candidate is built, then validated, then - if `PreApply` was installed - handed to it for a check that needs I/O (a rotated password actually opens a connection). Only after that gate passes does the atomic swap happen and `OnChange` fire. See [Rotation safety](/docs/usage/rotation/).
 - **OnChange is called one at a time.** Callbacks are serialized, so your callback never runs concurrently with itself. A slow callback delays the next event but never drops it in normal operation.
 - **Coalesced events.** Field changes within a debounce window (default 500ms, override per field with `?debounce=`) produce a single `Change`. A JSON secret with five keys rotating is one event, not five.
 - **Last-good on failure.** On a runtime resolve failure the last-good value is retained, `OnError` receives a `*ProviderError`, and the ref keeps being retried - on the poll interval by default, or with per-ref exponential backoff if you opt into it with [`WithBackoff`](#retry-backoff). `WithStale(maxAge)` escalates prolonged staleness to a hard `*StaleError`.

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -100,6 +100,24 @@ defer w.Close()
 cfg := w.Get() // latest fully-valid snapshot, safe to call anytime
 ```
 
+## Verify a rotated credential before it goes live
+
+`OnChange` fires after `Get()` already serves the new value - too late to refuse a credential that turns out not to work. `mamori.PreApply` installs a gate that runs after validation and before the atomic swap; returning an error rejects the candidate (`Get()` keeps the last good config, `OnChange` does not fire, `OnError` gets a `*PreApplyError`) and the check runs on the initial load too, so a bad configured credential fails `Watch`/`Load` at startup rather than at the first rotation.
+
+```go
+mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
+	if !ev.Changed("DBPassword") {
+		return nil // guard: only re-verify the field that actually rotated
+	}
+	return pool.Ping(ctx, ev.New.DBPassword.Reveal())
+})
+```
+
+Rules to hold onto:
+- `WithPreApplyTimeout` bounds the hook, defaulting to 10s. It cannot be disabled, and exceeding it is a **rejection**, not an acceptance - mamori does not know the candidate works, so it does not apply it.
+- The hook runs on the reconciler goroutine. `w.Get()` is lock-free and safe to call from inside it. `w.Pin`, `w.PinCurrent`, and `w.Unpin` are commands serviced by that same goroutine, so calling one from inside the hook blocks forever waiting for a reply only that same, currently-busy goroutine could send - and the timeout does not rescue this, since it only cancels the hook's `ctx`, which those methods do not take. Never call back into the same `Watcher` from a `PreApply` hook.
+- A hook typed for a different config than the one passed to `Watch[T]`/`Load[T]` fails `Watch` and `Load` outright (an error wrapping `ErrInvalid`), rather than silently leaving the gate open.
+
 ## Choosing a provider
 
 Pick the scheme, add its module, blank-import it. Common ones (see

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -115,7 +115,7 @@ mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
 
 Rules to hold onto:
 - `WithPreApplyTimeout` bounds the hook, defaulting to 10s. It cannot be disabled, and exceeding it is a **rejection**, not an acceptance - mamori does not know the candidate works, so it does not apply it.
-- The hook runs on the reconciler goroutine. `w.Get()` is lock-free and safe to call from inside it. `w.Pin`, `w.PinCurrent`, and `w.Unpin` are commands serviced by that same goroutine, so calling one from inside the hook blocks forever waiting for a reply only that same, currently-busy goroutine could send - and the timeout does not rescue this, since it only cancels the hook's `ctx`, which those methods do not take. Never call back into the same `Watcher` from a `PreApply` hook.
+- The hook runs on the reconciler goroutine. `w.Get()` is lock-free and safe to call from inside it. `w.Pin`, `w.PinCurrent`, and `w.Unpin` are commands serviced by that same goroutine, and the timeout does not rescue them, since it only cancels the hook's `ctx`, which those methods do not take. Never call back into the same `Watcher` from a `PreApply` hook. mamori detects it if you do, and refuses the call rather than hanging: `Pin` returns `ErrReentrantCall`, `PinCurrent` returns `0` (versions start at 1), and `Unpin` does nothing and leaves the watcher pinned. Calls from any other goroutine are unaffected.
 - A hook typed for a different config than the one passed to `Watch[T]`/`Load[T]` fails `Watch` and `Load` outright (an error wrapping `ErrInvalid`), rather than silently leaving the gate open.
 
 ## Choosing a provider


### PR DESCRIPTION
Implements sections 5 and 7 of `docs/superpowers/specs/2026-07-28-rotation-safety-design.md`. Fifth PR in the stack, on top of #60.

## The gap this closes

mamori's pitch is safe runtime rotation. But "validated" has meant only that the struct passes its `validate` tags, so a rotated database password that is syntactically fine and functionally wrong sails straight through: the swap happens, `OnChange` fires *after* the fact, and the application discovers the problem in its request path. `OnChange` is a notification, not a gate.

```go
w, err := mamori.Watch[Config](ctx,
    mamori.PreApply(func(ctx context.Context, ev mamori.Change[Config]) error {
        if !ev.Changed("DBPassword") {
            return nil
        }
        return pool.Ping(ctx, ev.New.DBPassword.Reveal())   // prove it works first
    }),
)
```

A rejection reuses the engine's existing outcome for "this candidate is not acceptable": `Get()` keeps the last valid config, `OnChange` stays silent, `OnError` receives a `*PreApplyError`. No new state, no new `Get()` semantics.

## Three decisions with teeth

**It runs on the reconciler goroutine**, because it must complete before the swap and the `OnChange` dispatch queue is *lossy by design* (`WithQueueDepth` drops the oldest event when full). A gate cannot ride a channel that is allowed to drop.

**So the timeout is mandatory and cannot be disabled**, defaulting to 10s. **Exceeding it is a rejection, not an acceptance**: on timeout mamori does not know whether the config works, and applying it anyway would defeat the entire feature. A permanently-hanging hook therefore stalls *updates*, loudly and once per attempt, rather than silently serving unverified config.

**It runs on the initial load too**, and a rejection fails `Watch` and `Load`. Discovering at startup that the configured credential does not work beats discovering it at the first rotation.

## Two things review caught that would have shipped broken

**A hook typed for the wrong `T` silently disabled the gate.** The first implementation copied `OnChange`'s non-panicking type assertion. For a dropped notification that trade is fine; for a safety gate it is a fail-open: the hook was called zero times, zero errors were emitted anywhere, and the value it was written to refuse went live. `Watch` and `Load` now both refuse it via a shared `typedPreApply` helper, so the two cannot drift.

**`ev.Fields` was nil on the initial load**, which made `ev.Changed` false for every field — so the guard pattern *this PR's own documentation recommends* returned early at startup and verified nothing. The gate would have shipped as a no-op for its default usage. It is now populated using the engine's own diff rule: at `loadValue` time no `applied` map exists yet, so every resolved field is a change from `""`, which is exactly what a missing applied entry already means everywhere else in this codebase.

## The subtle one: `e.applied` rollback

`buildCandidate` is **not pure** — it advances `e.applied` for every changed field as a side effect before returning. A rejection that left that advanced has two consequences, both proven by deleting the rollback and watching tests fail:

1. The next flush computes an empty diff, so the refused value is **never retried** and `Get()` serves stale config forever with no further errors.
2. Worse: the refused value stays in `e.observed` and rides into a later candidate built for an *unrelated* field. Because `e.applied` already matches its version, `ev.Changed` reports false for it, so a hook written the recommended way **waves the refused credential straight through**.

## Also in this PR

A correction to a claim this project made about its own behavior. The spec and doc comment said a hook calling back into the `Watcher` "deadlocks until the timeout fires." Verified false during implementation: `Pin`, `PinCurrent`, and `Unpin` take **no context**, and `sendPin` selects only on the control channel and the watcher's own `ctx`, so the send blocks and nothing releases it short of `Close`. The hook's timeout cannot help, because the hook is blocked inside `sendPin`, which never looks at the context it was given. That is a permanently wedged watcher, not a bounded stall, and the docs now say so.

## Notes

- The credential-overlap pattern needs no new machinery: `WithHistory(1)` plus `History()` already retains the previous validated snapshot. Documented, with its cost stated as plainly as its benefit, since retained snapshots hold rotated secrets in memory.
- No dual-credential types, no `?stage=` ref option, no retry policy. All deliberate non-goals.
- `Refresh` is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)