### PR TITLE
test: let a provider declare its watch baseline instead of sleeping 200ms

### DIFF
--- a/providers/consul/consul_integration_test.go
+++ b/providers/consul/consul_integration_test.go
@@ -49,12 +49,15 @@ func TestIntegrationConformance(t *testing.T) {
 	}
 
 	providertest.Run(t, providertest.Config{
-		New:               func() mamori.Provider { return New(WithClient(client)) },
-		Ref:               func(key string) string { return "consul://" + key },
-		Key:               func(name string) string { return prefix + name },
-		Seed:              put,
-		Mutate:            put,
-		EventuallyTimeout: 15 * time.Second,
+		New:    func() mamori.Provider { return New(WithClient(client)) },
+		Ref:    func(key string) string { return "consul://" + key },
+		Key:    func(name string) string { return prefix + name },
+		Seed:   put,
+		Mutate: put,
+		// See the unit-test conformance config: the first blocking query emits
+		// the baseline and establishes the index the watch resumes from.
+		WatchDeliversBaseline: true,
+		EventuallyTimeout:     15 * time.Second,
 		// live-backend integration test; error injection not possible, unit test covers classification
 		NoResolveErrors: true,
 	})

--- a/providers/consul/consul_test.go
+++ b/providers/consul/consul_test.go
@@ -148,8 +148,12 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withKV(fake), WithWaitTime(500*time.Millisecond))
 		},
-		Ref:  func(key string) string { return "consul://" + key },
-		Seed: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Ref: func(key string) string { return "consul://" + key },
+		// consul.go: the first blocking query (lastIndex == 0) reads and emits
+		// the baseline, and the index it returns is the subscription position,
+		// so nothing written after it can be missed.
+		WatchDeliversBaseline: true,
+		Seed:                  func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
 		Mutate: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/firebase-rtdb/firebasertdb_test.go
+++ b/providers/firebase-rtdb/firebasertdb_test.go
@@ -189,8 +189,11 @@ func TestConformance(t *testing.T) {
 		New: func() mamori.Provider {
 			return New(withBackend(fake), WithReconnectBackoff(200*time.Millisecond))
 		},
-		Ref:  func(key string) string { return "firebase-rtdb://" + key },
-		Seed: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		Ref: func(key string) string { return "firebase-rtdb://" + key },
+		// firebasertdb.go: the stream is opened first, then "Emit the current
+		// value as a baseline once, after the stream is open".
+		WatchDeliversBaseline: true,
+		Seed:                  func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
 		Mutate: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/firestore/firestore_test.go
+++ b/providers/firestore/firestore_test.go
@@ -164,6 +164,9 @@ func TestConformance(t *testing.T) {
 		// The document stores the value under a "value" field so a scalar can be
 		// round-tripped through a document-shaped backend.
 		Ref: func(key string) string { return "firestore://" + collection + "/" + key + "#value" },
+		// firestore.go: the snapshot stream is created before the goroutine
+		// runs, and its first event is the current document.
+		WatchDeliversBaseline: true,
 		Seed: func(_ context.Context, key, val string) error {
 			store.set(collection, key, map[string]interface{}{"value": val})
 			return nil

--- a/providers/k8s/k8s_test.go
+++ b/providers/k8s/k8s_test.go
@@ -169,6 +169,9 @@ func TestConformanceSecret(t *testing.T) {
 		},
 		Seed:   func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		Mutate: func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
+		// k8s.go: "Emit the current snapshot after the watch is established so
+		// no change occurring between snapshot and watch is lost."
+		WatchDeliversBaseline: true,
 		// The kit's key is a namespaced conformance key; the reactor only sees
 		// the object name that Ref/Seed derived from it via sanitize, so Fail
 		// and Clear must apply the same translation or the reactor never fires.
@@ -206,6 +209,8 @@ func TestConformanceConfigMap(t *testing.T) {
 		Ref:    func(key string) string { return "k8s-cm://" + testNamespace + "/" + sanitize(key) + "#value" },
 		Seed:   func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
 		Mutate: func(_ context.Context, key, val string) error { upsert(sanitize(key), val); return nil },
+		// Same Watch as the Secret case above: snapshot after the watch starts.
+		WatchDeliversBaseline: true,
 		Fail: func(_ context.Context, key string, err error) error {
 			fi.fail(sanitize(key), err)
 			return nil

--- a/providers/mamori/conformance_test.go
+++ b/providers/mamori/conformance_test.go
@@ -298,6 +298,10 @@ func runConformance(t *testing.T, serverOpts []server.Option, endpointFor func(*
 	cfg := providertest.Config{
 		New: func() mamori.Provider { return newClient() },
 		Ref: func(key string) string { return "mamori://" + key },
+		// The server sends a snapshot per subscribed name at subscribe time
+		// (server/handler.go, sendWatchSnapshot), so the first Update the SSE
+		// watch delivers proves the subscription is registered upstream.
+		WatchDeliversBaseline: true,
 		Key: func(name string) string {
 			switch {
 			case strings.HasPrefix(name, "classify-"):

--- a/providers/mongodb/mongodb_integration_test.go
+++ b/providers/mongodb/mongodb_integration_test.go
@@ -74,11 +74,14 @@ func TestIntegrationConformance(t *testing.T) {
 	}
 
 	providertest.Run(t, providertest.Config{
-		New:               func() mamori.Provider { return New(WithClient(client), WithDatabase(db)) },
-		Ref:               func(key string) string { return "mongodb://" + collName + "/" + key + "#value" },
-		Seed:              upsert,
-		Mutate:            upsert,
-		EventuallyTimeout: 15 * time.Second,
+		New:    func() mamori.Provider { return New(WithClient(client), WithDatabase(db)) },
+		Ref:    func(key string) string { return "mongodb://" + collName + "/" + key + "#value" },
+		Seed:   upsert,
+		Mutate: upsert,
+		// See the unit-test conformance config: change stream opened, then
+		// baseline read.
+		WatchDeliversBaseline: true,
+		EventuallyTimeout:     15 * time.Second,
 		// live-backend integration test; error injection not possible, unit test covers classification
 		NoResolveErrors: true,
 	})

--- a/providers/mongodb/mongodb_test.go
+++ b/providers/mongodb/mongodb_test.go
@@ -203,6 +203,9 @@ func TestConformance(t *testing.T) {
 		// The conformance kit stores each value as a document's "value" field and
 		// selects it with #value, so the resolved bytes equal the seeded string.
 		Ref: func(key string) string { return "mongodb://conformance/" + key + "#value" },
+		// mongodb.go: the change stream is opened before the goroutine runs and
+		// the baseline is read after it ("Emit the current value as a baseline").
+		WatchDeliversBaseline: true,
 		Seed: func(_ context.Context, key, val string) error {
 			fake.put("conformance", key, bson.M{"_id": key, "value": val})
 			return nil

--- a/providers/postgres/postgres_integration_test.go
+++ b/providers/postgres/postgres_integration_test.go
@@ -82,11 +82,14 @@ func TestIntegrationConformance(t *testing.T) {
 	setupTable(t, pool, table)
 
 	providertest.Run(t, providertest.Config{
-		New:               func() mamori.Provider { return New(WithPool(pool)) },
-		Ref:               func(key string) string { return "postgres://" + table + "/" + key },
-		Seed:              upsert(pool, table),
-		Mutate:            upsert(pool, table),
-		EventuallyTimeout: 15 * time.Second,
+		New:    func() mamori.Provider { return New(WithPool(pool)) },
+		Ref:    func(key string) string { return "postgres://" + table + "/" + key },
+		Seed:   upsert(pool, table),
+		Mutate: upsert(pool, table),
+		// See the unit-test conformance config: LISTEN precedes the baseline
+		// query, and pgx buffers a NOTIFY arriving before the next wait.
+		WatchDeliversBaseline: true,
+		EventuallyTimeout:     15 * time.Second,
 		// live-backend integration test; error injection not possible, unit test covers classification
 		NoResolveErrors: true,
 	})

--- a/providers/postgres/postgres_test.go
+++ b/providers/postgres/postgres_test.go
@@ -223,9 +223,13 @@ func mustRef(t *testing.T, s string) mamori.Ref {
 func TestConformance(t *testing.T) {
 	fake := newFakeBackend()
 	providertest.Run(t, providertest.Config{
-		New:  func() mamori.Provider { return New(withBackend(fake)) },
-		Ref:  func(key string) string { return "postgres://app_config/" + key },
-		Seed: func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
+		New: func() mamori.Provider { return New(withBackend(fake)) },
+		Ref: func(key string) string { return "postgres://app_config/" + key },
+		// postgres.go: LISTEN is issued before the baseline query, and the fake
+		// models the same queue-from-subscription semantics a real LISTEN has
+		// (see fakeBackend's doc comment).
+		WatchDeliversBaseline: true,
+		Seed:                  func(_ context.Context, key, val string) error { fake.set(key, val); return nil },
 		Mutate: func(_ context.Context, key, val string) error {
 			fake.set(key, val)
 			return nil

--- a/providers/redis/redis_test.go
+++ b/providers/redis/redis_test.go
@@ -209,6 +209,9 @@ func TestConformance(t *testing.T) {
 		Ref:    func(key string) string { return "redis://" + key },
 		Seed:   func(_ context.Context, key, val string) error { f.set(key, val); return nil },
 		Mutate: func(_ context.Context, key, val string) error { f.set(key, val); return nil },
+		// redis.go: "Subscribe before emitting the baseline so no notification
+		// is missed between the baseline GET and the start of the read loop."
+		WatchDeliversBaseline: true,
 		Fail: func(_ context.Context, key string, err error) error {
 			f.fail(key, err)
 			return nil

--- a/providers/sops/sops_test.go
+++ b/providers/sops/sops_test.go
@@ -207,6 +207,9 @@ func TestConformance(t *testing.T) {
 			}))
 		},
 		Ref: func(key string) string { return "sops://" + pathFor(key) },
+		// sops.go: the fsnotify watcher is created and w.Add'd before the
+		// goroutine starts, and the baseline is emitted from inside it.
+		WatchDeliversBaseline: true,
 		Seed: func(_ context.Context, key, val string) error {
 			return os.WriteFile(pathFor(key), []byte(val), 0o600)
 		},

--- a/providers/sqlite/sqlite_test.go
+++ b/providers/sqlite/sqlite_test.go
@@ -160,8 +160,11 @@ func TestConformance(t *testing.T) {
 				return failQueryer{inner: q, reg: reg}
 			}))
 		},
-		Ref:  func(key string) string { return "sqlite://cfg/" + key },
-		Seed: func(_ context.Context, key, val string) error { return writeKV(path, "cfg", key, val) },
+		Ref: func(key string) string { return "sqlite://cfg/" + key },
+		// sqlite.go: the fsnotify watch is added before the goroutine starts,
+		// and the baseline emit happens inside it.
+		WatchDeliversBaseline: true,
+		Seed:                  func(_ context.Context, key, val string) error { return writeKV(path, "cfg", key, val) },
 		Mutate: func(_ context.Context, key, val string) error {
 			return writeKV(path, "cfg", key, val)
 		},

--- a/providertest/providertest.go
+++ b/providertest/providertest.go
@@ -54,6 +54,41 @@ type Config struct {
 	// implements WatchableProvider (e.g. when the backend can't push in CI).
 	SkipWatch bool
 
+	// WatchDeliversBaseline declares that Watch emits an Update carrying the
+	// current value - a "baseline" - before any change notification, and, the
+	// load-bearing half, that the backend subscription is already established
+	// by the time that baseline is emitted.
+	//
+	// It exists because WatchEmitsOnMutate has to mutate the backend after the
+	// watch is live, and nothing in the WatchableProvider interface says when
+	// that happened. Watch may return its channel and subscribe afterwards in a
+	// goroutine - mamori explicitly permits this ("a native-watch subscription
+	// is asynchronous", reconciler.go) - so a mutation issued too early is
+	// simply not seen by anybody. Unset, the kit copes by waiting a fixed
+	// interval and hoping (see drainNonBlocking). Set, it waits for the
+	// baseline instead, which is an actual happens-after signal: a provider
+	// that subscribes before it reads-and-emits cannot produce that Update
+	// without having already subscribed. The wait is then deterministic rather
+	// than timing-dependent, and typically finishes in microseconds instead of
+	// the fixed 200ms.
+	//
+	// Subscribe-then-read is the ordering a watch wants regardless of this kit
+	// (see the redis provider: "Subscribe before emitting the baseline so no
+	// notification is missed between the baseline GET and the start of the read
+	// loop"), which is why declaring it is safe for a correct provider and only
+	// awkward for an incorrect one. If your Watch reads the value first and
+	// subscribes second, do not set this: that ordering drops any write landing
+	// in between, and setting the field will surface that as a watch failure -
+	// correctly, but the bug to fix is the ordering, not the declaration.
+	//
+	// The zero value keeps the previous behavior exactly, so leaving it unset
+	// is always safe. Providers that emit no baseline at all (a pure
+	// change-event stream, e.g. etcd or launchdarkly here) must leave it unset;
+	// for those the kit has no signal to wait on and falls back to the fixed
+	// interval. Declaring it when no baseline is coming fails the case with an
+	// explicit message rather than hanging silently.
+	WatchDeliversBaseline bool
+
 	// EventuallyTimeout bounds how long watch/poll tests wait for a change to
 	// propagate. Defaults to 5s.
 	EventuallyTimeout time.Duration
@@ -133,7 +168,7 @@ func Run(t *testing.T, c Config) {
 	t.Run("ContextCancel", func(t *testing.T) { testContextCancel(t, c) })
 	t.Run("ConcurrentResolve", func(t *testing.T) { testConcurrentResolve(t, c) })
 	t.Run("VersionMonotonic", func(t *testing.T) { testVersionMonotonic(t, c) })
-	t.Run("WatchEmitsOnMutate", func(t *testing.T) { testWatch(t, c) })
+	t.Run("WatchEmitsOnMutate", func(t *testing.T) { RunWatch(t, c) })
 	t.Run("WatchClosesOnCancel", func(t *testing.T) { testWatchCloses(t, c) })
 	t.Run("NoGoroutineLeak", func(t *testing.T) { testNoLeak(t, c) })
 }
@@ -319,33 +354,66 @@ func testVersionMonotonic(t *testing.T, c Config) {
 	}
 }
 
-func testWatch(t *testing.T, c Config) {
+// RunWatch runs only the watch-emits-on-mutate case. Run calls it; it is
+// exported for the same reason RunErrorClassification is, so the kit can test
+// itself against deliberately misbehaving providers - one that subscribes late,
+// one that declares a baseline it never sends - without running the whole suite
+// and without those expected failures failing the enclosing test.
+//
+// As in RunErrorClassification, every Fatal/Fatalf/Skip is followed by an
+// explicit return: driven by a recording testing.TB rather than a real
+// *testing.T, none of them stop execution on their own.
+func RunWatch(tb testing.TB, c Config) {
+	tb.Helper()
 	p := c.New()
 	wp, ok := p.(mamori.WatchableProvider)
 	if !ok || c.SkipWatch || c.Mutate == nil {
-		t.Skip("provider is not watchable or watch disabled")
+		tb.Skip("provider is not watchable or watch disabled")
+		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	key := c.key("watch")
 	if err := c.Seed(ctx, key, "start"); err != nil {
-		t.Fatalf("Seed: %v", err)
+		tb.Fatalf("Seed: %v", err)
+		return
 	}
-	ch, err := wp.Watch(ctx, c.parseRef(t, key))
+	ref, err := mamori.ParseRef(c.Ref(key))
 	if err != nil {
-		t.Fatalf("Watch: %v", err)
+		tb.Fatalf("Ref(%q) produced an unparseable ref: %v", key, err)
+		return
 	}
-	// Drain the baseline (if any), then mutate.
-	drainNonBlocking(ch)
+	ch, werr := wp.Watch(ctx, ref)
+	if werr != nil {
+		tb.Fatalf("Watch: %v", werr)
+		return
+	}
+
+	// Get past whatever the subscription itself emits, so the mutation below is
+	// the next thing on the channel and, more importantly, so the subscription
+	// is actually live when it happens.
+	if c.WatchDeliversBaseline {
+		if !awaitBaseline(ch, c.timeout()) {
+			tb.Fatalf("Config.WatchDeliversBaseline is set, but Watch delivered no Update "+
+				"within %v. Either this provider emits no baseline at subscribe time, in "+
+				"which case unset the field, or its watch never started.", c.timeout())
+			return
+		}
+	} else {
+		drainNonBlocking(ch)
+	}
+
 	if err := c.Mutate(ctx, key, "changed"); err != nil {
-		t.Fatalf("Mutate: %v", err)
+		tb.Fatalf("Mutate: %v", err)
+		return
 	}
 	deadline := time.After(c.timeout())
 	for {
 		select {
 		case u, open := <-ch:
 			if !open {
-				t.Fatal("watch channel closed before delivering the mutation")
+				tb.Fatal("watch channel closed before delivering the mutation")
+				return
 			}
 			if u.Err != nil {
 				continue
@@ -354,7 +422,8 @@ func testWatch(t *testing.T, c Config) {
 				return
 			}
 		case <-deadline:
-			t.Fatal("watch did not deliver the mutation within the timeout")
+			tb.Fatal("watch did not deliver the mutation within the timeout")
+			return
 		}
 	}
 }
@@ -406,6 +475,72 @@ func testNoLeak(t *testing.T, c Config) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+// awaitBaseline blocks for the first Update a Watch delivers - the baseline a
+// provider emits for the current value at subscribe time - and reports whether
+// one arrived before timeout. A closed channel counts as no baseline.
+//
+// This is the deterministic half of the watch case, and it works only because
+// of what Config.WatchDeliversBaseline promises: that the subscription is
+// established before the baseline is emitted. Given that ordering, receiving
+// the baseline is a genuine happens-after signal for "the subscription is
+// live", so the mutation that follows cannot be issued into a window where
+// nobody is listening. No sleep is involved and none is needed.
+//
+// Having taken the baseline, it consumes anything else already queued but does
+// not wait for more. Some providers emit several Updates around subscribe time
+// (a reconnect that re-emits, say). Left sitting in a small channel buffer,
+// those cost nothing for a provider that blocks on a full channel, but a
+// provider that drops sends into a full buffer would lose the mutation
+// notification to them - which is the one job drainNonBlocking did that was
+// never about timing.
+func awaitBaseline(ch <-chan mamori.Update, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case _, open := <-ch:
+		if !open {
+			return false
+		}
+	case <-timer.C:
+		return false
+	}
+	for {
+		select {
+		case _, open := <-ch:
+			if !open {
+				return true
+			}
+		default:
+			return true
+		}
+	}
+}
+
+// drainNonBlocking consumes Updates until the channel has been quiet for 200ms.
+// It is the fallback for a provider that has not set
+// Config.WatchDeliversBaseline, and it is worth being precise about what it
+// does and does not buy, because the answer is less than it looks.
+//
+// What it reliably does: empty the channel, so a provider that drops sends into
+// a full buffer still has room for the mutation notification.
+//
+// What it only appears to do: make an asynchronous subscription safe. The 200ms
+// is not a synchronization point with anything - it is a guess that whatever
+// goroutine Watch spawned has subscribed by now. It is enough for providers
+// whose subscription completes quickly and useless for one that takes longer,
+// and the kit cannot tell those apart. Two shapes explain why it has held up in
+// practice anyway. A provider that subscribes first and then reads-and-emits
+// the current value recovers on its own without help from any wait, because the
+// baseline read happens after the subscription and therefore observes a
+// mutation that the subscription missed; those providers should set
+// WatchDeliversBaseline and skip the wait entirely. A provider that subscribes
+// synchronously inside Watch was never at risk to begin with.
+//
+// The residual gap, which no amount of waiting closes: a provider that
+// subscribes asynchronously and emits no baseline offers the kit nothing to
+// synchronize on, so the wait is the only option and it is a guess. The fix
+// there belongs in the provider - subscribe before returning from Watch, or
+// emit a baseline after subscribing - not in a longer sleep here.
 func drainNonBlocking(ch <-chan mamori.Update) {
 	for {
 		select {

--- a/providertest/providertest_test.go
+++ b/providertest/providertest_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/xavidop/mamori"
 	"github.com/xavidop/mamori/providertest"
@@ -93,6 +94,189 @@ func TestConformanceKitPassesForCorrectProvider(t *testing.T) {
 		// exercised separately below by classifyingProvider.
 		NoResolveErrors: true,
 	})
+}
+
+// --- Watch: subscription timing ---
+//
+// WatchEmitsOnMutate has to mutate the backend after the watch is live, and
+// WatchableProvider says nothing about when Watch's subscription takes effect.
+// asyncSubscriber makes that window explicit and adjustable so the kit can be
+// tested against each shape a real provider can have, rather than against the
+// timing a particular machine happens to produce.
+//
+// subscribeDelay is how long after Watch returns the channel before the
+// subscription actually exists. Writes during that window reach no watcher.
+// emitBaseline says whether the provider, once subscribed, reads the current
+// value and emits it - the ordering Config.WatchDeliversBaseline describes.
+type asyncSubscriber struct {
+	mu             sync.Mutex
+	data           map[string]string
+	version        map[string]int
+	watchers       map[string][]chan mamori.Update
+	subscribeDelay time.Duration
+	emitBaseline   bool
+}
+
+func newAsync(delay time.Duration, baseline bool) *asyncSubscriber {
+	return &asyncSubscriber{
+		data: map[string]string{}, version: map[string]int{},
+		watchers:       map[string][]chan mamori.Update{},
+		subscribeDelay: delay, emitBaseline: baseline,
+	}
+}
+
+func (f *asyncSubscriber) Scheme() string { return "async" }
+
+func (f *asyncSubscriber) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, error) {
+	if err := ctx.Err(); err != nil {
+		return mamori.Value{}, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.data[ref.Path]
+	if !ok {
+		return mamori.Value{}, mamori.ErrNotFound
+	}
+	return mamori.Value{Bytes: []byte(v), Version: strconv.Itoa(f.version[ref.Path])}, nil
+}
+
+func (f *asyncSubscriber) Watch(ctx context.Context, ref mamori.Ref) (<-chan mamori.Update, error) {
+	ch := make(chan mamori.Update, 4)
+	go func() {
+		// Not subscribed yet. mamori permits exactly this: "a native-watch
+		// subscription is asynchronous" (reconciler.go, seedChainSources).
+		select {
+		case <-time.After(f.subscribeDelay):
+		case <-ctx.Done():
+			close(ch)
+			return
+		}
+		f.mu.Lock()
+		f.watchers[ref.Path] = append(f.watchers[ref.Path], ch)
+		if f.emitBaseline {
+			// Read AFTER subscribing. This ordering is the whole point: the
+			// read observes any write the subscription was too late for.
+			if v, ok := f.data[ref.Path]; ok {
+				ch <- mamori.Update{Value: mamori.Value{Bytes: []byte(v), Version: strconv.Itoa(f.version[ref.Path])}}
+			}
+		}
+		f.mu.Unlock()
+
+		<-ctx.Done()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		cur := f.watchers[ref.Path]
+		for i, c := range cur {
+			if c == ch {
+				f.watchers[ref.Path] = append(cur[:i], cur[i+1:]...)
+				break
+			}
+		}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (f *asyncSubscriber) set(key, val string) {
+	f.mu.Lock()
+	f.data[key] = val
+	f.version[key]++
+	chans := append([]chan mamori.Update(nil), f.watchers[key]...)
+	ver := strconv.Itoa(f.version[key])
+	f.mu.Unlock()
+	for _, ch := range chans {
+		select {
+		case ch <- mamori.Update{Value: mamori.Value{Bytes: []byte(val), Version: ver}}:
+		default:
+		}
+	}
+}
+
+func asyncConfig(b *asyncSubscriber) providertest.Config {
+	return providertest.Config{
+		New:               func() mamori.Provider { return b },
+		Ref:               func(key string) string { return "async://" + key },
+		Seed:              func(_ context.Context, key, val string) error { b.set(key, val); return nil },
+		Mutate:            func(_ context.Context, key, val string) error { b.set(key, val); return nil },
+		NoResolveErrors:   true,
+		EventuallyTimeout: 3 * time.Second,
+	}
+}
+
+// The case WatchDeliversBaseline exists for: the subscription takes far longer
+// than the fixed fallback wait, so no sleep the kit could pick would be right,
+// but waiting for the baseline is exact. Without the declaration this same
+// provider only passes because its post-subscribe read happens to recover the
+// missed write - see TestWatchLateSubscribeSurvivesOnlyViaBaselineRead.
+func TestWatchDeliversBaselineWaitsForLateSubscription(t *testing.T) {
+	cfg := asyncConfig(newAsync(600*time.Millisecond, true))
+	cfg.WatchDeliversBaseline = true
+	providertest.RunWatch(t, cfg)
+}
+
+// The declared path must not pay the fixed fallback wait, which is the concrete
+// cost the declaration removes and the part most likely to be quietly undone.
+//
+// The threshold is chosen against drainNonBlocking's own floor rather than
+// against a stopwatch: that wait cannot return until 200ms after the last
+// Update it saw, so a provider emitting its baseline immediately takes ~200ms
+// through the fallback and microseconds through awaitBaseline. 150ms sits
+// between the two with room on both sides. If RunWatch is ever changed to drain
+// unconditionally, this is the test that says so.
+func TestWatchDeliversBaselineSkipsTheFixedWait(t *testing.T) {
+	cfg := asyncConfig(newAsync(0, true))
+	cfg.WatchDeliversBaseline = true
+	start := time.Now()
+	providertest.RunWatch(t, cfg)
+	if elapsed := time.Since(start); elapsed >= 150*time.Millisecond {
+		t.Fatalf("RunWatch took %v with WatchDeliversBaseline set; it must wait for the "+
+			"baseline rather than for the fixed fallback interval", elapsed)
+	}
+}
+
+// Declaring a baseline that never arrives must fail with a message naming the
+// declaration, not hang until the suite's timeout. A provider whose watch
+// simply failed to start reaches the kit the same way, and the message covers
+// both.
+func TestWatchFailsWhenDeclaredBaselineNeverArrives(t *testing.T) {
+	cfg := asyncConfig(newAsync(10*time.Millisecond, false))
+	cfg.WatchDeliversBaseline = true
+	cfg.EventuallyTimeout = 250 * time.Millisecond
+	rec := &recordingTB{TB: t}
+	providertest.RunWatch(rec, cfg)
+	if !rec.failed {
+		t.Fatal("RunWatch passed a provider that declares WatchDeliversBaseline but emits none; it must fail")
+	}
+}
+
+// The counterweight to the test above, and the honest statement of what the
+// declaration is worth. Undeclared, this provider passes - but not because the
+// fixed 200ms wait covered a 600ms subscription. It passes because its baseline
+// read runs after the subscription and therefore picks up the mutation the
+// subscription was too late to be notified of. If this ever starts failing, the
+// fake's read-after-subscribe ordering was broken, not the kit's timing.
+func TestWatchLateSubscribeSurvivesOnlyViaBaselineRead(t *testing.T) {
+	providertest.RunWatch(t, asyncConfig(newAsync(600*time.Millisecond, true)))
+}
+
+// The residual gap, pinned as a test rather than left as a comment: a provider
+// that subscribes asynchronously and emits no baseline gives the kit nothing to
+// synchronize on, and the fallback wait is a guess that a slow enough
+// subscription defeats. This asserts the kit FAILS such a provider today. That
+// is a real limitation, and the fix belongs in the provider - subscribe before
+// returning from Watch, or emit a baseline after subscribing and declare it.
+//
+// If a future change closes this gap, this test is what will notice: it will
+// start failing, and it should then be inverted rather than deleted.
+func TestWatchCannotCoverAsyncSubscribeWithoutBaseline(t *testing.T) {
+	cfg := asyncConfig(newAsync(600*time.Millisecond, false))
+	cfg.EventuallyTimeout = 250 * time.Millisecond
+	rec := &recordingTB{TB: t}
+	providertest.RunWatch(rec, cfg)
+	if !rec.failed {
+		t.Fatal("RunWatch passed an async-subscribe provider with no baseline; " +
+			"if the kit gained a way to cover that shape, invert this test rather than deleting it")
+	}
 }
 
 // classifyingProvider is a minimal provider whose backend can be told to fail


### PR DESCRIPTION
`providertest.testWatch` drained the watch channel for a fixed **200ms** before mutating, on the theory that the wait gave an asynchronous subscription time to establish.

It does not do that. Measuring the actual provider shapes shows something worse.

## The sleep masks the bug it appears to guard against

Three shapes, each built and driven through the real `providertest.Run`:

| provider shape | result |
|---|---|
| subscribe → read → emit baseline | **passes with a 600ms subscribe delay**, far past any cover the sleep provides. The baseline *read* runs after the subscription, so it observes the very mutation the subscription was too late to be notified of. |
| async subscribe, **no** baseline | **fails regardless.** No constant is long enough in general. |
| **read baseline → subscribe** | **passes when its window is under 200ms — and it should not.** That is a genuine lost-notification window, the same bug fixed in the postgres fake. The sleep steps over the window before mutating. |

So the wait costs **detection**, not just time. Every in-tree watchable provider happens to be one of the two safe shapes, which is why 1500 iterations passed — and would have passed with `drainNonBlocking` deleted entirely.

## The fix

`Config.WatchDeliversBaseline` lets a provider declare that its subscription is established **before** its baseline is emitted. Given that ordering, receiving the baseline is a genuine happens-after signal for "the subscription is live", so the kit waits for that rather than for a clock — deterministic, and it mutates while a read-then-subscribe window would still be open.

**The zero value leaves the previous path as unchanged code**, so an out-of-tree provider that does not declare is exactly as well tested as before. Defaulting the other way would hard-fail `etcd` and `launchdarkly`, which legitimately emit no baseline.

`testWatch` is exported as `RunWatch(testing.TB, Config)`, mirroring the existing `RunErrorClassification`, so the kit can be driven against deliberately misbehaving providers without those expected failures failing the enclosing test.

## What it still cannot cover

Async subscribe with no baseline. There is no observable signal for it, so it is **pinned as a test asserting the limitation** rather than left as a comment, with instructions to invert that test if the gap is ever closed.

Mutation retry was considered and rejected: it does close the remaining gap, but it would mask the read-then-subscribe shape for every non-declarer, trading away more detection than it gains.

## Verification

Three plausible reversions were mutation-checked and each fails a different test. 32/32 provider modules pass under `-race`; `providertest` clean at `-count=40`; `-count=15` conformance stable on all 12 watch-running providers.

14 configs across 10 providers declare the field, each citing that provider's own ordering evidence. Three integration call sites declare it but could not be executed here, and were verified by reading the shared `Watch` code only.

**One correction to the premise this started from:** the saving is not "32 modules × 200ms". `testWatch` runs at 15 call sites, 3 behind the `integration` tag, so the measured recovery is **~2.4s**. The time is the least interesting of the three benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)