### PR TITLE
fix: let an exec: argument contain a space, and document env vars

### DIFF
--- a/builtin_exec.go
+++ b/builtin_exec.go
@@ -25,7 +25,10 @@ type execProvider struct{}
 func (execProvider) Scheme() string { return "exec" }
 
 func (execProvider) Resolve(ctx context.Context, ref Ref) (Value, error) {
-	fields := strings.Fields(ref.Path)
+	fields, err := splitArgs(ref.Path)
+	if err != nil {
+		return Value{}, fmt.Errorf("mamori: exec %q: %w", ref.Path, err)
+	}
 	if len(fields) == 0 {
 		return Value{}, fmt.Errorf("mamori: exec: %w: empty command", ErrInvalid)
 	}
@@ -46,6 +49,93 @@ func (execProvider) Resolve(ctx context.Context, ref Ref) (Value, error) {
 	}
 	b := out.Bytes()
 	return Value{Bytes: b, Version: VersionHash(b), Sensitive: true}, nil
+}
+
+// splitArgs splits a command line into argv, honoring single and double quotes
+// so an argument can contain spaces.
+//
+// strings.Fields was used here before, which meant no argument could ever
+// contain a space: `mytool --msg "hello world"` became four arguments, and
+// `sh -c 'echo hi'` handed sh the argument `'echo` and then failed with a
+// shell syntax error. Both look like they should work.
+//
+// This parses quotes; it does not run a shell. The binary is still exec'd
+// directly, so there is no globbing, no pipes, no command substitution, and no
+// shell injection. A caller who genuinely wants shell semantics now has a way
+// to ask for one explicitly by invoking it themselves, which is a decision
+// they make rather than one mamori makes for every exec: ref.
+//
+// The quoting rules are the common subset of every POSIX shell, kept
+// deliberately small:
+//
+//   - Single quotes are literal. Nothing inside them is special, not even a
+//     backslash.
+//   - Double quotes group, and a backslash escapes the next character.
+//   - Outside quotes, a backslash escapes the next character, and unquoted
+//     whitespace separates arguments.
+//
+// An unterminated quote or a trailing backslash is an error rather than a
+// guess: silently closing the quote would run a command the author did not
+// write.
+func splitArgs(s string) ([]string, error) {
+	var (
+		args []string
+		cur  strings.Builder
+		has  bool // cur holds an argument, even if it is the empty string ""
+	)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\'':
+			end := strings.IndexByte(s[i+1:], '\'')
+			if end < 0 {
+				return nil, fmt.Errorf("%w: unterminated single quote", ErrInvalid)
+			}
+			cur.WriteString(s[i+1 : i+1+end])
+			has = true
+			i += end + 1
+		case '"':
+			j := i + 1
+			closed := false
+			for j < len(s) {
+				if s[j] == '\\' && j+1 < len(s) {
+					cur.WriteByte(s[j+1])
+					j += 2
+					continue
+				}
+				if s[j] == '"' {
+					closed = true
+					break
+				}
+				cur.WriteByte(s[j])
+				j++
+			}
+			if !closed {
+				return nil, fmt.Errorf("%w: unterminated double quote", ErrInvalid)
+			}
+			has = true
+			i = j
+		case '\\':
+			if i+1 >= len(s) {
+				return nil, fmt.Errorf("%w: trailing backslash", ErrInvalid)
+			}
+			cur.WriteByte(s[i+1])
+			has = true
+			i++
+		case ' ', '\t', '\n', '\r':
+			if has {
+				args = append(args, cur.String())
+				cur.Reset()
+				has = false
+			}
+		default:
+			cur.WriteByte(s[i])
+			has = true
+		}
+	}
+	if has {
+		args = append(args, cur.String())
+	}
+	return args, nil
 }
 
 // WithExecProvider enables the exec: provider for this Load or Watch call only.

--- a/builtin_exec_args_test.go
+++ b/builtin_exec_args_test.go
@@ -1,0 +1,57 @@
+package mamori
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestSplitArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", "vault-agent token", []string{"vault-agent", "token"}},
+		{"collapses runs of space", "a   b\tc", []string{"a", "b", "c"}},
+		{"double quotes group", `mytool --msg "hello world"`, []string{"mytool", "--msg", "hello world"}},
+		{"single quotes group", `sh -c 'echo hi'`, []string{"sh", "-c", "echo hi"}},
+		{"single quotes are literal", `echo 'a\b$c"d'`, []string{"echo", `a\b$c"d`}},
+		{"backslash escapes in double quotes", `echo "a\"b"`, []string{"echo", `a"b`}},
+		{"backslash escapes outside quotes", `echo a\ b`, []string{"echo", "a b"}},
+		{"adjacent quoted and bare concatenate", `echo pre"fix post"`, []string{"echo", "prefix post"}},
+		{"empty quoted argument is preserved", `mytool ""`, []string{"mytool", ""}},
+		{"empty input", "", nil},
+		{"only whitespace", "   ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitArgs(tt.in)
+			if err != nil {
+				t.Fatalf("splitArgs(%q): %v", tt.in, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitArgs(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSplitArgsRejectsUnbalanced covers the cases that must not be guessed at.
+// Silently closing an open quote would run a command the author never wrote.
+func TestSplitArgsRejectsUnbalanced(t *testing.T) {
+	for _, in := range []string{`sh -c 'echo hi`, `echo "unterminated`, `echo trailing\`} {
+		t.Run(in, func(t *testing.T) {
+			got, err := splitArgs(in)
+			if err == nil {
+				t.Fatalf("splitArgs(%q) = %#v, want an error", in, got)
+			}
+			if !errors.Is(err, ErrInvalid) {
+				t.Errorf("error %v does not satisfy errors.Is(ErrInvalid)", err)
+			}
+			if got != nil {
+				t.Errorf("returned %#v alongside an error, want nil", got)
+			}
+		})
+	}
+}

--- a/site/src/pages/docs/providers/exec.md
+++ b/site/src/pages/docs/providers/exec.md
@@ -101,6 +101,28 @@ Home string `source:"exec:sh -c 'echo $HOME'"`
 
 Prefer the first. `${HOME}` fails loudly at `Load` if you forget to pass the variable, whereas a shell silently expands an unset variable to nothing. Invoking a shell is also your decision to make, not something mamori does to every `exec:` ref, and anything that shell can expand, it will.
 
+### Shell variables inside the script: use `$X`, not `${X}`
+
+If you invoke a shell and the script sets its own variables, **write them bare**. mamori expands `${...}` in the tag before the shell ever runs, so the braced form belongs to mamori, not to your script.
+
+```go
+// Correct: mamori leaves a bare $X alone, the shell resolves it.
+V string `source:"exec:sh -c 'X=hello; echo $X'"`
+```
+
+The braced form collides:
+
+| Script | What happens |
+| --- | --- |
+| `sh -c 'X=hello; echo $X'` | the shell's `X`, as intended |
+| `sh -c 'X=hello; echo ${X}'` | error at `Load`: `undefined ref variable "X"` |
+| `sh -c 'X=hello; echo ${X}'`, with `X` in `WithRefVars` | **mamori's value wins, silently** |
+| `sh -c 'X=hello; echo $${X}'` | the shell's `X`; `$$` escapes to a literal `$` |
+
+The third row is the one to watch. mamori substitutes first, so the command that actually runs is `sh -c 'X=hello; echo <mamori's value>'` and the script's own assignment is dead code. Nothing warns you, because from mamori's side the ref expanded exactly as asked.
+
+Row two failing loudly is the good case: a name mamori does not know is refused rather than guessed at.
+
 ### Trailing newlines
 
 Whatever the command prints becomes the value, newline included: `echo` gives you `"/home/app\n"`, not `"/home/app"`. That trailing byte fails a `validate:"..."` rule or any comparison expecting an exact match.

--- a/site/src/pages/docs/providers/exec.md
+++ b/site/src/pages/docs/providers/exec.md
@@ -39,14 +39,78 @@ exec:command arg1 arg2 ...
 | --- | --- | --- |
 | `exec:` | yes | Opaque scheme - the entire remainder is the command line, with no `//` authority. |
 | `command` | yes | The executable to run (resolved on `PATH`). |
-| `arg1 arg2 ...` | no | Arguments, split on spaces. Taken verbatim from the ref, never interpolated from other resolved values. |
+| `arg1 arg2 ...` | no | Arguments, split on whitespace. Quote an argument to keep spaces in it. Taken verbatim from the ref, never interpolated from other resolved values. |
 
 **Examples**
 
 - `exec:vault-agent token` runs `vault-agent token` and captures its stdout as the value - pair it with a `secret.String` field.
 - `exec:aws ecr get-login-password` shells out to the AWS CLI to mint a short-lived registry password.
+- `exec:mytool --msg "hello world"` passes one argument containing a space.
 
 The `exec:` scheme must be enabled per call with `WithExecProvider()` (see above), and its output is always marked `Sensitive`. See Security below.
+
+### Quoting
+
+Arguments split on whitespace, and single or double quotes keep an argument together. Single quotes are literal; inside double quotes a backslash escapes the next character. An unterminated quote is an error rather than a guess, since closing it silently would run a command you did not write.
+
+### There is no shell
+
+mamori runs the binary directly. There is no globbing, no pipes, no command substitution, and **no variable expansion**:
+
+```go
+// Does NOT work: no shell, so $HOME is passed as the literal text "$HOME".
+Home string `source:"exec:echo $HOME"`
+```
+
+That one produces the string `$HOME` and no error, which is the failure most worth knowing about on this page.
+
+### Using an environment variable
+
+Three ways, depending on what you actually need.
+
+**The value itself.** Do not use `exec:` at all:
+
+```go
+Home string `source:"env:HOME"`
+```
+
+**The command should see your environment.** It already does. mamori does not clear the environment, so the command inherits it and a script reading `$HOME` internally works:
+
+```go
+Token secret.String `source:"exec:vault-agent token"`
+```
+
+**The variable must appear in the command line.** Two routes, and they differ in who does the substituting.
+
+Let mamori substitute it, with [`${VAR}` interpolation](/docs/concepts/ref-interpolation/). You name the variables explicitly, so nothing ambient can reach the command:
+
+```go
+Home string `source:"exec:printf %s ${HOME}"`
+
+cfg, err := mamori.Load[Config](ctx,
+	mamori.WithExecProvider(),
+	mamori.WithRefVars(mamori.EnvVars("HOME")),
+)
+```
+
+Or ask for a shell yourself, quoting the script so it arrives as one argument:
+
+```go
+Home string `source:"exec:sh -c 'echo $HOME'"`
+```
+
+Prefer the first. `${HOME}` fails loudly at `Load` if you forget to pass the variable, whereas a shell silently expands an unset variable to nothing. Invoking a shell is also your decision to make, not something mamori does to every `exec:` ref, and anything that shell can expand, it will.
+
+### Trailing newlines
+
+Whatever the command prints becomes the value, newline included: `echo` gives you `"/home/app\n"`, not `"/home/app"`. That trailing byte fails a `validate:"..."` rule or any comparison expecting an exact match.
+
+Trim it with [`?decode=trim`](/docs/concepts/decoding/), or use a command that emits no newline:
+
+```go
+Home  string        `source:"exec:sh -c 'echo $HOME'?decode=trim"`
+Token secret.String `source:"exec:printf %s hunter2"`  // printf adds none
+```
 
 ## Security
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -22,7 +22,7 @@ const features = [
   {
     k: "03",
     t: "Atomic & gated",
-    d: "An update that fails validation is rejected, and PreApply lets you prove a rotated credential actually works before it becomes live. Get() keeps returning the last good config; your process never observes a half-applied or unverified one.",
+    d: "A bad update never goes live. Validation rejects it, and you can add your own check on top: try the new credential, and say no if it fails. Until then your app keeps serving the last good config.",
   },
   {
     k: "04",
@@ -90,7 +90,7 @@ const operational = [
   },
   {
     t: "Health & telemetry",
-    d: "Status and Health expose per-field health right now, and Doctor runs the same check in CI before a deploy. Structured slog, metrics and tracing cover what happened over time, with OpenTelemetry and Prometheus bridges that ship separately so neither reaches a core consumer.",
+    d: "See every field's health right now, or run the same check in CI before you deploy. Logs, metrics and traces cover what happened over time. The OpenTelemetry and Prometheus bridges are separate modules, so neither lands in your build unless you ask.",
     href: `${base}docs/observability`,
     cta: "Health & telemetry",
   },
@@ -312,16 +312,15 @@ cfg := w.<span class="f">Get</span>() <span class="c">// lock-free; always the l
         <span class="eyebrow">security</span>
         <h2>Secret-safe by construction.</h2>
         <p>
-          Config code is where every secret passes through, and it is also the code most
-          likely to end up in a log line, an error message, or a bug report. These are
-          defaults, not switches you have to remember.
+          Every secret passes through your config code. That code also ends up in logs,
+          errors, and bug reports. So these are on by default.
         </p>
       </div>
       <div class="sec">
-        <article class="card"><h3>Secrets stay out of your logs</h3><p>A secret is its own type, and it prints as <code>[REDACTED]</code> everywhere Go would otherwise show it: log lines, <code>fmt</code>, JSON, an error, a panic. Reading the real value takes a deliberate call, which is one word to grep for when you want every place that handles one.</p></article>
-        <article class="card"><h3>A leak fails the build</h3><p>mamori ships a <code>go vet</code> analyzer. Point it at your code and a secret assigned to an ordinary string fails in CI, before a human is asked to notice it in a diff.</p></article>
-        <article class="card"><h3>One secret cannot unlock another</h3><p>Running commands is off unless you switch it on. A value mamori has resolved can never be spliced into the next lookup, and neither can the ambient environment, so a leaked secret cannot redirect where the following one is read from.</p></article>
-        <article class="card"><h3>Honest about what it cannot do</h3><p>Wiping a secret from memory is best effort, and the docs say so rather than promising something Go's runtime cannot deliver. The guarantees that are real are the ones under test: no secret value is ever written to a log.</p></article>
+        <article class="card"><h3>Secrets stay out of your logs</h3><p>Secrets have their own type. Print one and you get <code>[REDACTED]</code>. That holds in logs, in JSON, in errors, in a panic. Getting the real value takes an explicit call, so it is one word to grep for.</p></article>
+        <article class="card"><h3>A leak fails the build</h3><p>mamori ships a <code>go vet</code> analyzer. Put a secret in a plain string and CI fails. Nobody has to catch it in review.</p></article>
+        <article class="card"><h3>One secret cannot unlock another</h3><p>Running commands is off by default. A secret mamori resolved can never build the next lookup. Neither can your environment. So a leaked secret cannot point mamori somewhere new.</p></article>
+        <article class="card"><h3>Honest about what it cannot do</h3><p>Wiping a secret from memory is best effort. Go's runtime cannot promise more, and we do not pretend otherwise. What we do promise is tested: no secret value ever reaches a log.</p></article>
       </div>
     </div>
   </section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -311,12 +311,17 @@ cfg := w.<span class="f">Get</span>() <span class="c">// lock-free; always the l
       <div class="section__head">
         <span class="eyebrow">security</span>
         <h2>Secret-safe by construction.</h2>
+        <p>
+          Config code is where every secret passes through, and it is also the code most
+          likely to end up in a log line, an error message, or a bug report. These are
+          defaults, not switches you have to remember.
+        </p>
       </div>
       <div class="sec">
-        <article class="card"><h3>Secrets stay out of your logs</h3><p>A secret prints as <code>[REDACTED]</code> anywhere it could leak - logs, error messages, JSON, a stack trace. Getting the real value takes an explicit call, so every place that touches one is easy to find in review.</p></article>
-        <article class="card"><h3>A leak fails the build</h3><p>Put a secret somewhere it does not belong and a shipped analyzer fails your build, rather than trusting a reviewer to spot it.</p></article>
-        <article class="card"><h3>One secret cannot unlock another</h3><p>Running commands is off unless you switch it on. Nothing a secret resolves to, and nothing sitting in the environment, can change where the next secret is read from.</p></article>
-        <article class="card"><h3>Honest about what it cannot do</h3><p>Wiping a secret from memory is best effort, and the docs say so rather than promising something Go's runtime cannot deliver. What is guaranteed is tested: no secret value is ever written to a log.</p></article>
+        <article class="card"><h3>Secrets stay out of your logs</h3><p>A secret is its own type, and it prints as <code>[REDACTED]</code> everywhere Go would otherwise show it: log lines, <code>fmt</code>, JSON, an error, a panic. Reading the real value takes a deliberate call, which is one word to grep for when you want every place that handles one.</p></article>
+        <article class="card"><h3>A leak fails the build</h3><p>mamori ships a <code>go vet</code> analyzer. Point it at your code and a secret assigned to an ordinary string fails in CI, before a human is asked to notice it in a diff.</p></article>
+        <article class="card"><h3>One secret cannot unlock another</h3><p>Running commands is off unless you switch it on. A value mamori has resolved can never be spliced into the next lookup, and neither can the ambient environment, so a leaked secret cannot redirect where the following one is read from.</p></article>
+        <article class="card"><h3>Honest about what it cannot do</h3><p>Wiping a secret from memory is best effort, and the docs say so rather than promising something Go's runtime cannot deliver. The guarantees that are real are the ones under test: no secret value is ever written to a log.</p></article>
       </div>
     </div>
   </section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -313,10 +313,10 @@ cfg := w.<span class="f">Get</span>() <span class="c">// lock-free; always the l
         <h2>Secret-safe by construction.</h2>
       </div>
       <div class="sec">
-        <article class="card"><h3>Redacted everywhere</h3><p><code>secret.String</code> and <code>secret.Bytes</code> render as <code>[REDACTED]</code> in <code>String()</code>, <code>fmt</code>, JSON, and <code>slog</code>. Only <code>Reveal()</code> exposes the value - and it's greppable in review.</p></article>
-        <article class="card"><h3>A vet analyzer</h3><p><code>mamori vet</code> flags any secret-bearing ref assigned to a plain <code>string</code> or <code>[]byte</code>, so a leak can't slip past code review.</p></article>
-        <article class="card"><h3>No injection chains</h3><p>The <code>exec:</code> provider is off by default. A ref can carry <code>${"{VAR}"}</code>, but only from the map you pass to <code>WithRefVars</code> - never from the ambient environment, and never from another resolved value. One secret can't build another's command.</p></article>
-        <article class="card"><h3>Honest about limits</h3><p><code>Zero()</code> is best-effort and documented as such - no false promises about Go's GC. No payloads are ever logged; the conformance kit asserts it.</p></article>
+        <article class="card"><h3>Secrets stay out of your logs</h3><p>A secret prints as <code>[REDACTED]</code> anywhere it could leak - logs, error messages, JSON, a stack trace. Getting the real value takes an explicit call, so every place that touches one is easy to find in review.</p></article>
+        <article class="card"><h3>A leak fails the build</h3><p>Put a secret somewhere it does not belong and a shipped analyzer fails your build, rather than trusting a reviewer to spot it.</p></article>
+        <article class="card"><h3>One secret cannot unlock another</h3><p>Running commands is off unless you switch it on. Nothing a secret resolves to, and nothing sitting in the environment, can change where the next secret is read from.</p></article>
+        <article class="card"><h3>Honest about what it cannot do</h3><p>Wiping a secret from memory is best effort, and the docs say so rather than promising something Go's runtime cannot deliver. What is guaranteed is tested: no secret value is ever written to a log.</p></article>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Stacked on #73.

## The bug

`exec:` split its command line with `strings.Fields`, which has no quote handling. So **no argument could ever contain a space**:

| Tag | Before |
|---|---|
| `exec:mytool --msg "hello world"` | four arguments, quotes included |
| `exec:sh -c 'echo hi'` | ❌ `unexpected EOF while looking for matching '` |
| `exec:sh -c echo $VAR` | ⚠️ `"\n"`, silently wrong |

`sh` was receiving `'echo` as its `-c` argument and `$VAR'` as `$0`. Both forms look like they should work and neither explained itself.

## The fix

`splitArgs` understands single and double quotes. It **parses** them; it does not run a shell. The binary is still exec'd directly, so there is no globbing, no pipes, no command substitution, and no injection chain.

What it does enable is invoking a shell *deliberately* (`sh -c 'script'`), which is a decision the author makes rather than one mamori makes for every `exec:` ref. An unterminated quote is an error rather than a guess, because silently closing it would run a command nobody wrote.

Verified after the change:

```
sh -c 'echo $MY_TEST_VAR' -> "hello\n"
printf %s-%s hello world  -> "hello-world"
```

## The docs question that prompted this

There was no answer on the page for "how do I use an environment variable here", and the obvious guess is silently wrong:

```go
Home string `source:"exec:echo $HOME"`   // yields the literal text "$HOME", no error
```

Nothing expands it, because there is no shell. The page now gives the three real options: `env:` when you just want the value, the inherited environment when a script reads it internally, and `${VAR}` with `EnvVars` when it genuinely has to appear in the command line. It recommends the last over `sh -c` because `${HOME}` fails loudly at `Load` if you forget to pass it, whereas a shell expands an unset variable to nothing.

Trailing newlines are covered too, since `echo` gives `"/home/app\n"` and that fails an exact-match `validate:`.

**Every snippet on that page was executed before it was written down**, which caught two of my own mistakes: I first documented `?decode=trim` while working on a branch where `?decode=` did not exist, and then wrote `exec:printf %s $HOME` as a no-newline example, which prints the literal `$HOME` for exactly the reason the section is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)