### PR TITLE
ci: type-check integration tests, and fix the one that had rotted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
       - name: go vet
         working-directory: ${{ matrix.dir }}
         run: go vet ./...
+      # Integration tests carry a //go:build integration tag, so no default
+      # build compiles them and CI never runs them: they need live backend
+      # credentials. That also means nothing type-checks them, and they rot
+      # silently. providers/aws's had been calling an undefined function and
+      # nobody could have noticed, because the file was never built.
+      #
+      # Type-checking them is not the same as running them, but it is the part
+      # that costs nothing: no credentials, no network, one vet pass. It keeps
+      # a refactor from quietly orphaning the only tests that touch a real
+      # backend.
+      - name: go vet (integration build tag)
+        working-directory: ${{ matrix.dir }}
+        run: go vet -tags integration ./...
       # -coverpkg=./... measures how much of the whole module each test binary
       # reaches, not just the package under test, which is the honest number for
       # a library whose tests deliberately drive it from the outside.

--- a/providers/aws/integration_test.go
+++ b/providers/aws/integration_test.go
@@ -15,6 +15,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -111,6 +112,4 @@ func mustParseLive(t *testing.T, raw string) mamori.Ref {
 	return ref
 }
 
-func isNotFound(err error) bool {
-	return err != nil && errorsIsNotFound(err)
-}
+func isNotFound(err error) bool { return errors.Is(err, mamori.ErrNotFound) }


### PR DESCRIPTION
## The gap

42 files across 35 provider modules carry `//go:build integration` tests. CI runs them **zero times**, which is correct: they need live backend credentials.

But nothing **type-checks** them either. So they rot invisibly, and one already had:

```
providers/aws/integration_test.go:115:23: undefined: errorsIsNotFound
```

That symbol exists nowhere in the repo. The file could not compile, so whatever it was meant to verify had been verified by nobody for however long. It is fixed here to match the form `providers/dynamodb/integration_test.go` already uses.

## The fix

One step in the existing `test` job, reusing the module-discovery matrix:

```yaml
- name: go vet (integration build tag)
  working-directory: ${{ matrix.dir }}
  run: go vet -tags integration ./...
```

Type-checking is not running. It is the part that costs nothing: no credentials, no network, one vet pass. It cannot tell you a provider still works against real AWS, but it does stop a refactor from silently orphaning the only tests that would.

Verified by simulating the new step across all 40 modules: every one passes with the AWS fix in place, and `providers/aws` was the only failure before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of missing secrets and parameters in AWS integration tests, ensuring “not found” results are handled consistently.

* **Tests**
  * Expanded CI validation to type-check integration-tagged Go code without running integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->