### PR TITLE
fix: make WithBackoff actually do something

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,71 @@
+package mamori
+
+import "time"
+
+// backoffState tracks one ref's consecutive-failure streak so the polling
+// adapter can space out its retries. It is owned by a single pollWatch
+// goroutine and never shared, so it needs no locking.
+//
+// The window is normalized once, at construction, rather than in WithBackoff:
+// every other Option in reconcile.go is a plain setter, and normalizing here
+// means a directly-constructed *options (tests, WatchRef) gets the same
+// clamping a caller going through WithBackoff does.
+type backoffState struct {
+	base     time.Duration
+	ceiling  time.Duration
+	failures int
+}
+
+// newBackoff reads the configured window off o and normalizes it.
+//
+// A base of zero or less disables backoff outright - that is the default, and
+// the shape a caller gets by passing WithBackoff(0, 0). A ceiling below the
+// base is raised to the base: the alternative reading, honoring a cap under
+// the base, would make every retry FASTER than the base the caller explicitly
+// asked for, which is the opposite of what capping means. That also gives
+// WithBackoff(d, 0) the sane meaning "retry every d while failing" instead of
+// unbounded exponential growth into hours.
+func newBackoff(o *options) *backoffState {
+	b := &backoffState{base: o.backoffBase, ceiling: o.backoffMax}
+	if b.base <= 0 {
+		return &backoffState{} // disabled
+	}
+	if b.ceiling < b.base {
+		b.ceiling = b.base
+	}
+	return b
+}
+
+// fail records one more consecutive failure.
+func (b *backoffState) fail() { b.failures++ }
+
+// reset ends the streak. It is called on every successful round trip with the
+// backend, which includes a not-found: absence is an answer, not a failure.
+func (b *backoffState) reset() { b.failures = 0 }
+
+// delay returns the retry delay for the current streak: base, doubled once per
+// consecutive failure beyond the first, held at the ceiling from then on.
+//
+// It returns 0 to mean "no backoff applies, use the normal poll interval",
+// which covers both a disabled window and a healthy ref. Callers must treat 0
+// as absence rather than as a zero-length delay.
+func (b *backoffState) delay() time.Duration {
+	if b.base <= 0 || b.failures <= 0 {
+		return 0
+	}
+	d := b.base
+	// Bounded by log2(ceiling/base) iterations, not by b.failures: a ref that
+	// has been failing for days must not cost a longer loop than one that just
+	// started. Returning at ceiling/2 is also what keeps the doubling from
+	// overflowing int64, since d <= ceiling/2 implies d*2 <= ceiling.
+	for i := 1; i < b.failures; i++ {
+		if d > b.ceiling/2 {
+			return b.ceiling
+		}
+		d *= 2
+	}
+	if d > b.ceiling {
+		d = b.ceiling
+	}
+	return d
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,589 @@
+package mamori
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+// backoffRef is the ref every test in this file polls. Nothing about it
+// matters except that it is stable across the fakes below.
+var backoffRef = Ref{Scheme: "bo", Path: "x"}
+
+// backoffOpts builds the options a cadence test needs: a fake clock, jitter
+// off so every armed delay is exact, a poll interval far away from any backoff
+// step so the two can never be confused for one another, and the backoff
+// window under test.
+func backoffOpts(clk *FakeClock, base, cap time.Duration) *options {
+	o := defaultOptions()
+	o.clock = clk
+	o.jitter = 0
+	o.pollInterval = 30 * time.Second
+	o.backoffBase, o.backoffMax = base, cap
+	return o
+}
+
+// expectErrThenDelay reads one error update off ch and returns the delay the
+// poll loop then arms.
+//
+// The read has to come first. pollWatch's emit sends on an unbuffered channel
+// and the loop only reaches its next NewTimer once that send completes, so a
+// test that blocks on the timer before draining the update deadlocks against
+// the goroutine it is waiting for.
+func expectErrThenDelay(t *testing.T, clk *FakeClock, ch <-chan Update) time.Duration {
+	t.Helper()
+	select {
+	case u, open := <-ch:
+		if !open {
+			t.Fatal("update channel closed, want an error update")
+		}
+		if u.Err == nil {
+			t.Fatalf("update = %+v, want an error", u)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no error update from the polling adapter")
+	}
+	blockUntilTimers(t, clk, 1)
+	return armedDelay(t, clk)
+}
+
+// drainClosed cancels a poll watch and drains its channel to closure, so
+// goleak sees the adapter goroutine exit.
+func drainClosed(cancel context.CancelFunc, ch <-chan Update) {
+	cancel()
+	for range ch { //nolint:revive // draining to closure is the point
+	}
+}
+
+// TestWithBackoffOptionTakesEffect is the regression test for WithBackoff
+// having been a dead option: it set options.backoffBase/backoffMax and nothing
+// in the engine ever read them, so a caller who asked for a 1s first retry got
+// the 30s poll interval instead.
+//
+// It is deliberately driven through the PUBLIC surface - WatchRef with
+// WithBackoff, not a hand-built *options - because that is the thing that was
+// broken. Against the dead option the first armed delay is 30s (the poll
+// interval) and this fails on the very first assertion.
+func TestWithBackoffOptionTakesEffect(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := WatchRef(ctx, p, backoffRef,
+		WithClock(clk),
+		WithJitter(0),
+		WithPollInterval(30*time.Second),
+		WithBackoff(time.Second, 4*time.Second),
+	)
+
+	if got := expectErrThenDelay(t, clk, ch); got != time.Second {
+		t.Fatalf("first retry delay = %v, want %v (the configured backoff base, not the poll interval)", got, time.Second)
+	}
+	clk.Advance(time.Second)
+	if got := expectErrThenDelay(t, clk, ch); got != 2*time.Second {
+		t.Fatalf("second retry delay = %v, want %v", got, 2*time.Second)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffGrowsAndCaps pins the growth curve: base, then a doubling per
+// consecutive failure, held at backoffMax from then on.
+func TestPollBackoffGrowsAndCaps(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+	o := backoffOpts(clk, time.Second, 8*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	// The first entry is the delay armed after the INITIAL resolve fails: a
+	// failed baseline is consecutive failure #1, not a free attempt.
+	want := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second, // capped
+		8 * time.Second, // stays capped
+		8 * time.Second,
+	}
+	for i, w := range want {
+		got := expectErrThenDelay(t, clk, ch)
+		if got != w {
+			t.Fatalf("retry delay after failure %d = %v, want %v", i+1, got, w)
+		}
+		clk.Advance(got)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffCapBelowBaseIsClampedUp covers the degenerate window a caller
+// can write by accident, WithBackoff(30s, 5s): a cap under the base is raised
+// to the base rather than silently making every retry 5s (which would be
+// FASTER than the base the caller asked for, the opposite of what a cap means).
+func TestPollBackoffCapBelowBaseIsClampedUp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+	o := backoffOpts(clk, 5*time.Second, time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	for i := range 3 {
+		got := expectErrThenDelay(t, clk, ch)
+		if got != 5*time.Second {
+			t.Fatalf("retry delay after failure %d = %v, want the base %v", i+1, got, 5*time.Second)
+		}
+		clk.Advance(got)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffResetsOnSuccess covers the other half of the contract: a
+// success ends the streak, the cadence returns to the poll interval, and a
+// later failure starts again from the base rather than resuming where the
+// previous streak left off.
+func TestPollBackoffResetsOnSuccess(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+	o := backoffOpts(clk, time.Second, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	if got := expectErrThenDelay(t, clk, ch); got != time.Second {
+		t.Fatalf("retry delay after failure 1 = %v, want %v", got, time.Second)
+	}
+	clk.Advance(time.Second)
+	if got := expectErrThenDelay(t, clk, ch); got != 2*time.Second {
+		t.Fatalf("retry delay after failure 2 = %v, want %v", got, 2*time.Second)
+	}
+
+	// The provider recovers.
+	p.setVal(Value{Bytes: []byte("v1"), Version: "1"})
+	p.setErr(nil)
+	clk.Advance(2 * time.Second)
+	drainOne(t, ch, "v1")
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != o.pollInterval {
+		t.Fatalf("delay after a successful resolve = %v, want the poll interval %v", got, o.pollInterval)
+	}
+
+	// Failing again restarts the curve from the base.
+	p.setErr(errors.New("boom again"))
+	clk.Advance(o.pollInterval)
+	if got := expectErrThenDelay(t, clk, ch); got != time.Second {
+		t.Fatalf("retry delay after the streak reset = %v, want the base %v", got, time.Second)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffIgnoresNotFound pins that ErrNotFound is absence, not
+// failure. The backend answered, so there is nothing to back off from, and
+// backing off would delay discovering a ref that gets provisioned later - the
+// "deploy the app, create the secret afterwards" workflow default:/optional:
+// exist to support. Not-found neither starts a streak nor survives one.
+func TestPollBackoffIgnoresNotFound(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: ErrNotFound}
+	o := backoffOpts(clk, time.Second, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	// pollWatch swallows not-found without emitting, so there is no update to
+	// drain: go straight to the timer the loop armed.
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != o.pollInterval {
+		t.Fatalf("delay after a not-found baseline = %v, want the poll interval %v", got, o.pollInterval)
+	}
+	clk.Advance(o.pollInterval)
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != o.pollInterval {
+		t.Fatalf("delay after a not-found poll = %v, want the poll interval %v", got, o.pollInterval)
+	}
+
+	// A real failure starts a streak...
+	p.setErr(errors.New("boom"))
+	clk.Advance(o.pollInterval)
+	if got := expectErrThenDelay(t, clk, ch); got != time.Second {
+		t.Fatalf("retry delay after a real failure = %v, want the base %v", got, time.Second)
+	}
+	// ...and a subsequent not-found ends it, because the backend answered.
+	p.setErr(ErrNotFound)
+	clk.Advance(time.Second)
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != o.pollInterval {
+		t.Fatalf("delay after not-found cleared the streak = %v, want the poll interval %v", got, o.pollInterval)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffDisabledByDefault is the upgrade-safety test. defaultOptions
+// leaves the backoff window at zero, so a caller who never passed WithBackoff
+// keeps exactly the pre-feature cadence: a failing ref is retried on the poll
+// interval, neither sooner nor later. Turning the previously-inert 1s/1m
+// default on would have made every existing deployment retry a just-failed
+// backend 30x faster for the first few seconds.
+func TestPollBackoffDisabledByDefault(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+
+	o := defaultOptions()
+	if o.backoffBase != 0 || o.backoffMax != 0 {
+		t.Fatalf("defaultOptions backoff = (%v, %v), want it off by default", o.backoffBase, o.backoffMax)
+	}
+	o.clock = clk
+	o.jitter = 0
+	o.pollInterval = 30 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	for i := range 3 {
+		got := expectErrThenDelay(t, clk, ch)
+		if got != o.pollInterval {
+			t.Fatalf("retry delay after failure %d = %v, want the unchanged poll interval %v", i+1, got, o.pollInterval)
+		}
+		clk.Advance(got)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffIsJittered covers design point 3. Backoff is randomized by
+// the same WithJitter fraction as the poll interval, because a shared backend
+// failing synchronizes every client's failure instant: unjittered exponential
+// backoff would then have the whole fleet retry in lockstep at base, 2*base,
+// 4*base, which is a synchronized retry storm aimed at a backend that is
+// already unhealthy.
+//
+// The bounds assertion is what catches jitter being applied to the poll
+// interval instead of to the backoff step (30s is nowhere near the +/-50% band
+// around 1s). The distinctness assertion is what catches jitter not being
+// applied at all; eight identical float64 draws from rand.Float64 is not a
+// realistic flake (the collision probability is on the order of 2^-52 per
+// pair), and no assertion here depends on wall-clock time.
+func TestPollBackoffIsJittered(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bo", err: errors.New("boom")}
+	o := backoffOpts(clk, time.Second, time.Second) // constant 1s step
+	o.jitter = 0.5
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+
+	seen := map[time.Duration]struct{}{}
+	for i := range 8 {
+		got := expectErrThenDelay(t, clk, ch)
+		if got < 500*time.Millisecond || got > 1500*time.Millisecond {
+			t.Fatalf("retry delay after failure %d = %v, outside the +/-50%% jitter band around the 1s backoff step (poll interval is %v)", i+1, got, o.pollInterval)
+		}
+		seen[got] = struct{}{}
+		clk.Advance(got)
+	}
+	if len(seen) < 2 {
+		t.Fatalf("every one of 8 backoff delays was identical (%v); jitter is not being applied to the backoff", seen)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestPollBackoffYieldsToLeaseRefreshOnlyWhenHealthy pins how backoff composes
+// with pollWatch's early-lease-refresh shortcut. The shortcut shortens the next
+// delay to ~90% of a Value.NotAfter lease's remaining life; left active during
+// a failure streak it would fight the backoff and win, and since the remaining
+// life shrinks on every pass it would converge into a tight retry loop at
+// exactly the moment the backend is least able to serve it. So the shortcut
+// applies only while the ref is healthy: once a streak is open the backoff
+// governs outright.
+func TestPollBackoffYieldsToLeaseRefreshOnlyWhenHealthy(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	start := clk.Now()
+	p := &pollFake{scheme: "bo", val: Value{
+		Bytes: []byte("lease1"), Version: "1", NotAfter: start.Add(10 * time.Second),
+	}}
+	o := backoffOpts(clk, time.Minute, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := pollWatch(ctx, p, backoffRef, o)
+	drainOne(t, ch, "lease1")
+
+	// Healthy: the lease shortcut still wins over the 30s poll interval.
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != 9*time.Second {
+		t.Fatalf("healthy delay = %v, want the 9s lease refresh", got)
+	}
+
+	// Failing: the 60s backoff governs, even though the lease shortcut would
+	// have asked for ~1s.
+	p.setErr(errors.New("boom"))
+	clk.Advance(9 * time.Second)
+	if got := expectErrThenDelay(t, clk, ch); got != time.Minute {
+		t.Fatalf("delay during a failure streak = %v, want the %v backoff, not the lease shortcut", got, time.Minute)
+	}
+	drainClosed(cancel, ch)
+}
+
+// TestBackoffDoesNotReachNativeWatchProviders covers design point 2. A
+// WatchableProvider whose Watch starts successfully owns its own stream:
+// watchRef hands that channel straight back and the polling adapter - the only
+// place a retry delay is expressible - is never entered. WithBackoff therefore
+// cannot influence it, and the assertion that makes that concrete is that no
+// timer is ever armed on the clock, however many errors the native stream
+// delivers.
+func TestBackoffDoesNotReachNativeWatchProviders(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	wp := newWatchProvider("bo")
+	wp.set("x", "v1", "1")
+
+	o := backoffOpts(clk, time.Second, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := watchRef(ctx, wp, backoffRef, o)
+
+	for i := range 3 {
+		wp.pushErr("x", errors.New("stream hiccup"))
+		select {
+		case u := <-ch:
+			if u.Err == nil {
+				t.Fatalf("update %d = %+v, want an error", i+1, u)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("no error update %d from the native watch", i+1)
+		}
+		if n := armedTimers(clk); n != 0 {
+			t.Fatalf("native watch armed %d timer(s) on the clock; backoff must not be in this path", n)
+		}
+	}
+}
+
+// failToStartWatcher is a WatchableProvider whose Watch never starts, the one
+// case in which watchRef falls back to pollWatch for a provider that is
+// nominally natively watchable.
+type failToStartWatcher struct{ *pollFake }
+
+func (failToStartWatcher) Watch(context.Context, Ref) (<-chan Update, error) {
+	return nil, errors.New("native watch unavailable")
+}
+
+// TestBackoffAppliesToNativeWatchFallback is the boundary of design point 2:
+// backoff does not reach a live native stream, but it does govern a
+// WatchableProvider that failed to start one, because watchRef has fallen back
+// to the polling adapter and the ref is being polled like any other.
+func TestBackoffAppliesToNativeWatchFallback(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := failToStartWatcher{&pollFake{scheme: "bo", err: errors.New("boom")}}
+	o := backoffOpts(clk, time.Second, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := watchRef(ctx, p, backoffRef, o)
+
+	if got := expectErrThenDelay(t, clk, ch); got != time.Second {
+		t.Fatalf("retry delay on the poll fallback = %v, want the backoff base %v", got, time.Second)
+	}
+	clk.Advance(time.Second)
+	if got := expectErrThenDelay(t, clk, ch); got != 2*time.Second {
+		t.Fatalf("second retry delay on the poll fallback = %v, want %v", got, 2*time.Second)
+	}
+	drainClosed(cancel, ch)
+}
+
+type staleBackoffConfig struct {
+	V string `source:"bostale://x"`
+}
+
+// TestBackoffDelaysStaleErrorButNotStaleStatus covers design point 4, the one
+// interaction worth being explicit about because it is a genuine (if opt-in)
+// cost.
+//
+// mamori has two staleness surfaces and backoff hits exactly one of them:
+//
+//   - Status()/Health() recompute Age and Stale at READ time from LastOK
+//     against the clock (report.go), so they are attempt-independent. A ref
+//     that is backing off still goes Stale, and still flips Healthy to false,
+//     at precisely maxAge. A readiness probe is unaffected.
+//   - The *StaleError delivered to OnError is escalated inside
+//     reportTerminalError (reconciler.go), which runs only when a failed
+//     attempt produces an error update. There is no independent staleness
+//     timer, so the escalation cannot happen sooner than the next attempt -
+//     and backoff is what pushes that attempt out.
+//
+// So a long backoffMax delays the OnError signal by up to one backoff step
+// while leaving the health surface exact. This test drives both halves at
+// once: a 5m backoff step straddling a 1m stale threshold.
+func TestBackoffDelaysStaleErrorButNotStaleStatus(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	clk := NewFakeClock(time.Time{})
+	p := &pollFake{scheme: "bostale", val: Value{Bytes: []byte("v1"), Version: "1"}}
+
+	const (
+		staleAfter  = time.Minute
+		backoffStep = 5 * time.Minute
+		pollEvery   = 30 * time.Second
+	)
+
+	errs := make(chan error, 8)
+	w, err := Watch[staleBackoffConfig](context.Background(),
+		WithProvider(p),
+		WithClock(clk),
+		WithJitter(0),
+		WithPollInterval(pollEvery),
+		WithBackoff(backoffStep, backoffStep), // a flat, easy-to-straddle step
+		WithStale(staleAfter),
+		OnError(func(e error) { errs <- e }),
+	)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Watch returns once its own initial Load has resolved, which says nothing
+	// about pollWatch's baseline resolve having run yet - that happens on the
+	// adapter's goroutine. Breaking the provider before the baseline lands
+	// makes the BASELINE the first failure, which opens the streak an interval
+	// earlier than this test is describing and shifts every deadline below.
+	// Two calls (Load's, then the baseline's) is the handshake that the
+	// adapter has taken its healthy reading; the timer assertion right after
+	// confirms it is sitting on the ordinary poll interval, not a backoff.
+	waitUntil(t, 2*time.Second, "pollWatch to take its baseline reading", func() bool {
+		return p.calls.Load() >= 2
+	})
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != pollEvery {
+		t.Fatalf("delay while healthy = %v, want the poll interval %v", got, pollEvery)
+	}
+
+	// First failure: still inside the stale threshold, so a plain
+	// *ProviderError, and the retry is pushed out by a full backoff step.
+	p.setErr(errors.New("backend down"))
+	clk.Advance(pollEvery)
+	select {
+	case e := <-errs:
+		var pe *ProviderError
+		if !errors.As(e, &pe) {
+			t.Fatalf("first error = %T (%v), want *ProviderError", e, e)
+		}
+		var se *StaleError
+		if errors.As(e, &se) {
+			t.Fatalf("escalated to *StaleError before the stale threshold elapsed: %v", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnError did not fire for the first failed poll")
+	}
+	blockUntilTimers(t, clk, 1)
+	if got := armedDelay(t, clk); got != backoffStep {
+		t.Fatalf("retry delay = %v, want the %v backoff step", got, backoffStep)
+	}
+
+	// Cross the stale threshold WITHOUT letting an attempt happen. The health
+	// surface must reflect it immediately anyway.
+	clk.Advance(staleAfter + time.Second)
+	rep := w.Status()
+	if len(rep.Fields) != 1 {
+		t.Fatalf("Status fields = %d, want 1", len(rep.Fields))
+	}
+	if !rep.Fields[0].Stale {
+		t.Fatalf("field not Stale past maxAge while backing off: %+v", rep.Fields[0])
+	}
+	if rep.Healthy {
+		t.Fatalf("Healthy = true with a stale field: %+v", rep)
+	}
+	select {
+	case e := <-errs:
+		t.Fatalf("unexpected error delivered with no attempt in flight: %v", e)
+	default:
+	}
+
+	// The attempt the backoff was holding back finally lands, and only now is
+	// the staleness escalated to OnError.
+	clk.Advance(backoffStep)
+	select {
+	case e := <-errs:
+		var se *StaleError
+		if !errors.As(e, &se) {
+			t.Fatalf("error after maxAge = %T (%v), want *StaleError", e, e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnError did not escalate to *StaleError on the first attempt past maxAge")
+	}
+}
+
+// TestBackoffDelayCurve exercises the delay computation directly, where the
+// edge cases (a disabled window, a nonsensical cap, a cap that is not a
+// power-of-two multiple of the base) are cheap to enumerate. want is indexed
+// by consecutive-failure count, so want[0] is always the "no failure
+// outstanding, use the poll interval" sentinel of 0.
+func TestBackoffDelayCurve(t *testing.T) {
+	const s = time.Second
+	cases := []struct {
+		name       string
+		base, ceil time.Duration
+		want       []time.Duration
+	}{
+		{
+			name: "off when base is zero",
+			want: []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "off when base is negative",
+			base: -s, ceil: time.Minute,
+			want: []time.Duration{0, 0, 0},
+		},
+		{
+			name: "doubles then caps",
+			base: s, ceil: 8 * s,
+			want: []time.Duration{0, s, 2 * s, 4 * s, 8 * s, 8 * s, 8 * s},
+		},
+		{
+			name: "zero cap clamps to the base",
+			base: 2 * s,
+			want: []time.Duration{0, 2 * s, 2 * s, 2 * s},
+		},
+		{
+			name: "cap below base clamps to the base",
+			base: 2 * s, ceil: s,
+			want: []time.Duration{0, 2 * s, 2 * s, 2 * s},
+		},
+		{
+			name: "cap that is not a power-of-two multiple still holds",
+			base: s, ceil: 3 * s,
+			want: []time.Duration{0, s, 2 * s, 3 * s, 3 * s},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newBackoff(&options{backoffBase: tc.base, backoffMax: tc.ceil})
+			for failures, want := range tc.want {
+				b.failures = failures
+				if got := b.delay(); got != want {
+					t.Fatalf("delay with %d consecutive failures = %v, want %v", failures, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestBackoffDelayDoesNotOverflow guards the doubling loop against both an
+// int64 overflow and an unbounded iteration count: a ref that has been failing
+// for days accumulates a large failure count, and the delay for it must still
+// be computed in a bounded number of steps and still land on the cap.
+func TestBackoffDelayDoesNotOverflow(t *testing.T) {
+	b := newBackoff(&options{backoffBase: time.Nanosecond, backoffMax: time.Hour})
+	for _, failures := range []int{64, 1_000, 1_000_000} {
+		b.failures = failures
+		if got := b.delay(); got != time.Hour {
+			t.Fatalf("delay with %d consecutive failures = %v, want the %v cap", failures, got, time.Hour)
+		}
+	}
+}

--- a/clock_test.go
+++ b/clock_test.go
@@ -29,6 +29,37 @@ func blockUntilTimers(t *testing.T, clk *FakeClock, n int) {
 	}
 }
 
+// armedTimers reports how many timers are currently pending on clk. It is the
+// counting half of armedDelay, used to assert that a code path arms no timer
+// at all (a natively-watched ref, which never enters the polling adapter).
+func armedTimers(clk *FakeClock) int {
+	clk.mu.Lock()
+	defer clk.mu.Unlock()
+	return len(clk.waiters)
+}
+
+// armedDelay returns the delay of the single timer currently pending on clk,
+// measured from the clock's current time.
+//
+// It is the assertion counterpart to blockUntilTimers: the block orders the
+// test after the goroutine armed its timer, and this reads the deadline that
+// goroutine chose. Reading the deadline directly is what makes a retry-cadence
+// assertion exact - the alternative is to advance the clock by a guessed amount
+// and infer the interval from whether a side effect happened, which can only
+// bracket the delay and turns every cadence test into a timing puzzle. It
+// insists on exactly one pending timer so a test that has accidentally armed a
+// debounce timer alongside the poll timer fails loudly rather than asserting on
+// whichever one happens to be first in the slice.
+func armedDelay(t *testing.T, clk *FakeClock) time.Duration {
+	t.Helper()
+	clk.mu.Lock()
+	defer clk.mu.Unlock()
+	if len(clk.waiters) != 1 {
+		t.Fatalf("pending timers on the fake clock = %d, want exactly 1", len(clk.waiters))
+	}
+	return clk.waiters[0].deadline.Sub(clk.now)
+}
+
 func TestFakeClockTimer(t *testing.T) {
 	c := NewFakeClock(time.Time{})
 	timer := c.NewTimer(10 * time.Second)

--- a/poll.go
+++ b/poll.go
@@ -13,10 +13,16 @@ import (
 // refresh before expiry. The returned channel is closed when ctx is cancelled.
 //
 // This is the single, canonical polling adapter: provider authors implement only
-// Resolve, and mamori supplies the loop - so nobody hand-rolls a ticker.
+// Resolve, and mamori supplies the loop - so nobody hand-rolls a ticker. It is
+// also the one place in the engine where a ref's retry cadence is expressible,
+// which is why WithBackoff lands here and nowhere else: everything downstream
+// (the forwarders, the reconciler) only consumes the Updates this loop decides
+// to produce and has no way to ask a source to try again sooner or later. See
+// WithBackoff's doc comment for what that means for natively-watched providers.
 func pollWatch(ctx context.Context, p Provider, ref Ref, o *options) <-chan Update {
 	ch := make(chan Update)
 	interval := o.pollInterval
+	bo := newBackoff(o)
 	go func() {
 		defer close(ch)
 
@@ -32,9 +38,12 @@ func pollWatch(ctx context.Context, p Provider, ref Ref, o *options) <-chan Upda
 			}
 		}
 
-		// Initial resolve so watchers see a baseline immediately.
+		// Initial resolve so watchers see a baseline immediately. A failed
+		// baseline is consecutive failure #1, not a free attempt: the first
+		// retry after it is already spaced by the backoff base.
 		if v, err := p.Resolve(ctx, ref); err != nil {
 			if !errors.Is(err, ErrNotFound) {
+				bo.fail()
 				if !emit(Value{}, err) {
 					return
 				}
@@ -47,18 +56,38 @@ func pollWatch(ctx context.Context, p Provider, ref Ref, o *options) <-chan Upda
 		}
 
 		for {
-			d := jittered(interval, o.jitter)
-			// Refresh before a known expiry, if that is sooner than the interval.
-			// Aim for ~90% of the remaining lease life so we renew slightly early.
-			if haveLast && !last.NotAfter.IsZero() {
-				untilExpiry := last.NotAfter.Sub(o.clock.Now())
-				if untilExpiry > 0 {
-					leaseRefresh := untilExpiry - untilExpiry/10
-					if leaseRefresh <= 0 {
-						leaseRefresh = untilExpiry
-					}
-					if leaseRefresh < d {
-						d = leaseRefresh
+			var d time.Duration
+			if retry := bo.delay(); retry > 0 {
+				// A failure streak is open, so the backoff governs the cadence
+				// outright: it replaces the poll interval AND suppresses the
+				// lease-refresh shortcut below. Letting the shortcut stay
+				// active while failing would defeat the backoff entirely - it
+				// only ever shortens, and the remaining lease life shrinks on
+				// every pass, so it would converge into a tight retry loop
+				// aimed at a backend that just proved it cannot serve one.
+				// A lease we are unable to renew is not a reason to try harder.
+				//
+				// The backoff is jittered by the same fraction as the interval,
+				// and for a stronger reason: a shared backend failing
+				// synchronizes every client's failure instant, so an
+				// un-jittered curve would have the whole fleet retry in
+				// lockstep against a backend that is already unhealthy.
+				d = jittered(retry, o.jitter)
+			} else {
+				d = jittered(interval, o.jitter)
+				// Refresh before a known expiry, if that is sooner than the
+				// interval. Aim for ~90% of the remaining lease life so we
+				// renew slightly early.
+				if haveLast && !last.NotAfter.IsZero() {
+					untilExpiry := last.NotAfter.Sub(o.clock.Now())
+					if untilExpiry > 0 {
+						leaseRefresh := untilExpiry - untilExpiry/10
+						if leaseRefresh <= 0 {
+							leaseRefresh = untilExpiry
+						}
+						if leaseRefresh < d {
+							d = leaseRefresh
+						}
 					}
 				}
 			}
@@ -73,13 +102,22 @@ func pollWatch(ctx context.Context, p Provider, ref Ref, o *options) <-chan Upda
 			v, err := p.Resolve(ctx, ref)
 			if err != nil {
 				if errors.Is(err, ErrNotFound) {
+					// Absence is an answer, not a failure: the backend was
+					// reached and reported the ref missing, which is ordinary
+					// default:/optional: territory. Backing off on it would
+					// slow down discovering a ref that gets provisioned after
+					// the process starts, so a not-found ends any open streak
+					// rather than extending it.
+					bo.reset()
 					continue
 				}
+				bo.fail()
 				if !emit(Value{}, err) {
 					return
 				}
 				continue
 			}
+			bo.reset()
 			if haveLast && !last.changed(v) {
 				continue
 			}

--- a/poll_test.go
+++ b/poll_test.go
@@ -27,6 +27,7 @@ func (p *pollFake) Resolve(context.Context, Ref) (Value, error) {
 	return p.val, p.err
 }
 func (p *pollFake) setVal(v Value) { p.mu.Lock(); p.val = v; p.mu.Unlock() }
+func (p *pollFake) setErr(e error) { p.mu.Lock(); p.err = e; p.mu.Unlock() }
 
 func drainOne(t *testing.T, ch <-chan Update, wantBytes string) {
 	t.Helper()

--- a/reconcile.go
+++ b/reconcile.go
@@ -28,7 +28,7 @@ type options struct {
 	debounce     time.Duration
 	queueDepth   int
 	stale        time.Duration // 0 = disabled
-	backoffBase  time.Duration
+	backoffBase  time.Duration // 0 = disabled; see WithBackoff
 	backoffMax   time.Duration
 	meter        Meter
 	tracer       Tracer
@@ -47,6 +47,13 @@ type options struct {
 	onError  func(error)
 }
 
+// defaultOptions returns the option set every Load and Watch starts from.
+//
+// backoffBase/backoffMax are deliberately absent, leaving the retry backoff
+// window at zero: backoff is opt-in via WithBackoff. This used to name 1s/1m
+// here while nothing in the engine read either field, so those numbers never
+// described real behavior; adopting them once the option was implemented would
+// have changed the retry cadence of every existing caller. See WithBackoff.
 func defaultOptions() *options {
 	return &options{
 		providers:    map[string]Provider{},
@@ -56,8 +63,6 @@ func defaultOptions() *options {
 		jitter:       defaultJitter,
 		debounce:     defaultDebounce,
 		queueDepth:   defaultQueueDepth,
-		backoffBase:  time.Second,
-		backoffMax:   time.Minute,
 		meter:        noopMeter{},
 		tracer:       noopTracer{},
 	}
@@ -123,7 +128,47 @@ func WithHistory(n int) Option {
 	}
 }
 
-// WithBackoff configures per-ref exponential backoff on resolve failure.
+// WithBackoff enables per-ref exponential backoff on resolve failure for
+// polled refs. After a ref fails to resolve, its next attempt is delayed by
+// base instead of the poll interval; each further consecutive failure doubles
+// that delay, held at max once it gets there. Any successful round trip with
+// the backend resets it, and the ref returns to the normal poll interval.
+//
+// Backoff is OFF by default. Without this option a failing ref is retried on
+// the WithPollInterval cadence, exactly as it always has been - which is the
+// point: this option set two fields nothing read until it was implemented, so
+// no existing caller can have been relying on backoff, and switching it on for
+// everyone would have made a just-failed backend get retried far sooner than
+// its operators had ever seen. Choose the window deliberately.
+//
+// Normalization: a base of zero or less disables backoff, so WithBackoff(0, 0)
+// turns it back off. A max below base is raised to base, which gives
+// WithBackoff(d, 0) the meaning "retry every d while failing" rather than
+// unbounded exponential growth.
+//
+// Three behaviors are worth knowing before choosing a window.
+//
+// It does not apply to providers with a native watch. A WatchableProvider
+// (Kubernetes informers, Consul blocking queries, Postgres LISTEN/NOTIFY, the
+// mamori:// SSE client, ...) owns its own stream and its own reconnection
+// cadence; mamori polls nothing on its behalf, so there is no attempt for this
+// option to delay. Reconnect behavior for those is provider-internal and
+// documented per provider. The single exception is a native watch that fails
+// to START: mamori falls back to the polling adapter for that ref, and backoff
+// governs it from then on like any other polled ref.
+//
+// A not-found is not a failure. ErrNotFound means the backend answered and the
+// ref is absent, which is ordinary default:/optional: territory; it ends a
+// streak rather than extending one, so a ref that gets provisioned after the
+// process starts is still discovered on the normal poll interval.
+//
+// It interacts with WithStale. Staleness is escalated to a *StaleError on the
+// first failed attempt after maxAge elapses, and backoff is what pushes that
+// attempt out, so a large max delays the OnError signal by up to one backoff
+// step. Watcher.Status and Watcher.Health are unaffected: they recompute Age
+// and Stale at read time from the last success, so a readiness probe still
+// turns unhealthy at exactly maxAge. Keep max well under the WithStale
+// threshold if the OnError timing matters to you.
 func WithBackoff(base, max time.Duration) Option {
 	return func(o *options) { o.backoffBase, o.backoffMax = base, max }
 }

--- a/site/src/pages/docs/providers/index.md
+++ b/site/src/pages/docs/providers/index.md
@@ -84,3 +84,5 @@ The [mamori (client)](/docs/providers/mamori/) provider is the one shipped provi
 - **poll** - mamori polls on `WithPollInterval` with jitter, using `Value.Version` to detect change.
 
 Provider authors implement the smallest interface native to their backend and never fake a watch with an internal ticker - mamori supplies the poller.
+
+Because mamori supplies the poller, it also supplies the retry cadence for the three polled rows: [`WithBackoff`](/docs/usage/watching/#retry-backoff) spaces out retries for a ref that keeps failing to resolve. It does not reach a **native** provider, which owns its stream and its own reconnect behavior; see each provider's page for that.

--- a/site/src/pages/docs/usage/watching.md
+++ b/site/src/pages/docs/usage/watching.md
@@ -66,8 +66,29 @@ These behaviors are guaranteed and covered by the conformance kit.
 - **Validated, all-or-nothing updates.** `OnChange` fires with a fully re-validated snapshot. If a new value fails validation the update is rejected: `Get()` keeps returning the last good config and `OnError` receives a `*ValidationError`.
 - **OnChange is called one at a time.** Callbacks are serialized, so your callback never runs concurrently with itself. A slow callback delays the next event but never drops it in normal operation.
 - **Coalesced events.** Field changes within a debounce window (default 500ms, override per field with `?debounce=`) produce a single `Change`. A JSON secret with five keys rotating is one event, not five.
-- **Last-good on failure.** On a runtime resolve failure the last-good value is retained, `OnError` receives a `*ProviderError`, and the ref is retried with per-ref exponential backoff. `WithStale(maxAge)` escalates prolonged staleness to a hard `*StaleError`.
+- **Last-good on failure.** On a runtime resolve failure the last-good value is retained, `OnError` receives a `*ProviderError`, and the ref keeps being retried - on the poll interval by default, or with per-ref exponential backoff if you opt into it with [`WithBackoff`](#retry-backoff). `WithStale(maxAge)` escalates prolonged staleness to a hard `*StaleError`.
 - **Clean shutdown.** `Close()` cancels provider watches, drains the callback queue, and returns.
+
+## Retry backoff
+
+A polled ref that fails to resolve is retried on the poll interval. `WithBackoff(base, max)` replaces that cadence with per-ref exponential backoff for as long as the ref keeps failing: the first retry is delayed by `base`, each further consecutive failure doubles the delay, and it holds at `max`. Any successful round trip with the backend resets it and the ref returns to the normal poll interval.
+
+```go
+w, err := mamori.Watch[Config](ctx,
+	mamori.WithPollInterval(30*time.Second),
+	mamori.WithBackoff(30*time.Second, 5*time.Minute),
+)
+```
+
+**Backoff is off by default.** Without `WithBackoff` a failing ref is retried on `WithPollInterval`, unchanged. Turn it on deliberately, and note that a `base` below your poll interval makes a *just-failed* backend get hit sooner than a healthy one - usually you want `base` at or above the poll interval, as above.
+
+Three things to know before choosing a window:
+
+- **It does not reach providers with a native watch.** A [push provider](/docs/providers/) - Kubernetes informers, Consul blocking queries, Postgres `LISTEN/NOTIFY`, the `mamori://` SSE client - owns its own stream and its own reconnect cadence. mamori polls nothing on its behalf, so there is no attempt for `WithBackoff` to delay; reconnect behavior is provider-internal and documented on each provider's page. The one exception is a native watch that fails to *start*: mamori falls back to polling for that ref, and backoff governs it from then on. `WithBackoff` is a polling knob, and setting it does not make a push provider back off.
+- **A not-found is not a failure.** `ErrNotFound` means the backend answered and the ref is absent - ordinary `default:` / `optional:` territory. It ends a backoff streak rather than extending one, so a ref you provision after the process starts is still picked up on the normal poll interval.
+- **It interacts with `WithStale`.** The `*StaleError` handed to `OnError` is escalated on the first failed attempt after `maxAge` elapses, and backoff is what pushes that attempt out - so a large `max` delays that callback by up to one backoff step. `Status()` and `Health()` are unaffected: they recompute `Age` and `Stale` at read time from the last success, so a readiness probe still flips at exactly `maxAge`. Keep `max` well under your `WithStale` threshold if the `OnError` timing matters.
+
+Jitter applies to backoff too. `WithJitter` randomizes each backoff delay by the same fraction it randomizes the poll interval, which matters more here than it does for ordinary polling: a shared backend failing synchronizes every client's failure instant, and un-jittered backoff would have the whole fleet retry in lockstep against a backend that is already unhealthy.
 
 ## Tuning the dispatch queue
 

--- a/watchref.go
+++ b/watchref.go
@@ -13,10 +13,13 @@ import "context"
 //
 // opts is turned into an *options the same way Load and Watch build theirs:
 // defaultOptions() overlaid with opts in the order given. Of everything an
-// *options carries, only clock, pollInterval, and jitter matter here - the
-// fields pollWatch itself reads - but the full Option surface (WithClock,
-// WithPollInterval, WithJitter, ...) is accepted so a caller does not need a
-// second, narrower configuration vocabulary just for this entry point.
+// *options carries, only clock, pollInterval, jitter, and the WithBackoff
+// window matter here - the fields pollWatch itself reads - but the full Option
+// surface (WithClock, WithPollInterval, WithJitter, ...) is accepted so a
+// caller does not need a second, narrower configuration vocabulary just for
+// this entry point. Since backoff lives in the polling adapter, it reaches a
+// ref watched through here on exactly the terms WithBackoff documents: polled
+// refs and native-watch fallbacks, never a native watch that started cleanly.
 //
 // The returned channel is closed when ctx is cancelled, matching both
 // WatchableProvider's and pollWatch's own contract.


### PR DESCRIPTION
`WithBackoff` has been a **dead public option**. `options.backoffBase` and `backoffMax` were written by the option and by `defaultOptions`, and read **nowhere** in the core engine. A caller who configured backoff got a silent no-op, while [usage/watching.md:70](site/src/pages/docs/usage/watching.md#L70) asserted the behavior existed.

Found during the final review of the rotation-safety work, which had newly claimed `Refresh` "bypasses per-ref backoff" — a bypass of a mechanism that did not exist.

## Implementation

`pollWatch` is the seam: it is the only place a retry cadence is expressible, since downstream code just consumes `Update`s. On a failed resolve the next attempt is delayed by `base`, doubling to `max`; a success resets it.

## Backoff is now OFF by default, and that is the important decision

Adopting the previously inert 1s/1m would have changed behavior for **every existing deployment**, in two directions at once:

- A just-failed backend would be retried **30× faster** than today (1s against the 30s poll interval). That is *more* load against something already unhealthy, which is precisely what backoff exists to prevent.
- Its 60s steady state is *slower* than today, delaying both the `StaleError` and recovery detection.

Since the option never did anything, **no caller can depend on it**, so there is no upside to weigh against a guaranteed cadence change for everyone. Callers now opt in deliberately:

```go
mamori.WithBackoff(30*time.Second, 5*time.Minute)
```

## Three interactions, all settled explicitly

**Jitter.** Backoff is jittered, for exactly the reason `WithJitter` exists: a shared backend failing synchronizes every client's failure instant, so an un-jittered curve becomes a fleet-wide retry storm at each step.

**Native-watch providers.** Kubernetes informers, Consul blocking queries, and Postgres LISTEN/NOTIFY do not poll, so this does not reach them and their reconnection stays provider-internal. Documented as a limitation rather than faked, with the fallback-to-polling boundary tested in both directions.

**`WithStale`.** Its `*StaleError` is attempt-driven, so a long backoff delays it by up to one step. `Status()` and `Health()` recompute at read time and are unaffected. Documented rather than engineered around.

## One thing found while testing

Backoff now suppresses the `Value.NotAfter` early-lease-refresh shortcut while a ref is failing. That shortcut only ever *shortens* the wait, and the remaining lease life shrinks each pass, so it defeated backoff entirely — a test recorded a **900ms** delay where 60s was configured. It affects only callers who opt into backoff.

## Testing

Timing is driven by `FakeClock` and its `BlockUntil` handshake throughout, never real sleeps — this repository has had two flaky-timing incidents recently and they are not worth repeating. Growth, capping, and reset are each pinned, and every test was verified to fail against the dead option.

A test race was also found and fixed along the way (not an implementation bug): `Watch` returning does not imply `pollWatch`'s baseline resolve has run, so breaking the provider too early made the *baseline* failure number one and shifted every deadline by a poll interval. It only appeared under `-count=30`, and is fixed with a real handshake rather than a sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-reference exponential retry backoff for polling failures, with configurable limits and jitter.
  * Backoff resets after successful resolution and ignores not-found results.
  * Native watch providers remain unaffected, while polling fallbacks use backoff when enabled.
  * Staleness reporting remains timely while stale-error escalation respects retry delays.

* **Bug Fixes**
  * Corrected `WithBackoff` so configured retry delays take effect.

* **Documentation**
  * Expanded watcher and provider documentation with retry, fallback, and staleness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->