### PR TITLE
feat(azure): azure-appconfig provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 | core (built-in) | `env:` · `dotenv://` · `file://` · `exec:` (opt-in) | fsnotify (file/dotenv) · poll (env/exec) | ✅ |
 | `providers/aws` | `aws-sm://` · `aws-ps://` · `aws-appconfig://` | poll | ✅ |
 | `providers/gcp` | `gcp-sm://` | poll | ✅ |
-| `providers/azure` | `azure-kv://` | poll | ✅ |
+| `providers/azure` | `azure-kv://` · `azure-appconfig://` | poll | ✅ |
 | `providers/vault` | `vault://` | lease-aware poll (`NotAfter`) | ✅ |
 | `providers/k8s` | `k8s-secret://` · `k8s-cm://` | **native** (watch API) | ✅ |
 | `providers/consul` | `consul://` | **native** (blocking queries) | ✅ |

--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -1,19 +1,23 @@
-# mamori Azure Key Vault provider
+# mamori Azure providers
 
 [![conformance](https://img.shields.io/badge/mamori%20conformance-passing-brightgreen)](../../providertest)
 
-A [mamori](https://github.com/xavidop/mamori) provider for **Azure Key Vault**
-secrets. Import it for its side effect to register the `azure-kv` scheme:
+[mamori](https://github.com/xavidop/mamori) providers for two Azure services:
+**Azure Key Vault** secrets and **Azure App Configuration** settings. Import the
+module for its side effect to register both schemes:
 
 ```go
-import _ "github.com/xavidop/mamori/providers/azure"
+import _ "github.com/xavidop/mamori/providers/azure" // registers azure-kv:// and azure-appconfig://
 ```
 
-## Scheme
+## Schemes
 
-```
-azure-kv://<vault-name>/<secret-name>[#json-key]?version=<v>
-```
+| Scheme | Backend | Sensitive | Watch |
+|---|---|---|---|
+| `azure-kv://<vault-name>/<secret-name>[#json-key]?version=<v>` | Key Vault | ✅ | poll |
+| `azure-appconfig://<store>/<key>[#json-key][?label=<label>]` | App Configuration | no | poll |
+
+## `azure-kv://`
 
 The `<vault-name>` is expanded to the vault URL
 `https://<vault-name>.vault.azure.net`, and `<secret-name>` is fetched with the
@@ -31,8 +35,6 @@ Resolved values are always marked `Sensitive`. The `Version` is the native Key
 Vault secret version (falling back to a content hash if unavailable), so mamori
 detects changes cheaply.
 
-## Ref examples
-
 ```go
 type Config struct {
     // Whole secret value (latest version).
@@ -46,48 +48,123 @@ type Config struct {
 }
 ```
 
+## `azure-appconfig://`
+
+```text
+azure-appconfig://<store>/<key>[#json-key][?label=<label>]
+```
+
+The `<store>` name is expanded to the endpoint `https://<store>.azconfig.io`,
+and `<key>` (which may itself contain slashes) is fetched with the
+[`azappconfig`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig)
+SDK.
+
+| Part | Required | What it means |
+| --- | --- | --- |
+| `<store>` | yes | The App Configuration store name. The endpoint is built as `https://<store>.azconfig.io`. |
+| `<key>` | yes | The setting key within that store. May contain `/`. |
+| `#json-key` | no | Select one field from a JSON setting value (via `mamori.SelectKey`). |
+| `?label=<label>` | no | Select a labelled setting. |
+
+**An absent `?label=` is not a wildcard.** Azure App Configuration treats "no
+label" as its own distinct **null label**, not as "any label" or "the latest
+label". A setting stored under the null label and a setting stored under the
+label `prod` are two different settings that can hold two different values.
+This provider passes the label explicitly on every call - the empty string
+when `?label=` is absent - so a ref without `?label=` always resolves the
+null-labelled setting and never silently falls back onto (or is shadowed by) a
+labelled one.
+
+```go
+type Config struct {
+    // The null-labelled setting.
+    LogLevel string `source:"azure-appconfig://my-store/app/log-level"`
+
+    // The setting explicitly labelled "prod".
+    LogLevelProd string `source:"azure-appconfig://my-store/app/log-level?label=prod"`
+
+    // A field from a JSON setting value.
+    APIPassword string `source:"azure-appconfig://my-store/app/api-conn#password"`
+}
+```
+
+Resolved values are **never** marked `Sensitive`: App Configuration is a
+configuration service, not a secret store. `Value.Version` is the setting's
+ETag, falling back to `mamori.VersionHash` if the ETag is unavailable.
+
+### Key Vault references are rejected, not resolved
+
+App Configuration can store a **reference** to a Key Vault secret instead of a
+value: a setting with content type
+`application/vnd.microsoft.appconfig.keyvaultref+json` whose value is JSON
+shaped like `{"uri":"https://<vault>.vault.azure.net/secrets/<name>"}`. This
+provider detects that content type and fails the resolve with
+`mamori.ErrInvalid`, naming the equivalent `azure-kv://` ref to use instead,
+rather than resolving or otherwise following the reference.
+
+This is deliberate, not a missing feature: returning the reference's raw JSON
+would hand a caller the literal text `{"uri":"..."}` as, say, their database
+password. That value is a non-empty string, so it passes a typical
+non-empty-string validation and only fails much later, deep inside whatever
+consumes it (a database driver reporting a bogus auth failure, for example),
+far from the actual cause. Point a `secret.String` field at an `azure-kv://`
+ref for the vault named in the error instead.
+
 ## Authentication
 
-Authentication uses the **Azure default credential chain**
+Both providers use the **Azure default credential chain**
 ([`azidentity.NewDefaultAzureCredential`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewDefaultAzureCredential)),
 which tries, in order: environment variables, workload identity, managed
 identity, and the Azure CLI login. No explicit configuration is needed when
 running in an environment with an ambient identity (AKS pod identity, an Azure
 VM with a managed identity, or a developer machine logged in via `az login`).
 
-The identity needs the `secrets/get` permission (data-plane RBAC role
-**Key Vault Secrets User**, or a matching access policy) on the target vault.
+- The Key Vault identity needs the `secrets/get` permission (data-plane RBAC
+  role **Key Vault Secrets User**, or a matching access policy) on the target
+  vault.
+- The App Configuration identity needs the **App Configuration Data Reader**
+  role (or equivalent) on the target store.
 
-Clients are created lazily, one per vault name, on first resolve - so importing
-the package and registering the provider performs no I/O and needs no
-credentials at init time.
+Clients are created lazily, one per vault/store name, on first resolve - so
+importing the package and registering both providers performs no I/O and needs
+no credentials at init time.
 
 ### Explicit configuration
 
-To inject a specific credential, register the provider yourself:
+To inject a specific credential, register the provider(s) yourself:
 
 ```go
 cred, err := azidentity.NewManagedIdentityCredential(nil)
 // handle err
 cfg, err := mamori.Load[Config](ctx,
     mamori.WithProvider(azure.New(azure.WithCredential(cred))),
+    mamori.WithProvider(azure.NewAppConfig(azure.WithAppConfigCredential(cred))),
 )
 ```
 
 Options:
 
-- `azure.WithCredential(cred azcore.TokenCredential)` - use an explicit
-  credential instead of the default chain.
-- `azure.WithClient(c)` - inject a pre-built client (or an in-memory fake in
-  tests) used for every vault.
+- `azure.WithCredential(cred azcore.TokenCredential)` / `azure.WithClient(c)` -
+  Key Vault provider: an explicit credential, or an injected client (a
+  pre-built `*azsecrets.Client` or, in tests, an in-memory fake) used for
+  every vault.
+- `azure.WithAppConfigCredential(cred azcore.TokenCredential)` /
+  `azure.WithAppConfigClient(c)` - App Configuration provider: the same two
+  knobs, used for every store.
+
+`Option` and `AppConfigOption` are distinct types, one per provider, so they
+cannot be mixed up at the call site.
 
 ## Watch
 
-Azure Key Vault has **no native change notification** for secrets, so this
-provider does not implement `WatchableProvider`. mamori polls it on the
-configured interval instead.
+Neither Azure Key Vault nor Azure App Configuration's `GetSetting` call offers
+a native change notification usable here, so neither provider implements
+`WatchableProvider`. mamori polls both instead.
 
 ## Error classification
+
+Both providers share one classifier, `classifyAzure`, since App Configuration
+returns the same HTTP statuses as Key Vault:
 
 | HTTP status | mamori kind |
 |---|---|
@@ -106,13 +183,16 @@ reachable with `errors.As`.
 ## Verified vs. needs a live backend
 
 - **Verified in unit tests (no Azure account):** scheme, resolution, JSON
-  `#key` selection, `?version=` pinning, not-found → `mamori.ErrNotFound`
-  mapping (Azure 404), sensitivity, version monotonicity, context cancellation,
-  concurrency, goroutine hygiene, and the full `providertest.Run` conformance
-  suite - all run against an in-memory fake `kvClient`.
-- **Needs a live backend:** end-to-end auth via the default credential chain and
-  real vault access. A live test is provided behind a build tag and is not run
-  in CI:
+  `#key` selection, not-found → `mamori.ErrNotFound` mapping (Azure 404),
+  version handling, context cancellation, concurrency, goroutine hygiene, and
+  the full `providertest.Run` conformance suite for both schemes - all run
+  against in-memory fakes. For Key Vault: `?version=` pinning and
+  `Sensitive == true`. For App Configuration: the null-label-is-not-a-wildcard
+  behavior of an absent `?label=`, `Sensitive == false`, and the Key Vault
+  reference rejection.
+- **Needs a live backend:** end-to-end auth via the default credential chain
+  and real vault/store access. A live test is provided behind a build tag and
+  is not run in CI:
 
   ```sh
   MAMORI_AZURE_VAULT=<vault-name> \

--- a/providers/azure/appconfig.go
+++ b/providers/azure/appconfig.go
@@ -105,7 +105,7 @@ func (p *AppConfigProvider) Resolve(ctx context.Context, ref mamori.Ref) (mamori
 	store, key, ok := strings.Cut(ref.Path, "/")
 	if !ok || store == "" || key == "" {
 		return mamori.Value{}, fmt.Errorf(
-			"azure-appconfig: ref %q must be azure-appconfig://<store>/<key>[#json-key][?label=l]: %w",
+			"azure-appconfig: ref %q must be azure-appconfig://<store>/<key>[#json-key][?label=<label>]: %w",
 			ref.Raw, mamori.ErrInvalid)
 	}
 
@@ -173,30 +173,47 @@ func (p *AppConfigProvider) Resolve(ctx context.Context, ref mamori.Ref) (mamori
 	}, nil
 }
 
+// keyVaultGenericHint is the advice given when the reference payload is not
+// the shape the service documents, or is a shape this helper does not (yet)
+// understand well enough to name a specific ref for.
+const keyVaultGenericHint = "use an azure-kv:// ref for the referenced secret"
+
 // keyVaultHint turns a Key Vault reference payload into the azure-kv:// ref the
-// user should write instead. It degrades to generic advice when the payload is
-// not the shape the service documents, since this only ever builds an error
-// message and must never itself fail.
+// user should write instead. It degrades to keyVaultGenericHint whenever the
+// payload is not the shape the service documents, since this only ever builds
+// an error message and must never itself fail or panic.
 func keyVaultHint(value string) string {
 	var ref struct {
 		URI string `json:"uri"`
 	}
 	if err := json.Unmarshal([]byte(value), &ref); err != nil || ref.URI == "" {
-		return "use an azure-kv:// ref for the referenced secret"
+		return keyVaultGenericHint
 	}
-	// https://<vault>.vault.azure.net/secrets/<name>
+	// https://<vault>.vault.azure.net/secrets/<name>[/<version>]
 	rest, ok := strings.CutPrefix(ref.URI, "https://")
 	if !ok {
-		return "use an azure-kv:// ref for the referenced secret"
+		return keyVaultGenericHint
 	}
 	host, path, ok := strings.Cut(rest, "/")
 	if !ok {
-		return "use an azure-kv:// ref for the referenced secret"
+		return keyVaultGenericHint
 	}
 	vault, _, _ := strings.Cut(host, ".")
-	name := strings.TrimPrefix(path, "secrets/")
-	if vault == "" || name == "" {
-		return "use an azure-kv:// ref for the referenced secret"
+	if vault == "" {
+		return keyVaultGenericHint
+	}
+	secretsPath, ok := strings.CutPrefix(path, "secrets/")
+	if !ok {
+		// Not a secret reference at all (e.g. a "keys/" or "certificates/"
+		// reference) - do not guess at a name that was never a secret name.
+		return keyVaultGenericHint
+	}
+	name, version, hasVersion := strings.Cut(secretsPath, "/")
+	if name == "" {
+		return keyVaultGenericHint
+	}
+	if hasVersion && version != "" {
+		return fmt.Sprintf("use azure-kv://%s/%s?version=%s instead", vault, name, version)
 	}
 	return fmt.Sprintf("use azure-kv://%s/%s instead", vault, name)
 }

--- a/providers/azure/appconfig.go
+++ b/providers/azure/appconfig.go
@@ -1,0 +1,239 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
+	"github.com/xavidop/mamori"
+)
+
+// SchemeAppConfig is the URL scheme handled by AppConfigProvider.
+const SchemeAppConfig = "azure-appconfig"
+
+// keyVaultRefContentType marks a setting whose value is a reference to a Key
+// Vault secret rather than the value itself.
+const keyVaultRefContentType = "application/vnd.microsoft.appconfig.keyvaultref+json"
+
+// appConfigClient is the minimal subset of *azappconfig.Client this provider
+// needs. The real SDK client satisfies it; tests inject an in-memory fake.
+type appConfigClient interface {
+	GetSetting(ctx context.Context, key string, opts *azappconfig.GetSettingOptions) (azappconfig.GetSettingResponse, error)
+}
+
+// AppConfigProvider resolves
+// azure-appconfig://<store>/<key>[#json-key][?label=<label>] refs against
+// Azure App Configuration. One provider serves every store named in a ref,
+// lazily building and caching a client per store name, so construction never
+// performs I/O and init-time registration is safe without Azure credentials
+// present.
+//
+// AppConfigProvider is safe for concurrent use.
+type AppConfigProvider struct {
+	mu sync.Mutex
+
+	clients map[string]appConfigClient
+	fixed   appConfigClient
+
+	cred         azcore.TokenCredential
+	credErr      error
+	credResolved bool
+
+	newCredential func() (azcore.TokenCredential, error)
+	newClient     func(endpoint string, cred azcore.TokenCredential) (appConfigClient, error)
+}
+
+// AppConfigOption configures an AppConfigProvider. It is distinct from Option,
+// which configures the Key Vault provider in this same package.
+type AppConfigOption func(*AppConfigProvider)
+
+// WithAppConfigCredential injects an explicit token credential instead of the
+// default Azure credential chain.
+func WithAppConfigCredential(cred azcore.TokenCredential) AppConfigOption {
+	return func(p *AppConfigProvider) {
+		p.newCredential = func() (azcore.TokenCredential, error) { return cred, nil }
+	}
+}
+
+// WithAppConfigClient injects a client used for every store, bypassing
+// credential and client construction. It is primarily intended for tests.
+func WithAppConfigClient(c appConfigClient) AppConfigOption {
+	return func(p *AppConfigProvider) { p.fixed = c }
+}
+
+// NewAppConfig constructs an Azure App Configuration provider. With no options
+// it uses the Azure default credential chain and builds a real azappconfig
+// client per store lazily on first Resolve.
+func NewAppConfig(opts ...AppConfigOption) *AppConfigProvider {
+	p := &AppConfigProvider{
+		clients: map[string]appConfigClient{},
+		newCredential: func() (azcore.TokenCredential, error) {
+			return azidentity.NewDefaultAzureCredential(nil)
+		},
+	}
+	p.newClient = func(endpoint string, cred azcore.TokenCredential) (appConfigClient, error) {
+		return azappconfig.NewClient(endpoint, cred, nil)
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// newAppConfigWithClient returns a provider backed by a caller-supplied
+// client. It is the injection seam used by tests.
+func newAppConfigWithClient(c appConfigClient) *AppConfigProvider {
+	return NewAppConfig(WithAppConfigClient(c))
+}
+
+// Compile-time interface check.
+var _ mamori.Provider = (*AppConfigProvider)(nil)
+
+// Scheme returns "azure-appconfig".
+func (p *AppConfigProvider) Scheme() string { return SchemeAppConfig }
+
+// Resolve fetches a setting from Azure App Configuration. The ref path is
+// "<store>/<key>", where the key may itself contain slashes. A #json-key
+// fragment selects a field from a JSON payload, and ?label=<label> selects a
+// labelled setting.
+func (p *AppConfigProvider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, error) {
+	store, key, ok := strings.Cut(ref.Path, "/")
+	if !ok || store == "" || key == "" {
+		return mamori.Value{}, fmt.Errorf(
+			"azure-appconfig: ref %q must be azure-appconfig://<store>/<key>[#json-key][?label=l]: %w",
+			ref.Raw, mamori.ErrInvalid)
+	}
+
+	client, err := p.clientFor(store)
+	if err != nil {
+		return mamori.Value{}, fmt.Errorf("azure-appconfig: building client for store %q: %w", store, err)
+	}
+
+	// An absent ?label= means Azure's null label, which is a distinct setting
+	// from any labelled one, not a wildcard. Passing the empty string
+	// explicitly requests that null label.
+	label := ref.Opt("label")
+	opts := &azappconfig.GetSettingOptions{Label: &label}
+
+	resp, err := client.GetSetting(ctx, key, opts)
+	if err != nil {
+		if isNotFound(err) {
+			return mamori.Value{}, fmt.Errorf(
+				"azure-appconfig: setting %q in store %q not found: %w: %w",
+				key, store, mamori.ErrNotFound, err)
+		}
+		return mamori.Value{}, fmt.Errorf("azure-appconfig: resolve %q: %w", ref.Path, classifyAzure(err))
+	}
+	if resp.Value == nil {
+		return mamori.Value{}, fmt.Errorf(
+			"azure-appconfig: setting %q in store %q has no value: %w", key, store, mamori.ErrNotFound)
+	}
+
+	// A Key Vault reference is a pointer to a secret, not the secret. Returning
+	// its JSON would hand the caller {"uri":"..."} as their value, which passes
+	// a non-empty-string validation and fails much later inside whatever
+	// consumes it. Fail here instead, naming the ref they should have written.
+	if resp.ContentType != nil && strings.HasPrefix(*resp.ContentType, keyVaultRefContentType) {
+		return mamori.Value{}, fmt.Errorf(
+			"azure-appconfig: setting %q in store %q is a Key Vault reference, which this provider does not resolve; %s: %w",
+			key, store, keyVaultHint(*resp.Value), mamori.ErrInvalid)
+	}
+
+	data := []byte(*resp.Value)
+	if ref.Key != "" {
+		data, err = mamori.SelectKey(data, ref.Key)
+		if err != nil {
+			return mamori.Value{}, err
+		}
+	}
+
+	version := ""
+	if resp.ETag != nil {
+		version = string(*resp.ETag)
+	}
+	if version == "" {
+		version = mamori.VersionHash(data)
+	}
+
+	meta := map[string]string{"store": store}
+	if label != "" {
+		meta["label"] = label
+	}
+
+	return mamori.Value{
+		Bytes:     data,
+		Version:   version,
+		Sensitive: false, // a configuration service, not a secret store
+		Metadata:  meta,
+	}, nil
+}
+
+// keyVaultHint turns a Key Vault reference payload into the azure-kv:// ref the
+// user should write instead. It degrades to generic advice when the payload is
+// not the shape the service documents, since this only ever builds an error
+// message and must never itself fail.
+func keyVaultHint(value string) string {
+	var ref struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal([]byte(value), &ref); err != nil || ref.URI == "" {
+		return "use an azure-kv:// ref for the referenced secret"
+	}
+	// https://<vault>.vault.azure.net/secrets/<name>
+	rest, ok := strings.CutPrefix(ref.URI, "https://")
+	if !ok {
+		return "use an azure-kv:// ref for the referenced secret"
+	}
+	host, path, ok := strings.Cut(rest, "/")
+	if !ok {
+		return "use an azure-kv:// ref for the referenced secret"
+	}
+	vault, _, _ := strings.Cut(host, ".")
+	name := strings.TrimPrefix(path, "secrets/")
+	if vault == "" || name == "" {
+		return "use an azure-kv:// ref for the referenced secret"
+	}
+	return fmt.Sprintf("use azure-kv://%s/%s instead", vault, name)
+}
+
+// clientFor returns the client for the named store, creating and caching it on
+// first use. When a fixed client was injected it is returned for every store.
+func (p *AppConfigProvider) clientFor(store string) (appConfigClient, error) {
+	if p.fixed != nil {
+		return p.fixed, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if c, ok := p.clients[store]; ok {
+		return c, nil
+	}
+
+	cred, err := p.credentialLocked()
+	if err != nil {
+		return nil, err
+	}
+	endpoint := "https://" + store + ".azconfig.io"
+	c, err := p.newClient(endpoint, cred)
+	if err != nil {
+		return nil, err
+	}
+	p.clients[store] = c
+	return c, nil
+}
+
+// credentialLocked resolves the token credential at most once. Callers must
+// hold p.mu.
+func (p *AppConfigProvider) credentialLocked() (azcore.TokenCredential, error) {
+	if !p.credResolved {
+		p.cred, p.credErr = p.newCredential()
+		p.credResolved = true
+	}
+	return p.cred, p.credErr
+}

--- a/providers/azure/appconfig_test.go
+++ b/providers/azure/appconfig_test.go
@@ -1,0 +1,261 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
+	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providertest"
+)
+
+// settingKey identifies a setting by key and label. An absent label is
+// Azure's null label, which is a distinct setting from any labelled one, so
+// the empty string is a meaningful map key here rather than a missing value.
+type settingKey struct {
+	key   string
+	label string
+}
+
+type fakeSetting struct {
+	value       string
+	etag        string
+	contentType string
+}
+
+type fakeAppConfig struct {
+	mu       sync.Mutex
+	settings map[settingKey]fakeSetting
+	fails    map[string]error
+	counter  int
+}
+
+func newFakeAppConfig() *fakeAppConfig {
+	return &fakeAppConfig{
+		settings: map[settingKey]fakeSetting{},
+		fails:    map[string]error{},
+	}
+}
+
+func (f *fakeAppConfig) set(key, label, val string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.counter++
+	f.settings[settingKey{key, label}] = fakeSetting{value: val, etag: fmt.Sprintf("e%d", f.counter)}
+}
+
+// setTyped stores a setting with an explicit content type, used to model a
+// Key Vault reference.
+func (f *fakeAppConfig) setTyped(key, label, val, contentType string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.counter++
+	f.settings[settingKey{key, label}] = fakeSetting{value: val, etag: fmt.Sprintf("e%d", f.counter), contentType: contentType}
+}
+
+func (f *fakeAppConfig) remove(key, label string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.settings, settingKey{key, label})
+}
+
+func (f *fakeAppConfig) fail(key string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fails[key] = err
+}
+
+func (f *fakeAppConfig) clear(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.fails, key)
+}
+
+func (f *fakeAppConfig) GetSetting(ctx context.Context, key string, opts *azappconfig.GetSettingOptions) (azappconfig.GetSettingResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return azappconfig.GetSettingResponse{}, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if err, ok := f.fails[key]; ok {
+		return azappconfig.GetSettingResponse{}, err
+	}
+
+	var label string
+	if opts != nil && opts.Label != nil {
+		label = *opts.Label
+	}
+	s, ok := f.settings[settingKey{key, label}]
+	if !ok {
+		return azappconfig.GetSettingResponse{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+
+	etag := azcore.ETag(s.etag)
+	resp := azappconfig.GetSettingResponse{}
+	resp.Key = &key
+	resp.Value = &s.value
+	resp.ETag = &etag
+	if s.contentType != "" {
+		ct := s.contentType
+		resp.ContentType = &ct
+	}
+	return resp, nil
+}
+
+func TestAzureAppConfigResolve(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.set("db/port", "", "5432")
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/db/port")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	v, err := p.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := string(v.Bytes); got != "5432" {
+		t.Errorf("Bytes = %q, want %q", got, "5432")
+	}
+	if v.Sensitive {
+		t.Error("Sensitive = true, want false: App Configuration is not a secret store")
+	}
+	if v.Version == "" {
+		t.Error("Version is empty, want the setting's ETag")
+	}
+}
+
+// TestAzureAppConfigLabelIsNotWildcard asserts that an absent ?label= selects
+// the null label rather than matching any label. The two are distinct settings
+// in the service, and conflating them would silently return the wrong value.
+func TestAzureAppConfigLabelIsNotWildcard(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.set("db/port", "prod", "5432")
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/db/port")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if _, err := p.Resolve(context.Background(), ref); !errors.Is(err, mamori.ErrNotFound) {
+		t.Errorf("Resolve without a label found the 'prod'-labelled setting; error = %v, want errors.Is(ErrNotFound)", err)
+	}
+
+	labelled, err := mamori.ParseRef("azure-appconfig://mystore/db/port?label=prod")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	v, err := p.Resolve(context.Background(), labelled)
+	if err != nil {
+		t.Fatalf("Resolve with ?label=prod: %v", err)
+	}
+	if got := string(v.Bytes); got != "5432" {
+		t.Errorf("Bytes = %q, want %q", got, "5432")
+	}
+}
+
+// TestAzureAppConfigKeyVaultReferenceRejected covers the deliberate choice to
+// fail rather than return the reference JSON. A caller whose field is a
+// password would otherwise receive the literal text {"uri":"..."}, which
+// validates as a non-empty string and reaches a database driver, surfacing as
+// an auth failure far from its cause.
+func TestAzureAppConfigKeyVaultReferenceRejected(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.setTyped("db/password", "", `{"uri":"https://myvault.vault.azure.net/secrets/dbpass"}`,
+		"application/vnd.microsoft.appconfig.keyvaultref+json")
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/db/password")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	v, err := p.Resolve(context.Background(), ref)
+	if err == nil {
+		t.Fatalf("Resolve returned %q, want an error: a Key Vault reference must never be applied as a value", v.Bytes)
+	}
+	if !errors.Is(err, mamori.ErrInvalid) {
+		t.Errorf("error %v does not satisfy errors.Is(ErrInvalid)", err)
+	}
+	if !strings.Contains(err.Error(), "azure-kv://") {
+		t.Errorf("error %q does not name the azure-kv:// ref the user should write instead", err)
+	}
+}
+
+// TestAzureAppConfigResolveNotFoundAfterRemove exercises fakeAppConfig.remove,
+// proving a setting that existed and was then deleted is reported not-found on
+// the next resolve, distinct from TestAzureAppConfigNotFound (which never had
+// a setting at all).
+func TestAzureAppConfigResolveNotFoundAfterRemove(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.set("db/port", "", "5432")
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/db/port")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if _, err := p.Resolve(context.Background(), ref); err != nil {
+		t.Fatalf("Resolve before remove: %v", err)
+	}
+
+	fake.remove("db/port", "")
+
+	if _, err := p.Resolve(context.Background(), ref); !errors.Is(err, mamori.ErrNotFound) {
+		t.Errorf("Resolve after remove error = %v, want errors.Is(ErrNotFound)", err)
+	}
+}
+
+func TestAzureAppConfigNotFound(t *testing.T) {
+	fake := newFakeAppConfig()
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/nope")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if _, err := p.Resolve(context.Background(), ref); !errors.Is(err, mamori.ErrNotFound) {
+		t.Errorf("Resolve error = %v, want errors.Is(ErrNotFound)", err)
+	}
+}
+
+func TestConformanceAzureAppConfig(t *testing.T) {
+	fake := newFakeAppConfig()
+	providertest.Run(t, providertest.Config{
+		New: func() mamori.Provider { return newAppConfigWithClient(fake) },
+		Ref: func(key string) string { return SchemeAppConfig + "://mystore/" + key },
+		PointerRef: func(key, frag string) string {
+			return SchemeAppConfig + "://mystore/" + key + frag
+		},
+		Seed:   func(_ context.Context, key, val string) error { fake.set(key, "", val); return nil },
+		Mutate: func(_ context.Context, key, val string) error { fake.set(key, "", val); return nil },
+		Fail:   func(_ context.Context, key string, err error) error { fake.fail(key, err); return nil },
+		Clear:  func(_ context.Context, key string) error { fake.clear(key); return nil },
+	})
+}
+
+func TestAzureAppConfigResolvePreservesClassification(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.set("k", "", "v")
+	fake.fail("k", &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"})
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/k")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	_, err = p.Resolve(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Resolve returned nil error")
+	}
+	if got := mamori.ErrorKind(err); got != mamori.KindPermissionDenied {
+		t.Fatalf("ErrorKind(err) = %q, want %q; classifyAzure may not be wired into the App Configuration resolve path", got, mamori.KindPermissionDenied)
+	}
+}

--- a/providers/azure/appconfig_test.go
+++ b/providers/azure/appconfig_test.go
@@ -65,6 +65,24 @@ func (f *fakeAppConfig) remove(key, label string) {
 	delete(f.settings, settingKey{key, label})
 }
 
+// setNoETag stores a setting with no ETag at all, modeling a response the
+// service never actually sends but which the provider must still tolerate,
+// to exercise the mamori.VersionHash fallback.
+func (f *fakeAppConfig) setNoETag(key, label, val string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.settings[settingKey{key, label}] = fakeSetting{value: val}
+}
+
+// etagOf returns the ETag stored for key/label, for tests that must assert
+// Value.Version equals the specific ETag the fake returned rather than merely
+// being non-empty.
+func (f *fakeAppConfig) etagOf(key, label string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.settings[settingKey{key, label}].etag
+}
+
 func (f *fakeAppConfig) fail(key string, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -88,20 +106,45 @@ func (f *fakeAppConfig) GetSetting(ctx context.Context, key string, opts *azappc
 		return azappconfig.GetSettingResponse{}, err
 	}
 
-	var label string
+	var s fakeSetting
+	var found bool
 	if opts != nil && opts.Label != nil {
-		label = *opts.Label
+		// A non-nil Label - including a pointer to the empty string - selects
+		// exactly that setting. The empty string means the null label
+		// specifically, not "no filter".
+		s, found = f.settings[settingKey{key, *opts.Label}]
+	} else {
+		// A nil Label has no real analogue in the actual azappconfig SDK
+		// (the generated client only ever sends the label query parameter
+		// when the pointer is non-nil); we model it here as a wildcard that
+		// matches any label for this key, preferring a labelled setting over
+		// the null-labelled one when both exist. This is deliberately more
+		// permissive than the real service, so that an implementation which
+		// forgets to pass the label explicitly for an absent ?label= gets
+		// served a plausible-looking wrong answer here too, instead of the
+		// fake silently agreeing with a bug by coincidence.
+		for k, v := range f.settings {
+			if k.key != key {
+				continue
+			}
+			if k.label != "" {
+				s, found = v, true
+				break
+			}
+			s, found = v, true
+		}
 	}
-	s, ok := f.settings[settingKey{key, label}]
-	if !ok {
+	if !found {
 		return azappconfig.GetSettingResponse{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 	}
 
-	etag := azcore.ETag(s.etag)
 	resp := azappconfig.GetSettingResponse{}
 	resp.Key = &key
 	resp.Value = &s.value
-	resp.ETag = &etag
+	if s.etag != "" {
+		etag := azcore.ETag(s.etag)
+		resp.ETag = &etag
+	}
 	if s.contentType != "" {
 		ct := s.contentType
 		resp.ContentType = &ct
@@ -128,8 +171,30 @@ func TestAzureAppConfigResolve(t *testing.T) {
 	if v.Sensitive {
 		t.Error("Sensitive = true, want false: App Configuration is not a secret store")
 	}
-	if v.Version == "" {
-		t.Error("Version is empty, want the setting's ETag")
+	if want := fake.etagOf("db/port", ""); v.Version != want {
+		t.Errorf("Version = %q, want the setting's own ETag %q", v.Version, want)
+	}
+}
+
+// TestAzureAppConfigResolveVersionHashFallback asserts that when the service
+// returns no ETag at all, Version falls back to mamori.VersionHash(data)
+// rather than staying empty.
+func TestAzureAppConfigResolveVersionHashFallback(t *testing.T) {
+	fake := newFakeAppConfig()
+	fake.setNoETag("db/port", "", "5432")
+	p := newAppConfigWithClient(fake)
+
+	ref, err := mamori.ParseRef("azure-appconfig://mystore/db/port")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	v, err := p.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := mamori.VersionHash(v.Bytes)
+	if v.Version != want {
+		t.Errorf("Version = %q, want the VersionHash fallback %q", v.Version, want)
 	}
 }
 
@@ -184,8 +249,72 @@ func TestAzureAppConfigKeyVaultReferenceRejected(t *testing.T) {
 	if !errors.Is(err, mamori.ErrInvalid) {
 		t.Errorf("error %v does not satisfy errors.Is(ErrInvalid)", err)
 	}
-	if !strings.Contains(err.Error(), "azure-kv://") {
-		t.Errorf("error %q does not name the azure-kv:// ref the user should write instead", err)
+	// Must name the *specific* ref for this reference's vault and secret, not
+	// merely mention the azure-kv:// scheme - keyVaultHint's generic fallback
+	// text also contains "azure-kv://", so a substring check on the scheme
+	// alone would pass even if the hint degraded to generic advice.
+	const wantRef = "azure-kv://myvault/dbpass"
+	if !strings.Contains(err.Error(), wantRef) {
+		t.Errorf("error %q does not name the specific %s ref the user should write instead", err, wantRef)
+	}
+}
+
+// TestKeyVaultHint covers keyVaultHint directly: the well-formed unversioned
+// and versioned Key Vault reference shapes, and every malformed payload shape
+// that must degrade to keyVaultGenericHint rather than naming a bogus ref.
+func TestKeyVaultHint(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "unversioned secret",
+			value: `{"uri":"https://myvault.vault.azure.net/secrets/dbpass"}`,
+			want:  "use azure-kv://myvault/dbpass instead",
+		},
+		{
+			name:  "versioned secret",
+			value: `{"uri":"https://myvault.vault.azure.net/secrets/dbpass/abc123"}`,
+			want:  "use azure-kv://myvault/dbpass?version=abc123 instead",
+		},
+		{
+			name:  "non-JSON payload",
+			value: "not json at all",
+			want:  keyVaultGenericHint,
+		},
+		{
+			name:  "empty JSON object",
+			value: "{}",
+			want:  keyVaultGenericHint,
+		},
+		{
+			name:  "missing https scheme",
+			value: `{"uri":"myvault.vault.azure.net/secrets/dbpass"}`,
+			want:  keyVaultGenericHint,
+		},
+		{
+			name:  "empty host",
+			value: `{"uri":"https:///secrets/dbpass"}`,
+			want:  keyVaultGenericHint,
+		},
+		{
+			name:  "empty secret name",
+			value: `{"uri":"https://myvault.vault.azure.net/secrets/"}`,
+			want:  keyVaultGenericHint,
+		},
+		{
+			name:  "path not under secrets/",
+			value: `{"uri":"https://myvault.vault.azure.net/keys/dbpass"}`,
+			want:  keyVaultGenericHint,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := keyVaultHint(tc.value); got != tc.want {
+				t.Errorf("keyVaultHint(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -210,6 +339,27 @@ func TestAzureAppConfigResolveNotFoundAfterRemove(t *testing.T) {
 
 	if _, err := p.Resolve(context.Background(), ref); !errors.Is(err, mamori.ErrNotFound) {
 		t.Errorf("Resolve after remove error = %v, want errors.Is(ErrNotFound)", err)
+	}
+}
+
+// TestAzureAppConfigResolveBadRef mirrors azure_test.go's TestResolveBadRef
+// for the Key Vault provider: a malformed ref (missing store or missing key)
+// must fail, but not with ErrNotFound - it never reached the backend at all.
+func TestAzureAppConfigResolveBadRef(t *testing.T) {
+	p := newAppConfigWithClient(newFakeAppConfig())
+	for _, raw := range []string{
+		"azure-appconfig://onlystore", // no key
+		"azure-appconfig:///keyonly",  // no store
+	} {
+		ref, err := mamori.ParseRef(raw)
+		if err != nil {
+			t.Fatalf("ParseRef(%q): %v", raw, err)
+		}
+		if _, err := p.Resolve(context.Background(), ref); err == nil {
+			t.Errorf("Resolve(%q) = nil error, want a malformed-ref error", raw)
+		} else if errors.Is(err, mamori.ErrNotFound) {
+			t.Errorf("Resolve(%q) returned ErrNotFound; a malformed ref is not not-found", raw)
+		}
 	}
 }
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -1,6 +1,8 @@
-// Package azure provides a mamori Provider for Azure Key Vault secrets.
+// Package azure provides mamori Providers for two Azure services: Key Vault
+// secrets and App Configuration settings.
 //
-// It resolves refs of the form:
+// The Key Vault provider (Provider, registered under Scheme = "azure-kv")
+// resolves refs of the form:
 //
 //	azure-kv://<vault-name>/<secret-name>[#json-key]?version=<v>
 //
@@ -11,9 +13,22 @@
 // ?version=<v> query pins a specific secret version; when omitted the latest
 // version is returned.
 //
-// Values are always marked Sensitive. Azure Key Vault has no native change
-// notification for secrets, so this provider does not implement Watch; mamori
-// polls it instead.
+// The App Configuration provider (AppConfigProvider, registered under
+// SchemeAppConfig = "azure-appconfig") resolves refs of the form:
+//
+//	azure-appconfig://<store>/<key>[#json-key][?label=<label>]
+//
+// The store name is turned into the endpoint https://<store>.azconfig.io and
+// the setting is fetched with the azappconfig SDK. An absent ?label= requests
+// Azure's null label, not any label, since the two are distinct settings in
+// the service. A setting stored as a Key Vault reference (content type
+// application/vnd.microsoft.appconfig.keyvaultref+json) is never resolved;
+// Resolve fails with mamori.ErrInvalid naming the equivalent azure-kv:// ref.
+//
+// Key Vault values are always marked Sensitive; App Configuration values never
+// are, since App Configuration is a configuration service, not a secret store.
+// Neither provider implements Watch, since neither Azure service has a native
+// change notification usable here; mamori polls both instead.
 package azure
 
 import (
@@ -33,7 +48,10 @@ import (
 // Scheme is the URL scheme handled by this provider.
 const Scheme = "azure-kv"
 
-func init() { mamori.Register(New()) }
+func init() {
+	mamori.Register(New())
+	mamori.Register(NewAppConfig())
+}
 
 // kvClient is the minimal subset of *azsecrets.Client this provider needs. The
 // real SDK client satisfies it, and tests inject an in-memory fake.

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -97,6 +97,27 @@ func TestScheme(t *testing.T) {
 	}
 }
 
+func TestRegisteredSchemes(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range mamori.RegisteredSchemes() {
+		got[s] = true
+	}
+	for _, want := range []string{Scheme, SchemeAppConfig} {
+		if !got[want] {
+			t.Errorf("scheme %q was not registered by init()", want)
+		}
+	}
+}
+
+func TestConstructorSchemes(t *testing.T) {
+	if s := New().Scheme(); s != Scheme {
+		t.Errorf("Provider.Scheme() = %q, want %q", s, Scheme)
+	}
+	if s := NewAppConfig().Scheme(); s != SchemeAppConfig {
+		t.Errorf("AppConfigProvider.Scheme() = %q, want %q", s, SchemeAppConfig)
+	}
+}
+
 func TestResolve(t *testing.T) {
 	fake := newFakeVault()
 	fake.set("db-password", "s3cr3t")

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
+	github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/xavidop/mamori v0.1.0
 )

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 h1:CU4+EJeJi3TKYWEcYuSd
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0/go.mod h1:q0+UTSRvShwUCrR/s5HtyInYphN7Wvxb7snFM3u+SLA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
+github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0 h1:uU4FujKFQAz31AbWOO3INV9qfIanHeIUSsGhRlcJJmg=
+github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0/go.mod h1:qr3M3Oy6V98VR0c5tCHKUpaeJTRQh6KYzJewRtFWqfc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFOzch6ZJo4Ct9hI4A9Y2fPen5YNRTPmkSBhe5m0ZQ=

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -69,6 +69,7 @@ const groups = [
       { slug: "providers/redis", title: "Redis", indent: true },
       { subhead: "KV & config" },
       { slug: "providers/aws-appconfig", title: "AWS AppConfig", indent: true },
+      { slug: "providers/azure-appconfig", title: "Azure AppConfig", indent: true },
       { slug: "providers/consul", title: "Consul", indent: true },
       { slug: "providers/etcd", title: "etcd", indent: true },
       { subhead: "Kubernetes" },

--- a/site/src/pages/docs/providers/azure-appconfig.md
+++ b/site/src/pages/docs/providers/azure-appconfig.md
@@ -1,0 +1,103 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Azure AppConfig provider
+---
+
+# Azure AppConfig
+
+Azure App Configuration, built on the `azappconfig` SDK. Ships in the same module as [Azure Key Vault](/docs/providers/azure).
+
+| | |
+| --- | --- |
+| Scheme | `azure-appconfig://` |
+| Module | `github.com/xavidop/mamori/providers/azure` |
+| Sensitive | no |
+| Watch | poll |
+| Auth | `DefaultAzureCredential` |
+
+## Install
+
+```bash
+go get github.com/xavidop/mamori/providers/azure
+```
+
+```go
+import _ "github.com/xavidop/mamori/providers/azure" // registers azure-kv:// and azure-appconfig://
+```
+
+## Using the ref
+
+An `azure-appconfig://` ref points at one setting in an Azure App Configuration store, under a specific (or the null) label.
+
+```text
+azure-appconfig://<store>/<key>[#json-key][?label=<label>]
+```
+
+| Part | Required | What it means |
+| --- | --- | --- |
+| `<store>` | yes | The App Configuration store name. The endpoint is built as `https://<store>.azconfig.io`. |
+| `<key>` | yes | The setting key within that store. May itself contain `/`. |
+| `#json-key` | no | Select one field from a JSON setting value (via `mamori.SelectKey`). |
+| `?label=<label>` | no | Select a labelled setting. Absent means the null label - see below. |
+
+**Examples**
+
+- `azure-appconfig://my-store/app/log-level` reads the null-labelled `app/log-level` setting.
+- `azure-appconfig://my-store/app/log-level?label=prod` reads the same key under the `prod` label - a different setting.
+- `azure-appconfig://my-store/app/conn#password` selects the `password` field of a JSON setting value.
+
+```go
+type Config struct {
+	LogLevel     string `source:"azure-appconfig://my-store/app/log-level"`             // null label
+	LogLevelProd string `source:"azure-appconfig://my-store/app/log-level?label=prod"`   // "prod" label
+	APIPassword  string `source:"azure-appconfig://my-store/app/conn#password"`          // JSON field
+}
+```
+
+Values are never marked `Sensitive`: App Configuration is a configuration service, not a secret store. `Value.Version` is the setting's ETag, falling back to `mamori.VersionHash` if unavailable.
+
+### An absent `?label=` is the null label, not a wildcard
+
+Azure App Configuration treats "no label" as its own distinct **null label**, a setting in its own right, not as "any label" or "whichever label was written most recently." A setting stored under the null label and a setting stored under the label `prod` are two different settings that can hold two different values at the same time.
+
+This provider always passes the label explicitly to the SDK - the empty string when `?label=` is absent from the ref - rather than leaving the option unset. A ref without `?label=` therefore always resolves the null-labelled setting specifically, and can never be silently satisfied by a same-keyed setting under a different label.
+
+### Key Vault references are rejected, not resolved
+
+App Configuration can store a setting whose value is a **reference** to a Key Vault secret rather than the value itself: content type `application/vnd.microsoft.appconfig.keyvaultref+json`, value shaped like `{"uri":"https://<vault>.vault.azure.net/secrets/<name>"}`. This provider detects that content type and fails the resolve with `mamori.ErrInvalid`, naming the equivalent [`azure-kv://`](/docs/providers/azure) ref in the error message, instead of resolving or following the reference.
+
+This is a deliberate refusal, not a missing feature. Returning the reference's raw JSON would hand a caller the literal text `{"uri":"..."}` as, say, a database password - a non-empty string that passes typical validation and only fails much later, deep inside whatever consumes it, far from the actual cause. Point a `secret.String` field at the named `azure-kv://` ref instead.
+
+## Explicit configuration
+
+Authentication uses `DefaultAzureCredential` (environment, managed identity, Azure CLI, ...). Inject a credential or client explicitly for tests or non-default auth:
+
+```go
+import azureprov "github.com/xavidop/mamori/providers/azure"
+
+mamori.WithProvider(azureprov.NewAppConfig(azureprov.WithAppConfigCredential(myCred)))
+```
+
+`AppConfigOption` is a distinct type from Key Vault's `Option`, so the two providers' configuration cannot be mixed up at the call site.
+
+## Watch
+
+App Configuration's `GetSetting` call has no native change-notification surface usable here, so this provider does not implement `WatchableProvider`. mamori polls it (`WithPollInterval` + jitter, `Value.Version` comparison).
+
+## Error classification
+
+Failures are classified with `classifyAzure`, the same function used by [`azure-kv://`](/docs/providers/azure) - App Configuration returns the same HTTP statuses as Key Vault:
+
+| HTTP status | mamori kind |
+|---|---|
+| 404 | `not_found` |
+| 403 | `permission_denied` |
+| 401 | `unauthenticated` |
+| 429 | `rate_limited` |
+| 5xx | `unavailable` |
+| 400 | `invalid` |
+| anything else | `unknown` |
+
+A transport failure (no HTTP response at all) stays `unknown`, since it could be a client problem rather than a backend one. `*azcore.ResponseError` stays reachable with `errors.As`.
+
+Verified by unit tests and the conformance kit against an in-memory fake, including the null-label behavior and the Key Vault reference rejection above.

--- a/site/src/pages/docs/providers/azure.md
+++ b/site/src/pages/docs/providers/azure.md
@@ -82,6 +82,8 @@ Key Vault has no native change notification, so mamori polls (`WithPollInterval`
 | 400 | `invalid` |
 | anything else | `unknown` |
 
+This table is `classifyAzure`, one function shared with [`azure-appconfig://`](/docs/providers/azure-appconfig) in this same module - App Configuration returns the same HTTP statuses as Key Vault, so nothing in this table is specific to secrets.
+
 A transport failure (no HTTP response at all) stays `unknown`, since it could be a client problem rather than a backend one. `*azcore.ResponseError` stays reachable with `errors.As`.
 
 Verified by unit tests and the conformance kit against an in-memory fake; live Azure behavior is covered by `//go:build integration` tests.

--- a/site/src/pages/docs/providers/index.md
+++ b/site/src/pages/docs/providers/index.md
@@ -15,7 +15,7 @@ Every provider that ships in this repo passes the conformance kit (see **Write a
 
 The **Errors** column shows which providers classify a failure beyond `not_found`, mapping backend-specific errors onto `mamori.ErrorKind` values like `permission_denied`, `unauthenticated`, `unavailable`, `rate_limited`, and `invalid`. The classification sweep across the whole catalog is now complete, and every provider falls into exactly one of three honest states:
 
-- **✅** - classifies real backend errors beyond `not_found`: thirty-one providers across twenty-seven modules (the `env:` / `dotenv://` / `file://` / `exec:` rows are one core module, counted as four providers).
+- **✅** - classifies real backend errors beyond `not_found`: thirty-two providers across twenty-seven modules (the `env:` / `dotenv://` / `file://` / `exec:` rows are one core module, counted as four providers).
 - **no (chain preserved)** - `firebase-rtdb`, `growthbook`, and `flagsmith` have no backend-specific error vocabulary to map, so a non-not-found failure still reports `unknown`, but `Resolve` wraps the underlying error with `%w` rather than flattening it, so `errors.Is`/`errors.As` still reach it. This is not classification; it is proof that the chain survives even where there is nothing more specific to name.
 - **n/a (no error surface)** - `unleash`, `configcat`, and `split` wrap client surfaces that return only `bool`/`string`, with no per-key error at all, so `Resolve` can only ever produce `not_found` or a client-construction error. Each is explicitly exempt from the conformance kit's `ErrorClassification` case via `providertest.Config.NoResolveErrors`, a deliberate, greppable opt-out rather than a silent gap.
 
@@ -33,6 +33,7 @@ Don't read either non-✅ state as broken: `not_found` is detected everywhere re
 | `vault://` | Vault | yes | lease-aware poll | ✅ |
 | `gcp-sm://` | GCP | yes | poll | ✅ |
 | `azure-kv://` | Azure | yes | poll | ✅ |
+| `azure-appconfig://` | Azure AppConfig | no | poll | ✅ |
 | `doppler://` | Doppler | yes | poll | ✅ |
 | `op://` | 1Password | yes | poll | ✅ |
 | `sops://` | SOPS | yes | fsnotify | ✅ |

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -28,7 +28,7 @@ Full docs: https://mamorigo.dev/docs . Core module: `github.com/xavidop/mamori`.
 import (
 	"github.com/xavidop/mamori"
 	"github.com/xavidop/mamori/secret"
-	_ "github.com/xavidop/mamori/providers/aws" // registers aws-sm:// and aws-ps://
+	_ "github.com/xavidop/mamori/providers/aws" // registers aws-sm://, aws-ps://, and aws-appconfig://
 )
 
 type Config struct {

--- a/skills/mamori/references/providers.md
+++ b/skills/mamori/references/providers.md
@@ -21,10 +21,10 @@ Module path is `github.com/xavidop/mamori/providers/<name>`.
 
 | Module | Scheme(s) | Ref example |
 | --- | --- | --- |
-| `aws` | `aws-sm://` `aws-ps://` | `aws-sm://prod/db#password`, `aws-ps://svc/port` |
+| `aws` | `aws-sm://` `aws-ps://` `aws-appconfig://` | `aws-sm://prod/db#password`, `aws-ps://svc/port`, `aws-appconfig://myapp/prod/flags#/db/port` |
 | `vault` | `vault://` | `vault://kv/data/api#token` |
 | `gcp` | `gcp-sm://` | `gcp-sm://my-project/api-key` |
-| `azure` | `azure-kv://` | `azure-kv://vaultname/secret-name` |
+| `azure` | `azure-kv://` `azure-appconfig://` | `azure-kv://vaultname/secret-name`, `azure-appconfig://mystore/db/port?label=prod` |
 | `doppler` | `doppler://` | `doppler://project/config#SECRET` |
 | `onepassword` | `op://` | `op://vault/item/field` |
 | `sops` | `sops://` | `sops://secrets.enc.yaml#key` |
@@ -57,9 +57,10 @@ Store these in `secret.String` / `secret.Bytes`, never a plain `string`:
   (mamori marks all command output secret), `mamori` (relays whatever the
   server marks).
 
-`mamori vet` flags a secret scheme stored in a plain type. `k8s-cm` (ConfigMap)
-and config schemes (`env`, `file`, `consul`, ...) are not secret-bearing. For a
-custom provider, add its scheme: `mamori vet --secret-schemes=mysecrets ./...`.
+`mamori vet` flags a secret scheme stored in a plain type. `k8s-cm` (ConfigMap),
+`aws-appconfig`, and `azure-appconfig` (config services, not secret stores) -
+and config schemes (`env`, `file`, `consul`, ...) - are not secret-bearing. For
+a custom provider, add its scheme: `mamori vet --secret-schemes=mysecrets ./...`.
 
 ## Composition
 


### PR DESCRIPTION
Adds Azure App Configuration as `azure-appconfig://<store>/<key>[#json-key][?label=<label>]`, in the module that already holds Key Vault so it reuses `classifyAzure`, `isNotFound`, and the same lazily-resolved ambient credential. `classifyAzure` needed no changes: App Configuration returns the same HTTP statuses, already covered by `TestClassifyAzure`.

Stacked on #66.

## An absent `?label=` is the null label, not a wildcard

Azure treats a setting stored under the null label and one stored under `prod` as **different settings**. Conflating them does not error, it returns the wrong value. The provider passes the label explicitly, since the generated SDK client only sends the `label` query parameter when the pointer is non-nil.

This is worth calling out because the first version of the test could not have caught a regression: the fake collapsed a nil label and an explicit empty-string label onto one key, so an implementation that passed nil kept the suite green. The fake now treats nil as a wildcard, and the mutation that previously passed silently now fails.

## Key Vault references are rejected, not resolved

App Configuration can store a *reference* to a Key Vault secret: content type `application/vnd.microsoft.appconfig.keyvaultref+json`, value `{"uri":"https://<vault>.vault.azure.net/secrets/<name>"}`. This provider does not resolve those. It fails with `ErrInvalid` and names the `azure-kv://` ref to use instead.

Returning the JSON would be worse than failing. A caller whose field is `Password string` would receive the literal text `{"uri":"..."}`, which validates as a non-empty string, reaches a database driver, and surfaces as an auth error far from its cause. Failing at resolve time with the ref they should have written is strictly better, and adding resolution later breaks nobody, since every ref that would newly succeed currently errors.

The hint builder also handles versioned reference URIs, which are a documented shape: `.../secrets/x/version1` suggests `azure-kv://myvault/x?version=version1`, not `azure-kv://myvault/x/version1`, which would not resolve because the path is cut on its first slash. It degrades to generic advice for anything malformed and can never itself panic or error, since it only ever builds an error message.

## Verification

`go test`, `go test -race`, `go vet`, and `golangci-lint run` all clean in `providers/azure`; `providertest` conformance passes with `PointerRef` supplied. Every guard test was checked for teeth by breaking the line it protects and confirming the failure, including the two above that were originally vacuous.

Docs: module README, new site page, both coverage tables (the root table is per-module, the site table per-scheme), `skills/` reference, and an error-classification section in README and site page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)