### PR TITLE
feat(secret): add Clone, and stop Zero's doc recommending corruption

### DIFF
--- a/secret/clone_test.go
+++ b/secret/clone_test.go
@@ -1,0 +1,81 @@
+package secret
+
+import "testing"
+
+// TestZeroAliasesEveryCopy pins the hazard Clone exists to solve, and is the
+// reason mamori never zeroes a secret itself.
+//
+// A String is a struct holding a slice, so copying one shares the backing
+// array. Watcher.Get returns config by value, so a caller's "own" copy reads
+// through to the same bytes the reconciler serves. This test documents that
+// truthfully rather than asserting the comfortable thing, so that a later
+// change which makes Zero look safe fails here instead of in production.
+func TestZeroAliasesEveryCopy(t *testing.T) {
+	orig := NewString("hunter2")
+	shared := orig // what Watcher.Get hands a caller
+
+	orig.Zero()
+
+	if got := shared.Reveal(); got == "hunter2" {
+		t.Fatal("copies no longer alias; Clone and the Zero doc comment need revisiting")
+	}
+}
+
+func TestCloneBreaksAliasing(t *testing.T) {
+	orig := NewString("hunter2")
+	owned := orig.Clone()
+
+	owned.Zero()
+
+	if got := orig.Reveal(); got != "hunter2" {
+		t.Errorf("zeroing a clone corrupted the original: %q", got)
+	}
+	if !owned.IsZero() {
+		t.Error("the clone was not zeroed")
+	}
+}
+
+func TestCloneRevealsSameValue(t *testing.T) {
+	orig := NewString("hunter2")
+	if got := orig.Clone().Reveal(); got != "hunter2" {
+		t.Errorf("Clone().Reveal() = %q, want %q", got, "hunter2")
+	}
+}
+
+func TestCloneOfEmptyDoesNotAllocate(t *testing.T) {
+	var s String
+	c := s.Clone()
+	if !c.IsZero() {
+		t.Error("cloning an empty String produced a non-empty one")
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = s.Clone() }); n != 0 {
+		t.Errorf("cloning an empty String allocated %v times, want 0", n)
+	}
+}
+
+func TestBytesCloneBreaksAliasing(t *testing.T) {
+	orig := NewBytes([]byte("hunter2"))
+	owned := orig.Clone()
+
+	owned.Zero()
+
+	if got := string(orig.Reveal()); got != "hunter2" {
+		t.Errorf("zeroing a clone corrupted the original: %q", got)
+	}
+	if !owned.IsZero() {
+		t.Error("the clone was not zeroed")
+	}
+}
+
+// TestCloneIsRedactedToo guards against the obvious mistake of building Clone
+// in a way that loses the redaction contract.
+func TestCloneIsRedactedToo(t *testing.T) {
+	c := NewString("hunter2").Clone()
+	if c.String() != Redacted {
+		t.Errorf("Clone().String() = %q, want %q", c.String(), Redacted)
+	}
+	b := NewBytes([]byte("hunter2")).Clone()
+	if b.String() != Redacted {
+		t.Errorf("Bytes.Clone().String() = %q, want %q", b.String(), Redacted)
+	}
+}

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -52,10 +52,47 @@ func (s String) Sensitive() bool { return true }
 // IsZero reports whether the secret holds no bytes.
 func (s String) IsZero() bool { return len(s.b) == 0 }
 
+// Clone returns a copy backed by its own bytes, so the caller can Zero it
+// without touching any other copy.
+//
+// This is the safe way to wipe a secret that came from Watcher.Get: that
+// returns your config by value, which shares the secret's backing array with
+// the reconciler and with every other caller. Clone breaks the sharing, and
+// only then is Zero yours to call.
+//
+// A cloned nil or empty secret stays empty rather than allocating.
+func (s String) Clone() String {
+	if len(s.b) == 0 {
+		return String{}
+	}
+	return String{b: append([]byte(nil), s.b...)}
+}
+
 // Zero best-effort wipes the underlying bytes. This is a defense-in-depth
 // measure only: Go's garbage collector may have already copied the value
 // elsewhere (during string conversion, interface boxing, or GC compaction), so
-// zeroization cannot be guaranteed. It is still worth doing on rotation.
+// zeroization cannot be guaranteed.
+//
+// Only call this on a secret whose bytes you own. A String is a struct holding
+// a slice, so copying one copies the slice header and shares the backing
+// array: every copy reads through to the same bytes, and zeroing any of them
+// zeroes all of them.
+//
+// That matters because Watcher.Get returns your config by value, which copies
+// the struct without copying the secret's bytes. Zeroing a secret obtained
+// that way does not wipe "your" copy, it wipes the live one the reconciler is
+// still serving, and every other caller's too. A request in flight would
+// authenticate with null bytes.
+//
+// Use Clone to take ownership first when you need to wipe:
+//
+//	pw := cfg.DBPassword.Clone()
+//	defer pw.Zero()
+//	db.Connect(pw.Reveal())
+//
+// mamori itself never calls Zero. It cannot know when the last caller has
+// finished with a superseded value, so wiping one on rotation would be a use
+// after free with extra steps.
 func (s *String) Zero() {
 	for i := range s.b {
 		s.b[i] = 0
@@ -92,7 +129,19 @@ func (b Bytes) Sensitive() bool { return true }
 // IsZero reports whether the secret holds no bytes.
 func (b Bytes) IsZero() bool { return len(b.b) == 0 }
 
-// Zero best-effort wipes the underlying bytes (see String.Zero for caveats).
+// Clone returns a copy backed by its own bytes, so the caller can Zero it
+// without touching any other copy. See String.Clone.
+func (b Bytes) Clone() Bytes {
+	if len(b.b) == 0 {
+		return Bytes{}
+	}
+	return Bytes{b: append([]byte(nil), b.b...)}
+}
+
+// Zero best-effort wipes the underlying bytes. Only call it on a secret whose
+// bytes you own: copies share one backing array, so zeroing any copy zeroes
+// every copy, including the live one the reconciler is serving. Use Clone to
+// take ownership first. See String.Zero for the full rationale.
 func (b *Bytes) Zero() {
 	for i := range b.b {
 		b.b[i] = 0


### PR DESCRIPTION
Stacked on #70.

## What was wrong

`secret.String.Zero()`'s doc comment ended with *"It is still worth doing on rotation."*

Doing that corrupts live configuration, and I demonstrated it before writing a line:

```
after zeroing the other copy, the caller's copy reads "\x00\x00\x00\x00\x00\x00\x00"
```

A `String` is a struct holding a slice, so copying one copies the header and **shares the backing array**. `Watcher.Get` returns your config by value, which copies the struct without copying the secret's bytes. So a caller's "own" copy reads through to the same bytes the reconciler serves. Zeroing it does not wipe your copy; it wipes the live one, and every other caller's. A request in flight would authenticate with null bytes.

The advice invited exactly that.

## What this changes

Nothing about when mamori zeroes anything, because **mamori still never calls `Zero`**. It cannot know when the last caller has finished with a superseded value, so wiping one on rotation would be a use-after-free with extra steps. That is now stated in the doc comment rather than left to be inferred.

`Clone()` on `String` and `Bytes` returns a copy backed by its own bytes, which gives `Zero` a safe usage for the first time:

```go
pw := cfg.DBPassword.Clone()
defer pw.Zero()
db.Connect(pw.Reveal())
```

Cloning an empty secret allocates nothing, and a clone keeps the full redaction contract.

## On the tests

`TestZeroAliasesEveryCopy` asserts the aliasing rather than the comfortable thing. It is deliberately written so that a future change making `Zero` look safe fails there instead of in production.

The `Clone` guard was checked by making `Clone` alias instead of copy, which is the exact mistake it exists to prevent: `zeroing a clone corrupted the original: "\x00\x00..."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)