### PR TITLE
feat(cli): mamori diff, a config-surface and privilege delta for PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ For a pre-deploy check, `mamori.Doctor[Config](ctx, opts...)` resolves every fie
 
 ## CLI
 
-[`cmd/mamori`](cmd/mamori/) is a standalone CLI with two halves that never mix: `explain`/`schema`/`policy` statically read your Go source and never resolve anything (struct field tables, JSON Schema, least-privilege IAM/GCP/ExternalSecret artifacts), while `doctor`/`status` are thin clients of a running process's admin endpoint (`WithAdminHTTP` above), exiting `0`-`4` so a script can tell a broken config apart from one it merely couldn't reach.
+[`cmd/mamori`](cmd/mamori/) is a standalone CLI with two halves that never mix: `explain`/`schema`/`policy`/`diff` never resolve anything (struct field tables, JSON Schema, least-privilege IAM/GCP/ExternalSecret artifacts, and the config-surface delta between two revisions), while `doctor`/`status` are thin clients of a running process's admin endpoint (`WithAdminHTTP` above), exiting `0`-`4` so a script can tell a broken config apart from one it merely couldn't reach.
+
+`mamori diff` is built for pull request review: given two `mamori explain --json` outputs it reports which fields and precedence chains changed, flags any field that newly reads secret material, and shows the **privilege delta**, the backend paths the service starts and stops reading, optionally rendered as concrete IAM or GCP grants. `--exit-code=privilege` turns that into a merge gate that fires only when the permission surface grows.
 
 ```bash
 brew install xavidop/tap/mamori

--- a/cmd/mamori/diff.go
+++ b/cmd/mamori/diff.go
@@ -1,0 +1,246 @@
+// This file implements `mamori diff`: it compares two `mamori explain --json`
+// outputs and reports what changed about a service's configuration surface,
+// including the delta in backend permissions that surface implies.
+//
+// It is the fourth static command (decision D1: the CLI's static commands read
+// source and never resolve anything), and the only one that does not even read
+// Go source: its inputs are two JSON files, so it needs no build, no module
+// graph, and no network. That is deliberate. The rejected alternative was
+// taking git revisions and running packages.Load against a historical tree,
+// whose failure mode is "your base commit no longer builds" - worse than no
+// tool at all for something meant to run on every pull request.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var diffUsage = `usage: mamori diff <base.json> <head.json> [--json|--markdown]
+                   [--exit-code[=any|privilege]] [--policy-format=<f>]
+
+Diff compares two "mamori explain --json" outputs and reports what changed
+about a config surface: fields added, removed, and modified, precedence
+chains gained and lost, and the backend paths the service newly reads or
+stops reading. It never resolves anything (no network calls, no secret
+managers contacted) and never loads Go source: both operands are JSON files.
+
+  <base.json>       the earlier explain output. "-" reads it from stdin.
+  <head.json>       the later explain output. "-" reads it from stdin.
+                    At most one operand may be "-".
+  --json            emit the whole diff as JSON instead of a text report
+  --markdown        emit markdown suited to a pull request comment or
+                    $GITHUB_STEP_SUMMARY. Mutually exclusive with --json.
+  --exit-code       signal findings through the exit code (see below).
+                    A bare --exit-code means "any".
+  --policy-format   additionally render the concrete grant for each changed
+                    backend path, in one of: aws-iam, gcp, external-secret.
+                    Without it the privilege delta is scheme neutral, which
+                    works for every provider and presumes no cloud.
+
+Typical CI use:
+
+  git checkout "$BASE" && mamori explain ./... --json > /tmp/base.json
+  git checkout "$HEAD" && mamori explain ./... --json > /tmp/head.json
+  mamori diff /tmp/base.json /tmp/head.json --markdown >> "$GITHUB_STEP_SUMMARY"
+
+  # and, to block a merge that grows the permission surface:
+  mamori diff /tmp/base.json /tmp/head.json --exit-code=privilege
+
+Exit codes:
+  0   success. Also the result when findings exist but --exit-code was not
+      given: showing a diff is not a failure.
+  1   usage error, unreadable operand, or JSON that is not an explain output
+  2   findings present, and --exit-code asked for them to be signalled.
+      --exit-code=any signals on any change; --exit-code=privilege signals
+      only when the permission surface GREW, since losing access is not a
+      risk worth gating a merge on.
+`
+
+// exit-code modes.
+const (
+	exitCodeOff       = ""
+	exitCodeAny       = "any"
+	exitCodePrivilege = "privilege"
+)
+
+// diffConfig carries the injectable stdin, so the "-" operand is testable
+// without touching the real os.Stdin. It mirrors liveFlags.stdin (flags.go).
+type diffConfig struct {
+	stdin io.Reader
+}
+
+// diffCmd is the mamori diff subcommand, using the real stdin.
+func diffCmd(args []string, stdout, stderr io.Writer) int {
+	c := &diffConfig{}
+	return c.run(args, stdout, stderr)
+}
+
+func (c *diffConfig) run(args []string, stdout, stderr io.Writer) int {
+	if wantsHelp(args) {
+		return writeHelp(stdout, diffUsage)
+	}
+
+	opts, err := parseDiffArgs(args)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprint(stderr, diffUsage)
+		return 1
+	}
+
+	base, err := c.loadExplainJSON(opts.baseFile)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: %v\n", err)
+		return 1
+	}
+	head, err := c.loadExplainJSON(opts.headFile)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: %v\n", err)
+		return 1
+	}
+
+	d := computeDiff(base, head)
+
+	switch {
+	case opts.jsonOut:
+		if code := renderDiffJSON(stdout, stderr, d); code != 0 {
+			return code
+		}
+	case opts.markdown:
+		renderDiffMarkdown(stdout, d, opts.policyFormat)
+	default:
+		renderDiffText(stdout, d, opts.policyFormat)
+	}
+
+	switch opts.exitCode {
+	case exitCodeAny:
+		if !d.Empty() {
+			return 2
+		}
+	case exitCodePrivilege:
+		if d.PrivilegeGrew() {
+			return 2
+		}
+	}
+	return 0
+}
+
+// diffOptions is the parsed command line.
+type diffOptions struct {
+	baseFile     string
+	headFile     string
+	jsonOut      bool
+	markdown     bool
+	exitCode     string
+	policyFormat string
+}
+
+// parseDiffArgs scans by recognized flag shape rather than using
+// flag.FlagSet, so operands and flags may appear in either order, matching
+// parseExplainArgs and parsePolicyArgs.
+func parseDiffArgs(args []string) (diffOptions, error) {
+	var o diffOptions
+	var operands []string
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json" || a == "-json":
+			o.jsonOut = true
+		case a == "--markdown" || a == "-markdown":
+			o.markdown = true
+		case a == "--exit-code" || a == "-exit-code":
+			o.exitCode = exitCodeAny
+		case strings.HasPrefix(a, "--exit-code="):
+			o.exitCode = strings.TrimPrefix(a, "--exit-code=")
+		case strings.HasPrefix(a, "-exit-code="):
+			o.exitCode = strings.TrimPrefix(a, "-exit-code=")
+		case strings.HasPrefix(a, "--policy-format="):
+			o.policyFormat = strings.TrimPrefix(a, "--policy-format=")
+		case strings.HasPrefix(a, "-policy-format="):
+			o.policyFormat = strings.TrimPrefix(a, "-policy-format=")
+		case a == "--policy-format" || a == "-policy-format":
+			i++
+			if i >= len(args) {
+				return diffOptions{}, fmt.Errorf("mamori diff: %s requires a value", a)
+			}
+			o.policyFormat = args[i]
+		case a == "-":
+			// The stdin operand, not a flag.
+			operands = append(operands, a)
+		case strings.HasPrefix(a, "-"):
+			return diffOptions{}, fmt.Errorf("mamori diff: unknown flag %q", a)
+		default:
+			operands = append(operands, a)
+		}
+	}
+
+	if len(operands) != 2 {
+		return diffOptions{}, fmt.Errorf("mamori diff: need exactly two operands (base and head), got %d", len(operands))
+	}
+	o.baseFile, o.headFile = operands[0], operands[1]
+	if o.baseFile == "-" && o.headFile == "-" {
+		return diffOptions{}, fmt.Errorf("mamori diff: only one operand may be \"-\"")
+	}
+
+	if o.jsonOut && o.markdown {
+		return diffOptions{}, fmt.Errorf("mamori diff: --json and --markdown are mutually exclusive")
+	}
+
+	switch o.exitCode {
+	case exitCodeOff, exitCodeAny, exitCodePrivilege:
+	default:
+		return diffOptions{}, fmt.Errorf("mamori diff: unknown --exit-code value %q (want any or privilege)", o.exitCode)
+	}
+
+	switch o.policyFormat {
+	case "", policyFormatAWSIAM, policyFormatGCP, policyFormatExternalSecret:
+	default:
+		return diffOptions{}, fmt.Errorf("mamori diff: unknown --policy-format %q (want aws-iam, gcp, or external-secret)", o.policyFormat)
+	}
+
+	return o, nil
+}
+
+// loadExplainJSON reads one operand and decodes it as an explain output.
+//
+// Decoding is deliberately tolerant of unknown object fields (the default for
+// encoding/json, stated here because it is load-bearing rather than
+// incidental): base.json is typically a stored CI artifact produced weeks
+// earlier, possibly by an older mamori binary, so a newer binary's output must
+// stay readable by an older diff and vice versa. See the stability promise
+// documented on `mamori explain --json`: fields may be added to that JSON,
+// never removed and never retyped.
+//
+// A top-level value that is not an array is rejected by name, since the
+// likeliest cause is a file produced by a different command.
+func (c *diffConfig) loadExplainJSON(path string) ([]StructInfo, error) {
+	var r io.Reader
+	if path == "-" {
+		r = c.stdin
+		if r == nil {
+			r = os.Stdin
+		}
+	} else {
+		fh, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = fh.Close() }()
+		r = fh
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var out []StructInfo
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("%s is not a \"mamori explain --json\" output: %w", path, err)
+	}
+	return out, nil
+}

--- a/cmd/mamori/diff.go
+++ b/cmd/mamori/diff.go
@@ -197,9 +197,10 @@ func parseDiffArgs(args []string) (diffOptions, error) {
 	}
 
 	switch o.policyFormat {
-	case "", policyFormatAWSIAM, policyFormatGCP, policyFormatExternalSecret:
+	case "", formatAWSIAM, formatGCP, formatExternalSecret:
 	default:
-		return diffOptions{}, fmt.Errorf("mamori diff: unknown --policy-format %q (want aws-iam, gcp, or external-secret)", o.policyFormat)
+		return diffOptions{}, fmt.Errorf("mamori diff: unknown --policy-format %q (want %s)",
+			o.policyFormat, strings.Join(supportedPolicyFormats, ", "))
 	}
 
 	return o, nil

--- a/cmd/mamori/diff_test.go
+++ b/cmd/mamori/diff_test.go
@@ -221,6 +221,40 @@ func TestDiffCmdRejectsTwoStdinOperands(t *testing.T) {
 	}
 }
 
+func TestDiffCmdPolicyFormatThreadsToARenderer(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--policy-format=aws-iam")
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	if !strings.Contains(stdout, "arn:aws:secretsmanager:*:*:secret:prod/stripe") {
+		t.Errorf("want a real ARN threaded through to the renderer, got %q", stdout)
+	}
+}
+
+func TestDiffCmdPolicyFormatSpaceSeparatedMatchesEquals(t *testing.T) {
+	_, eqOut, eqErr := runDiff(t, baseFixture, headFixture, "--policy-format=aws-iam")
+	_, spaceOut, spaceErr := runDiff(t, baseFixture, headFixture, "--policy-format", "aws-iam")
+
+	if eqOut != spaceOut {
+		t.Errorf("want --policy-format aws-iam to match --policy-format=aws-iam on stdout\n=: %q\nspace: %q", eqOut, spaceOut)
+	}
+	if eqErr != spaceErr {
+		t.Errorf("want --policy-format aws-iam to match --policy-format=aws-iam on stderr\n=: %q\nspace: %q", eqErr, spaceErr)
+	}
+}
+
+func TestDiffCmdMarkdownWithExitCodeAnyRendersAndSignals(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--markdown", "--exit-code=any")
+
+	if code != 2 {
+		t.Errorf("want exit 2, got %d", code)
+	}
+	if !strings.Contains(stdout, "### `acme/svc.Config`") {
+		t.Errorf("want markdown still rendered even though the exit code signals findings, got %q", stdout)
+	}
+}
+
 func TestRunDispatchesDiff(t *testing.T) {
 	// `mamori diff` with no operands must reach diffCmd (exit 1), not the
 	// top-level unknown-subcommand path (exit 2).

--- a/cmd/mamori/diff_test.go
+++ b/cmd/mamori/diff_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	baseFixture      = "testdata/diff/base.json"
+	headFixture      = "testdata/diff/head.json"
+	headMinusFixture = "testdata/diff/head-minus.json"
+	notArrayFixture  = "testdata/diff/notarray.json"
+)
+
+func runDiff(t *testing.T, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut strings.Builder
+	code = diffCmd(args, &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestDiffCmdHelpIsSuccessOnStdout(t *testing.T) {
+	code, stdout, stderr := runDiff(t, "--help")
+
+	if code != 0 {
+		t.Errorf("want exit 0 for help, got %d", code)
+	}
+	if !strings.Contains(stdout, "usage: mamori diff") {
+		t.Errorf("want usage on stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("want empty stderr for help, got %q", stderr)
+	}
+}
+
+func TestDiffCmdDefaultExitsZeroDespiteFindings(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture)
+
+	if code != 0 {
+		t.Errorf("want exit 0 without --exit-code, got %d", code)
+	}
+	if !strings.Contains(stdout, "StripeKey") {
+		t.Errorf("want the added field reported, got %q", stdout)
+	}
+}
+
+func TestDiffCmdExitCodeAny(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code=any")
+	if code != 2 {
+		t.Errorf("want exit 2 when findings exist with --exit-code=any, got %d", code)
+	}
+}
+
+func TestDiffCmdBareExitCodeMeansAny(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code")
+	if code != 2 {
+		t.Errorf("want a bare --exit-code to behave as any, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodeAnyOnIdenticalInput(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, baseFixture, "--exit-code=any")
+	if code != 0 {
+		t.Errorf("want exit 0 when nothing changed, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodePrivilegeSignalsOnGrowth(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code=privilege")
+	if code != 2 {
+		t.Errorf("want exit 2 when the privilege surface grew, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodePrivilegeIgnoresShrink(t *testing.T) {
+	// head to head-minus is a pure shrink: aws-sm prod/stripe is lost and
+	// nothing is gained. Reversing base and head would NOT be a pure shrink,
+	// because base carries prod/legacy, which head lacks.
+	code, _, _ := runDiff(t, headFixture, headMinusFixture, "--exit-code=privilege")
+	if code != 0 {
+		t.Errorf("want exit 0 when the privilege surface only shrank, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodeAnyStillSignalsOnPureShrink(t *testing.T) {
+	// The same pair under --exit-code=any IS a finding: something changed.
+	code, _, _ := runDiff(t, headFixture, headMinusFixture, "--exit-code=any")
+	if code != 2 {
+		t.Errorf("want exit 2 for a shrink under --exit-code=any, got %d", code)
+	}
+}
+
+func TestDiffCmdMissingFileIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, filepath.Join("testdata", "diff", "nope.json"), headFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a missing file, got %d", code)
+	}
+	if !strings.Contains(stderr, "nope.json") {
+		t.Errorf("want the failing path named on stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCmdNonArrayJSONIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, notArrayFixture, headFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a non-array top level, got %d", code)
+	}
+	if !strings.Contains(stderr, notArrayFixture) {
+		t.Errorf("want the offending file named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdWrongOperandCountIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for one operand, got %d", code)
+	}
+	if !strings.Contains(stderr, "usage: mamori diff") {
+		t.Errorf("want usage echoed on stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCmdJSONAndMarkdownAreMutuallyExclusive(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--json", "--markdown")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for conflicting formats, got %d", code)
+	}
+	if !strings.Contains(stderr, "mutually exclusive") {
+		t.Errorf("want an explicit conflict message, got %q", stderr)
+	}
+}
+
+func TestDiffCmdUnknownFlagIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--nope")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for an unknown flag, got %d", code)
+	}
+	if !strings.Contains(stderr, "--nope") {
+		t.Errorf("want the unknown flag named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdBadExitCodeValueIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--exit-code=maybe")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a bad --exit-code value, got %d", code)
+	}
+	if !strings.Contains(stderr, "maybe") {
+		t.Errorf("want the bad value named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdBadPolicyFormatIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--policy-format=azure")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for an unsupported policy format, got %d", code)
+	}
+	if !strings.Contains(stderr, "azure") {
+		t.Errorf("want the bad format named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdMarkdownOutput(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--markdown")
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	if !strings.Contains(stdout, "### `acme/svc.Config`") {
+		t.Errorf("want markdown output, got %q", stdout)
+	}
+}
+
+func TestDiffCmdJSONOutput(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--json")
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stdout), "{") {
+		t.Errorf("want a JSON object, got %q", stdout)
+	}
+}
+
+func TestDiffCmdStdinOperand(t *testing.T) {
+	data, err := os.ReadFile(headFixture)
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+
+	var out, errOut strings.Builder
+	c := &diffConfig{stdin: bytes.NewReader(data)}
+	code := c.run([]string{baseFixture, "-"}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d (stderr: %q)", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "StripeKey") {
+		t.Errorf("want the head read from stdin, got %q", out.String())
+	}
+}
+
+func TestDiffCmdRejectsTwoStdinOperands(t *testing.T) {
+	code, _, stderr := runDiff(t, "-", "-")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for two stdin operands, got %d", code)
+	}
+	if !strings.Contains(stderr, "only one operand") {
+		t.Errorf("want an explicit message, got %q", stderr)
+	}
+}
+
+func TestRunDispatchesDiff(t *testing.T) {
+	// `mamori diff` with no operands must reach diffCmd (exit 1), not the
+	// top-level unknown-subcommand path (exit 2).
+	if code := run([]string{"diff", "--help"}); code != 0 {
+		t.Errorf("want run() to dispatch diff --help to exit 0, got %d", code)
+	}
+}

--- a/cmd/mamori/diffmodel.go
+++ b/cmd/mamori/diffmodel.go
@@ -72,7 +72,7 @@ type StructDiff struct {
 }
 
 // PrivilegeDelta is the set of backend paths gained and lost, bucketed by
-// scheme. Populated by Task 3.
+// scheme, as computed by computePrivilegeDelta.
 type PrivilegeDelta struct {
 	Added   map[string][]string `json:"added,omitempty"`
 	Removed map[string][]string `json:"removed,omitempty"`
@@ -222,9 +222,9 @@ func indexFields(in []Field) map[string]Field {
 
 // diffAttrs compares two matched fields attribute by attribute, in a fixed
 // declared order so output never churns. Source is deliberately NOT compared
-// here: it is the raw tag whose meaningful content is the chain, which Task 2
-// compares at ref granularity instead. Comparing both would report every
-// chain edit twice.
+// here: it is the raw tag whose meaningful content is the chain, which
+// diffChain compares at ref granularity instead. Comparing both would report
+// every chain edit twice.
 func diffAttrs(base, head Field) []AttrChange {
 	var out []AttrChange
 	add := func(name, b, h string) {

--- a/cmd/mamori/diffmodel.go
+++ b/cmd/mamori/diffmodel.go
@@ -193,8 +193,14 @@ func diffFields(base, head []Field) []FieldDiff {
 			snapshot := h
 			out = append(out, FieldDiff{Path: p, Kind: ChangeAdded, Field: &snapshot})
 		default:
-			fd := FieldDiff{Path: p, Kind: ChangeModified, Attrs: diffAttrs(b, h)}
-			if len(fd.Attrs) == 0 {
+			fd := FieldDiff{
+				Path:            p,
+				Kind:            ChangeModified,
+				Attrs:           diffAttrs(b, h),
+				Refs:            diffChain(b.Refs, h.Refs),
+				BecameSensitive: !b.Sensitive && h.Sensitive,
+			}
+			if len(fd.Attrs) == 0 && len(fd.Refs) == 0 {
 				continue
 			}
 			out = append(out, fd)
@@ -243,4 +249,63 @@ func defaultAttr(f Field) string {
 		return attrAbsent
 	}
 	return f.Default
+}
+
+// diffChain compares two precedence chains at ref granularity. A chain is an
+// ordered list, and its order IS precedence, so this reports three things: a
+// ref only in head (added), a ref only in base (removed), and a ref in both
+// but at a different index (moved). Reporting a chain edit as one opaque
+// Source string change would hide that a service acquired a new backend
+// dependency, which is the whole point of the command.
+//
+// Output is sorted by ref so a chain edit renders identically on every run.
+// A duplicated ref within one chain is compared at its first index; refs are
+// not meaningfully repeatable in a chain (a second occurrence can never win),
+// so no attempt is made to pair up duplicates positionally.
+func diffChain(base, head []string) []RefChange {
+	basePos := firstIndexOf(base)
+	headPos := firstIndexOf(head)
+
+	refs := make([]string, 0, len(basePos)+len(headPos))
+	seen := map[string]bool{}
+	for r := range basePos {
+		if !seen[r] {
+			seen[r] = true
+			refs = append(refs, r)
+		}
+	}
+	for r := range headPos {
+		if !seen[r] {
+			seen[r] = true
+			refs = append(refs, r)
+		}
+	}
+	sort.Strings(refs)
+
+	var out []RefChange
+	for _, r := range refs {
+		b, inBase := basePos[r]
+		h, inHead := headPos[r]
+		switch {
+		case inBase && !inHead:
+			out = append(out, RefChange{Kind: ChangeRemoved, Ref: r, BasePos: b, HeadPos: -1})
+		case !inBase && inHead:
+			out = append(out, RefChange{Kind: ChangeAdded, Ref: r, BasePos: -1, HeadPos: h})
+		case b != h:
+			out = append(out, RefChange{Kind: ChangeMoved, Ref: r, BasePos: b, HeadPos: h})
+		}
+	}
+	return out
+}
+
+// firstIndexOf maps each ref to its first index in the chain.
+func firstIndexOf(chain []string) map[string]int {
+	out := make(map[string]int, len(chain))
+	for i, r := range chain {
+		if _, dup := out[r]; dup {
+			continue
+		}
+		out[r] = i
+	}
+	return out
 }

--- a/cmd/mamori/diffmodel.go
+++ b/cmd/mamori/diffmodel.go
@@ -1,0 +1,246 @@
+// This file holds the pure comparison logic behind `mamori diff`: it turns
+// two []StructInfo (each decoded from a `mamori explain --json` output) into
+// a Diff describing what changed. It performs no IO of any kind, which is
+// what lets every case be table-tested from literals rather than fixtures.
+//
+// Everything here sorts its output. `mamori diff` is meant to be pasted into
+// a pull request comment, where unstable ordering would produce phantom churn
+// between runs and train reviewers to ignore the tool.
+package main
+
+import (
+	"sort"
+	"strconv"
+)
+
+// ChangeKind is the verdict for one struct, field, or chain position.
+type ChangeKind string
+
+const (
+	ChangeAdded    ChangeKind = "added"
+	ChangeRemoved  ChangeKind = "removed"
+	ChangeModified ChangeKind = "modified"
+	// ChangeMoved is used only for a chain position whose ref is present on
+	// both sides but at a different index. Chain order is precedence, so a
+	// reorder is a real change even though the ref set is identical.
+	ChangeMoved ChangeKind = "moved"
+)
+
+// attrAbsent is what an unset Default renders as, so that "no default" and
+// "a default of the empty string" do not both print as nothing.
+const attrAbsent = "(none)"
+
+// AttrChange is one Field attribute that differs, reported old to new.
+type AttrChange struct {
+	Name string `json:"name"`
+	Base string `json:"base"`
+	Head string `json:"head"`
+}
+
+// RefChange is one precedence-chain position that differs.
+type RefChange struct {
+	Kind ChangeKind `json:"kind"`
+	Ref  string     `json:"ref"`
+	// BasePos and HeadPos are the ref's index in the base and head chains,
+	// or -1 where it is absent.
+	BasePos int `json:"base_pos"`
+	HeadPos int `json:"head_pos"`
+}
+
+// FieldDiff is one field's verdict.
+type FieldDiff struct {
+	Path string     `json:"path"`
+	Kind ChangeKind `json:"kind"`
+	// Attrs and Refs are populated only when Kind is ChangeModified.
+	Attrs []AttrChange `json:"attrs,omitempty"`
+	Refs  []RefChange  `json:"refs,omitempty"`
+	// BecameSensitive is true when Sensitive went false to true: the service
+	// began reading secret material where it previously read plain config.
+	BecameSensitive bool `json:"became_sensitive,omitempty"`
+	// Field is a snapshot used to render added and removed fields. It is the
+	// head field for ChangeAdded and the base field for ChangeRemoved, and
+	// nil for ChangeModified (where Attrs and Refs carry the detail).
+	Field *Field `json:"field,omitempty"`
+}
+
+// StructDiff groups the field diffs for one struct type.
+type StructDiff struct {
+	Package  string      `json:"package"`
+	TypeName string      `json:"type_name"`
+	Kind     ChangeKind  `json:"kind"`
+	Fields   []FieldDiff `json:"fields,omitempty"`
+}
+
+// PrivilegeDelta is the set of backend paths gained and lost, bucketed by
+// scheme. Populated by Task 3.
+type PrivilegeDelta struct {
+	Added   map[string][]string `json:"added,omitempty"`
+	Removed map[string][]string `json:"removed,omitempty"`
+}
+
+// Diff is the whole comparison of two explain outputs.
+type Diff struct {
+	Structs   []StructDiff   `json:"structs,omitempty"`
+	Privilege PrivilegeDelta `json:"privilege"`
+}
+
+// Empty reports whether nothing at all changed.
+func (d Diff) Empty() bool {
+	return len(d.Structs) == 0 && len(d.Privilege.Added) == 0 && len(d.Privilege.Removed) == 0
+}
+
+// structKey identifies a struct across the two sides.
+type structKey struct {
+	pkg      string
+	typeName string
+}
+
+// computeDiff compares two explain outputs. Structs match on
+// (Package, TypeName) and fields on (Package, TypeName, Path). The result is
+// sorted: structs by package then type name, fields by path.
+func computeDiff(base, head []StructInfo) Diff {
+	baseByKey := indexStructs(base)
+	headByKey := indexStructs(head)
+
+	keys := make([]structKey, 0, len(baseByKey)+len(headByKey))
+	seen := map[structKey]bool{}
+	for k := range baseByKey {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range headByKey {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].pkg != keys[j].pkg {
+			return keys[i].pkg < keys[j].pkg
+		}
+		return keys[i].typeName < keys[j].typeName
+	})
+
+	var out []StructDiff
+	for _, k := range keys {
+		b, inBase := baseByKey[k]
+		h, inHead := headByKey[k]
+		switch {
+		case inBase && !inHead:
+			out = append(out, StructDiff{Package: k.pkg, TypeName: k.typeName, Kind: ChangeRemoved})
+		case !inBase && inHead:
+			out = append(out, StructDiff{Package: k.pkg, TypeName: k.typeName, Kind: ChangeAdded})
+		default:
+			fields := diffFields(b.Fields, h.Fields)
+			if len(fields) == 0 {
+				continue
+			}
+			out = append(out, StructDiff{
+				Package: k.pkg, TypeName: k.typeName, Kind: ChangeModified, Fields: fields,
+			})
+		}
+	}
+	return Diff{Structs: out}
+}
+
+// indexStructs keys a slice of StructInfo by (Package, TypeName). A duplicate
+// key keeps the first occurrence, matching Extract's documented deterministic
+// order (packages sorted, structs in source declaration order).
+func indexStructs(in []StructInfo) map[structKey]StructInfo {
+	out := make(map[structKey]StructInfo, len(in))
+	for _, s := range in {
+		k := structKey{pkg: s.Package, typeName: s.TypeName}
+		if _, dup := out[k]; dup {
+			continue
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// diffFields compares the fields of two matched structs, sorted by path.
+func diffFields(base, head []Field) []FieldDiff {
+	baseByPath := indexFields(base)
+	headByPath := indexFields(head)
+
+	paths := make([]string, 0, len(baseByPath)+len(headByPath))
+	seen := map[string]bool{}
+	for p := range baseByPath {
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	for p := range headByPath {
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	var out []FieldDiff
+	for _, p := range paths {
+		b, inBase := baseByPath[p]
+		h, inHead := headByPath[p]
+		switch {
+		case inBase && !inHead:
+			snapshot := b
+			out = append(out, FieldDiff{Path: p, Kind: ChangeRemoved, Field: &snapshot})
+		case !inBase && inHead:
+			snapshot := h
+			out = append(out, FieldDiff{Path: p, Kind: ChangeAdded, Field: &snapshot})
+		default:
+			fd := FieldDiff{Path: p, Kind: ChangeModified, Attrs: diffAttrs(b, h)}
+			if len(fd.Attrs) == 0 {
+				continue
+			}
+			out = append(out, fd)
+		}
+	}
+	return out
+}
+
+func indexFields(in []Field) map[string]Field {
+	out := make(map[string]Field, len(in))
+	for _, f := range in {
+		if _, dup := out[f.Path]; dup {
+			continue
+		}
+		out[f.Path] = f
+	}
+	return out
+}
+
+// diffAttrs compares two matched fields attribute by attribute, in a fixed
+// declared order so output never churns. Source is deliberately NOT compared
+// here: it is the raw tag whose meaningful content is the chain, which Task 2
+// compares at ref granularity instead. Comparing both would report every
+// chain edit twice.
+func diffAttrs(base, head Field) []AttrChange {
+	var out []AttrChange
+	add := func(name, b, h string) {
+		if b != h {
+			out = append(out, AttrChange{Name: name, Base: b, Head: h})
+		}
+	}
+
+	add("GoType", base.GoType, head.GoType)
+	add("Default", defaultAttr(base), defaultAttr(head))
+	add("Optional", strconv.FormatBool(base.Optional), strconv.FormatBool(head.Optional))
+	add("Sensitive", strconv.FormatBool(base.Sensitive), strconv.FormatBool(head.Sensitive))
+	add("OnFail", base.OnFail, head.OnFail)
+	add("Validate", base.Validate, head.Validate)
+	return out
+}
+
+// defaultAttr renders a field's default, distinguishing "no default: tag" from
+// "a default: tag whose value is the empty string".
+func defaultAttr(f Field) string {
+	if !f.HasDefault {
+		return attrAbsent
+	}
+	return f.Default
+}

--- a/cmd/mamori/diffmodel.go
+++ b/cmd/mamori/diffmodel.go
@@ -142,7 +142,7 @@ func computeDiff(base, head []StructInfo) Diff {
 			})
 		}
 	}
-	return Diff{Structs: out}
+	return Diff{Structs: out, Privilege: computePrivilegeDelta(base, head)}
 }
 
 // indexStructs keys a slice of StructInfo by (Package, TypeName). A duplicate
@@ -308,4 +308,84 @@ func firstIndexOf(chain []string) map[string]int {
 		out[r] = i
 	}
 	return out
+}
+
+// computePrivilegeDelta reports which backend paths the head surface gained
+// and lost relative to base, bucketed by scheme.
+//
+// It reuses collectPolicyRefs (policy.go) unchanged, which is why this costs
+// almost nothing: that function already takes exactly the []StructInfo that
+// `explain --json` emits, already buckets every ref by scheme, and already
+// deduplicates and sorts each bucket. Every scheme it collects is compared
+// here, not only the three that policy.go knows how to render as an IAM or
+// GCP artifact, so a change to a vault:// or k8s-secret:// ref is never
+// silently dropped from the privilege view just because no IAM vocabulary
+// exists for it.
+func computePrivilegeDelta(base, head []StructInfo) PrivilegeDelta {
+	baseRefs := collectPolicyRefs(base)
+	headRefs := collectPolicyRefs(head)
+
+	out := PrivilegeDelta{}
+	for _, scheme := range unionSchemes(baseRefs, headRefs) {
+		if added := missingFrom(headRefs[scheme], baseRefs[scheme]); len(added) > 0 {
+			if out.Added == nil {
+				out.Added = map[string][]string{}
+			}
+			out.Added[scheme] = added
+		}
+		if removed := missingFrom(baseRefs[scheme], headRefs[scheme]); len(removed) > 0 {
+			if out.Removed == nil {
+				out.Removed = map[string][]string{}
+			}
+			out.Removed[scheme] = removed
+		}
+	}
+	return out
+}
+
+// unionSchemes returns every scheme present in either side, sorted.
+func unionSchemes(a, b policyRefs) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(a)+len(b))
+	for s := range a {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for s := range b {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// missingFrom returns every element of want that does not appear in have,
+// preserving want's order (collectPolicyRefs already sorted it).
+func missingFrom(want, have []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	inHave := make(map[string]bool, len(have))
+	for _, h := range have {
+		inHave[h] = true
+	}
+	var out []string
+	for _, w := range want {
+		if !inHave[w] {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// PrivilegeGrew reports whether the head surface reads any backend path the
+// base surface did not. This is the condition worth blocking a merge on:
+// a surface that only SHRANK is not a finding, because losing access is not
+// a risk to gate.
+func (d Diff) PrivilegeGrew() bool {
+	return len(d.Privilege.Added) > 0
 }

--- a/cmd/mamori/diffmodel_test.go
+++ b/cmd/mamori/diffmodel_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// si builds a one-struct slice with the given fields, for brevity in tests.
+func si(pkg, typeName string, fields ...Field) []StructInfo {
+	return []StructInfo{{Package: pkg, TypeName: typeName, Fields: fields}}
+}
+
+func TestComputeDiffStructAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config", Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Other", Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 2 {
+		t.Fatalf("want 2 struct diffs, got %d: %+v", len(got.Structs), got.Structs)
+	}
+	// Deterministic order: sorted by package then type name, so "Config" precedes "Other".
+	if got.Structs[0].TypeName != "Config" || got.Structs[0].Kind != ChangeRemoved {
+		t.Errorf("want Config removed, got %+v", got.Structs[0])
+	}
+	if got.Structs[1].TypeName != "Other" || got.Structs[1].Kind != ChangeAdded {
+		t.Errorf("want Other added, got %+v", got.Structs[1])
+	}
+}
+
+func TestComputeDiffFieldAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "Workers", GoType: "int", Source: "env:WORKERS", Refs: []string{"env:WORKERS"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 {
+		t.Fatalf("want 1 struct diff, got %d", len(got.Structs))
+	}
+	sd := got.Structs[0]
+	if sd.Kind != ChangeModified {
+		t.Errorf("want struct modified, got %q", sd.Kind)
+	}
+	if len(sd.Fields) != 2 {
+		t.Fatalf("want 2 field diffs, got %d: %+v", len(sd.Fields), sd.Fields)
+	}
+	// Fields sort by path: "Port" precedes "Workers".
+	if sd.Fields[0].Path != "Port" || sd.Fields[0].Kind != ChangeRemoved {
+		t.Errorf("want Port removed, got %+v", sd.Fields[0])
+	}
+	if sd.Fields[1].Path != "Workers" || sd.Fields[1].Kind != ChangeAdded {
+		t.Errorf("want Workers added, got %+v", sd.Fields[1])
+	}
+}
+
+func TestComputeDiffIdenticalIsEmpty(t *testing.T) {
+	in := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+
+	got := computeDiff(in, in)
+
+	if len(got.Structs) != 0 {
+		t.Errorf("want no struct diffs for identical input, got %+v", got.Structs)
+	}
+	if !got.Empty() {
+		t.Error("want Empty() true for identical input")
+	}
+}
+
+func TestDiffAttrsReportsEachAttributeOldToNew(t *testing.T) {
+	base := Field{Path: "W", GoType: "int", Source: "env:W", Refs: []string{"env:W"},
+		Default: "4", HasDefault: true, Optional: false, Sensitive: false, OnFail: "", Validate: "gte=1"}
+	head := Field{Path: "W", GoType: "int64", Source: "env:W", Refs: []string{"env:W"},
+		Default: "8", HasDefault: true, Optional: true, Sensitive: false, OnFail: "fail", Validate: "gte=1"}
+
+	got := diffAttrs(base, head)
+
+	want := []AttrChange{
+		{Name: "GoType", Base: "int", Head: "int64"},
+		{Name: "Default", Base: "4", Head: "8"},
+		{Name: "Optional", Base: "false", Head: "true"},
+		{Name: "OnFail", Base: "", Head: "fail"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diffAttrs mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestDiffAttrsHasDefaultTogglesShowAsPresence(t *testing.T) {
+	base := Field{Path: "W", Default: "", HasDefault: false}
+	head := Field{Path: "W", Default: "4", HasDefault: true}
+
+	got := diffAttrs(base, head)
+
+	want := []AttrChange{{Name: "Default", Base: "(none)", Head: "4"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diffAttrs mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}

--- a/cmd/mamori/diffmodel_test.go
+++ b/cmd/mamori/diffmodel_test.go
@@ -99,3 +99,132 @@ func TestDiffAttrsHasDefaultTogglesShowAsPresence(t *testing.T) {
 		t.Errorf("diffAttrs mismatch\n got: %+v\nwant: %+v", got, want)
 	}
 }
+
+func TestDiffChainAddedRemovedMoved(t *testing.T) {
+	cases := []struct {
+		name string
+		base []string
+		head []string
+		want []RefChange
+	}{
+		{
+			name: "position added at the end",
+			base: []string{"env:PORT"},
+			head: []string{"env:PORT", "aws-ps://svc/port"},
+			want: []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}},
+		},
+		{
+			name: "position removed",
+			base: []string{"env:PORT", "aws-ps://svc/port"},
+			head: []string{"env:PORT"},
+			want: []RefChange{{Kind: ChangeRemoved, Ref: "aws-ps://svc/port", BasePos: 1, HeadPos: -1}},
+		},
+		{
+			name: "same refs reordered is a precedence change",
+			base: []string{"env:PORT", "aws-ps://svc/port"},
+			head: []string{"aws-ps://svc/port", "env:PORT"},
+			want: []RefChange{
+				{Kind: ChangeMoved, Ref: "aws-ps://svc/port", BasePos: 1, HeadPos: 0},
+				{Kind: ChangeMoved, Ref: "env:PORT", BasePos: 0, HeadPos: 1},
+			},
+		},
+		{
+			name: "identical chain reports nothing",
+			base: []string{"env:PORT"},
+			head: []string{"env:PORT"},
+			want: nil,
+		},
+		{
+			name: "added and removed at once",
+			base: []string{"env:PORT", "aws-ps://old"},
+			head: []string{"env:PORT", "aws-ps://new"},
+			want: []RefChange{
+				{Kind: ChangeAdded, Ref: "aws-ps://new", BasePos: -1, HeadPos: 1},
+				{Kind: ChangeRemoved, Ref: "aws-ps://old", BasePos: 1, HeadPos: -1},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffChain(tc.base, tc.head)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("diffChain mismatch\n got: %+v\nwant: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeDiffPopulatesChainChanges(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "string", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "string", Source: "env:PORT,aws-ps://svc/port",
+			Refs: []string{"env:PORT", "aws-ps://svc/port"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 || len(got.Structs[0].Fields) != 1 {
+		t.Fatalf("want one field diff, got %+v", got.Structs)
+	}
+	fd := got.Structs[0].Fields[0]
+	if fd.Kind != ChangeModified {
+		t.Errorf("want modified, got %q", fd.Kind)
+	}
+	want := []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}}
+	if !reflect.DeepEqual(fd.Refs, want) {
+		t.Errorf("Refs mismatch\n got: %+v\nwant: %+v", fd.Refs, want)
+	}
+	if len(fd.Attrs) != 0 {
+		t.Errorf("want no attr changes for a pure chain edit, got %+v", fd.Attrs)
+	}
+}
+
+func TestComputeDiffFlagsBecameSensitive(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "string", Source: "env:KEY", Refs: []string{"env:KEY"}, Sensitive: false})
+	head := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "secret.String", Source: "aws-sm://prod/stripe#key",
+			Refs: []string{"aws-sm://prod/stripe#key"}, Sensitive: true})
+
+	fd := computeDiff(base, head).Structs[0].Fields[0]
+
+	if !fd.BecameSensitive {
+		t.Error("want BecameSensitive true when Sensitive goes false to true")
+	}
+}
+
+func TestComputeDiffDoesNotFlagSensitiveGoingAway(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "secret.String", Source: "aws-sm://prod/k", Refs: []string{"aws-sm://prod/k"}, Sensitive: true})
+	head := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "string", Source: "env:KEY", Refs: []string{"env:KEY"}, Sensitive: false})
+
+	fd := computeDiff(base, head).Structs[0].Fields[0]
+
+	if fd.BecameSensitive {
+		t.Error("want BecameSensitive false when Sensitive goes true to false")
+	}
+	// It is still reported as an ordinary attribute change.
+	found := false
+	for _, a := range fd.Attrs {
+		if a.Name == "Sensitive" && a.Base == "true" && a.Head == "false" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a Sensitive true->false attr change, got %+v", fd.Attrs)
+	}
+}
+
+func TestComputeDiffChainOnlyChangeStillCountsAsModified(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "P", Source: "env:A", Refs: []string{"env:A"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "P", Source: "env:B", Refs: []string{"env:B"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 {
+		t.Fatalf("a chain-only change must still produce a struct diff, got %+v", got.Structs)
+	}
+}

--- a/cmd/mamori/diffmodel_test.go
+++ b/cmd/mamori/diffmodel_test.go
@@ -228,3 +228,79 @@ func TestComputeDiffChainOnlyChangeStillCountsAsModified(t *testing.T) {
 		t.Fatalf("a chain-only change must still produce a struct diff, got %+v", got.Structs)
 	}
 }
+
+func TestComputePrivilegeDeltaAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/legacy#k", Refs: []string{"aws-sm://prod/legacy#k"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/stripe#k", Refs: []string{"aws-sm://prod/stripe#k"}})
+
+	got := computePrivilegeDelta(base, head)
+
+	if want := []string{"prod/stripe"}; !reflect.DeepEqual(got.Added["aws-sm"], want) {
+		t.Errorf("added mismatch\n got: %+v\nwant: %+v", got.Added["aws-sm"], want)
+	}
+	if want := []string{"prod/legacy"}; !reflect.DeepEqual(got.Removed["aws-sm"], want) {
+		t.Errorf("removed mismatch\n got: %+v\nwant: %+v", got.Removed["aws-sm"], want)
+	}
+}
+
+func TestComputePrivilegeDeltaIgnoresUnchangedPaths(t *testing.T) {
+	in := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/db#p", Refs: []string{"aws-sm://prod/db#p"}})
+
+	got := computePrivilegeDelta(in, in)
+
+	if len(got.Added) != 0 || len(got.Removed) != 0 {
+		t.Errorf("want empty delta, got %+v", got)
+	}
+}
+
+func TestComputePrivilegeDeltaCoversNonPolicySchemes(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}},
+		Field{Path: "B", Source: "vault://kv/data/api#token", Refs: []string{"vault://kv/data/api#token"}})
+
+	got := computePrivilegeDelta(base, head)
+
+	// vault has no IAM vocabulary, but it must still appear in the neutral view.
+	if want := []string{"kv/data/api"}; !reflect.DeepEqual(got.Added["vault"], want) {
+		t.Errorf("want vault path surfaced, got %+v", got.Added)
+	}
+}
+
+func TestPrivilegeGrew(t *testing.T) {
+	grew := Diff{Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/new"}}}}
+	if !grew.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew true when a path was added")
+	}
+
+	shrank := Diff{Privilege: PrivilegeDelta{Removed: map[string][]string{"aws-sm": {"prod/old"}}}}
+	if shrank.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew false when the surface only shrank")
+	}
+
+	var none Diff
+	if none.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew false for an empty diff")
+	}
+}
+
+func TestComputeDiffIncludesPrivilegeDelta(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}},
+		Field{Path: "B", Source: "aws-sm://prod/stripe#k", Refs: []string{"aws-sm://prod/stripe#k"}, Sensitive: true})
+
+	got := computeDiff(base, head)
+
+	if !got.PrivilegeGrew() {
+		t.Errorf("computeDiff must populate Privilege, got %+v", got.Privilege)
+	}
+	if got.Empty() {
+		t.Error("want Empty() false")
+	}
+}

--- a/cmd/mamori/diffrender.go
+++ b/cmd/mamori/diffrender.go
@@ -1,0 +1,179 @@
+// This file renders a Diff (diffmodel.go) in the three formats `mamori diff`
+// supports. Rendering is kept separate from computation so every format can
+// be tested against a Diff literal, with no files and no JSON round trip.
+//
+// All three formats share privilegeLines, so the privilege section cannot
+// drift between the text a human reads in a terminal and the markdown a
+// reviewer reads in a pull request.
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// Policy format names accepted by --policy-format. The empty string means the
+// scheme-neutral default.
+const (
+	policyFormatAWSIAM         = "aws-iam"
+	policyFormatGCP            = "gcp"
+	policyFormatExternalSecret = "external-secret"
+)
+
+// renderDiffText writes the default human-readable report: one section per
+// changed struct, then the privilege delta.
+func renderDiffText(w io.Writer, d Diff, policyFormat string) {
+	if d.Empty() {
+		_, _ = fmt.Fprintln(w, "no configuration surface changes")
+		return
+	}
+
+	for i, sd := range d.Structs {
+		if i > 0 {
+			_, _ = fmt.Fprintln(w)
+		}
+		switch sd.Kind {
+		case ChangeAdded:
+			_, _ = fmt.Fprintf(w, "+ %s.%s (new config struct)\n", sd.Package, sd.TypeName)
+			continue
+		case ChangeRemoved:
+			_, _ = fmt.Fprintf(w, "- %s.%s (config struct removed)\n", sd.Package, sd.TypeName)
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "%s.%s\n", sd.Package, sd.TypeName)
+		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		for _, fd := range sd.Fields {
+			switch fd.Kind {
+			case ChangeAdded:
+				_, _ = fmt.Fprintf(tw, "  + %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+			case ChangeRemoved:
+				_, _ = fmt.Fprintf(tw, "  - %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+			default:
+				_, _ = fmt.Fprintf(tw, "  ~ %s\t\t\n", fd.Path)
+				for _, a := range fd.Attrs {
+					_, _ = fmt.Fprintf(tw, "      %s\t%s -> %s\t\n", a.Name, blank(a.Base), blank(a.Head))
+				}
+				for _, r := range fd.Refs {
+					_, _ = fmt.Fprintf(tw, "      %s\t%s\t\n", chainMarker(r), r.Ref)
+				}
+			}
+			if fd.BecameSensitive {
+				_, _ = fmt.Fprintf(tw, "      !\tnow reads secret material\t\n")
+			}
+		}
+		_ = tw.Flush()
+	}
+
+	lines := privilegeLines(d.Privilege, policyFormat)
+	if len(lines) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "privilege delta")
+	for _, l := range lines {
+		_, _ = fmt.Fprintf(w, "  %s\n", l)
+	}
+}
+
+// chainMarker renders a RefChange's verdict as a short prefix.
+func chainMarker(r RefChange) string {
+	switch r.Kind {
+	case ChangeAdded:
+		return "chain +"
+	case ChangeRemoved:
+		return "chain -"
+	default:
+		return fmt.Sprintf("chain ~ (position %d -> %d)", r.BasePos, r.HeadPos)
+	}
+}
+
+// blank renders an empty attribute value visibly, so "" to "fail" does not
+// print as a line that appears to start with an arrow.
+func blank(s string) string {
+	if s == "" {
+		return `""`
+	}
+	return s
+}
+
+func fieldType(f *Field) string {
+	if f == nil {
+		return ""
+	}
+	return f.GoType
+}
+
+func fieldChain(f *Field) string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(f.Refs, ", ")
+}
+
+// privilegeLines renders the privilege delta as one line per path. With an
+// empty policyFormat it is scheme neutral, which works for every provider and
+// presumes no cloud. With a policyFormat it additionally renders the concrete
+// grant for the schemes that format knows how to address, reusing policy.go's
+// own ARN and resource-name helpers so the identifiers match what
+// `mamori policy` would emit for the same refs.
+//
+// A scheme the chosen format cannot address still gets its neutral line: a
+// change to a vault:// or k8s-secret:// ref must never vanish from the report
+// just because no IAM vocabulary exists for it.
+func privilegeLines(d PrivilegeDelta, policyFormat string) []string {
+	var out []string
+	out = append(out, privilegeSide(d.Added, "+", policyFormat)...)
+	out = append(out, privilegeSide(d.Removed, "-", policyFormat)...)
+	return out
+}
+
+func privilegeSide(byScheme map[string][]string, marker, policyFormat string) []string {
+	if len(byScheme) == 0 {
+		return nil
+	}
+	schemes := make([]string, 0, len(byScheme))
+	for s := range byScheme {
+		schemes = append(schemes, s)
+	}
+	sort.Strings(schemes)
+
+	var out []string
+	for _, scheme := range schemes {
+		for _, path := range byScheme[scheme] {
+			line := fmt.Sprintf("%s %s  %s", marker, scheme, path)
+			if grant := concreteGrant(scheme, path, policyFormat); grant != "" {
+				line += "  " + grant
+			}
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// concreteGrant renders the artifact-specific grant for one path, or "" when
+// the chosen format has no vocabulary for that scheme.
+func concreteGrant(scheme, path, policyFormat string) string {
+	switch policyFormat {
+	case policyFormatAWSIAM:
+		switch scheme {
+		case awsSMScheme:
+			return "secretsmanager:GetSecretValue on " + awsSecretARN(path)
+		case awsPSScheme:
+			return "ssm:GetParameter on " + awsParameterARN(path)
+		}
+	case policyFormatGCP:
+		if scheme == gcpSMScheme {
+			return gcpSecretAccessorRole + " on " + gcpResourceName(path)
+		}
+	case policyFormatExternalSecret:
+		switch scheme {
+		case awsSMScheme, awsPSScheme, gcpSMScheme:
+			return "ExternalSecret remoteRef.key " + path
+		}
+	}
+	return ""
+}

--- a/cmd/mamori/diffrender.go
+++ b/cmd/mamori/diffrender.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -176,4 +177,86 @@ func concreteGrant(scheme, path, policyFormat string) string {
 		}
 	}
 	return ""
+}
+
+// renderDiffJSON writes the whole Diff as indented JSON. It mirrors
+// writeExplainJSON (explain.go): the only failure mode is an encoding error,
+// which cannot happen for this plain data, and is reported on stderr with
+// exit 1 rather than being swallowed.
+func renderDiffJSON(stdout, stderr io.Writer, d Diff) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(d); err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: encoding JSON: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// renderDiffMarkdown writes a report suited to a pull request comment or a
+// GitHub step summary: one table per changed struct, then the privilege delta
+// in a fenced block so its alignment survives.
+func renderDiffMarkdown(w io.Writer, d Diff, policyFormat string) {
+	if d.Empty() {
+		_, _ = fmt.Fprintln(w, "No configuration surface changes.")
+		return
+	}
+
+	for _, sd := range d.Structs {
+		switch sd.Kind {
+		case ChangeAdded:
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nNew config struct.\n\n", sd.Package, sd.TypeName)
+			continue
+		case ChangeRemoved:
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nConfig struct removed.\n\n", sd.Package, sd.TypeName)
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "### `%s.%s`\n\n", sd.Package, sd.TypeName)
+		_, _ = fmt.Fprintln(w, "| | Field | Change |")
+		_, _ = fmt.Fprintln(w, "| --- | --- | --- |")
+		for _, fd := range sd.Fields {
+			switch fd.Kind {
+			case ChangeAdded:
+				_, _ = fmt.Fprintf(w, "| + | `%s` | %s `%s` |\n",
+					mdEscape(fd.Path), mdEscape(fieldType(fd.Field)), mdEscape(fieldChain(fd.Field)))
+			case ChangeRemoved:
+				_, _ = fmt.Fprintf(w, "| - | `%s` | %s `%s` |\n",
+					mdEscape(fd.Path), mdEscape(fieldType(fd.Field)), mdEscape(fieldChain(fd.Field)))
+			default:
+				for _, a := range fd.Attrs {
+					_, _ = fmt.Fprintf(w, "| ~ | `%s` | %s: %s to %s |\n",
+						mdEscape(fd.Path), mdEscape(a.Name), mdEscape(blank(a.Base)), mdEscape(blank(a.Head)))
+				}
+				for _, r := range fd.Refs {
+					_, _ = fmt.Fprintf(w, "| ~ | `%s` | %s `%s` |\n",
+						mdEscape(fd.Path), mdEscape(chainMarker(r)), mdEscape(r.Ref))
+				}
+			}
+			if fd.BecameSensitive {
+				_, _ = fmt.Fprintf(w, "| ! | `%s` | **now reads secret material** |\n", mdEscape(fd.Path))
+			}
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	lines := privilegeLines(d.Privilege, policyFormat)
+	if len(lines) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "### Privilege delta")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "```")
+	for _, l := range lines {
+		_, _ = fmt.Fprintln(w, l)
+	}
+	_, _ = fmt.Fprintln(w, "```")
+}
+
+// mdEscape escapes the characters that would break a markdown table cell. A
+// pipe inside a validate: tag (e.g. oneof=a|b) is the realistic case.
+func mdEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.ReplaceAll(s, "\n", " ")
 }

--- a/cmd/mamori/diffrender.go
+++ b/cmd/mamori/diffrender.go
@@ -246,11 +246,40 @@ func renderDiffMarkdown(w io.Writer, d Diff, policyFormat string) {
 	}
 	_, _ = fmt.Fprintln(w, "### Privilege delta")
 	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintln(w, "```")
+	fence := mdFence(lines)
+	_, _ = fmt.Fprintln(w, fence)
 	for _, l := range lines {
 		_, _ = fmt.Fprintln(w, l)
 	}
-	_, _ = fmt.Fprintln(w, "```")
+	_, _ = fmt.Fprintln(w, fence)
+}
+
+// mdFence returns a fence long enough to hold lines verbatim. CommonMark
+// closes a fenced block at the first run of backticks at least as long as
+// the opening fence, so content containing ``` would end the block early and
+// let the rest render as live markdown. Since a Diff is decoded from an
+// arbitrary JSON file rather than from compiler-constrained Go source, that
+// content is not trusted: the fence grows past the longest run instead.
+func mdFence(lines []string) string {
+	longest := 0
+	for _, l := range lines {
+		run := 0
+		for _, r := range l {
+			if r == '`' {
+				run++
+				if run > longest {
+					longest = run
+				}
+			} else {
+				run = 0
+			}
+		}
+	}
+	n := 3
+	if longest >= n {
+		n = longest + 1
+	}
+	return strings.Repeat("`", n)
 }
 
 // mdEscape escapes the characters that would break a markdown table cell. A

--- a/cmd/mamori/diffrender.go
+++ b/cmd/mamori/diffrender.go
@@ -16,14 +16,6 @@ import (
 	"text/tabwriter"
 )
 
-// Policy format names accepted by --policy-format. The empty string means the
-// scheme-neutral default.
-const (
-	policyFormatAWSIAM         = "aws-iam"
-	policyFormatGCP            = "gcp"
-	policyFormatExternalSecret = "external-secret"
-)
-
 // renderDiffText writes the default human-readable report: one section per
 // changed struct, then the privilege delta.
 func renderDiffText(w io.Writer, d Diff, policyFormat string) {
@@ -36,30 +28,32 @@ func renderDiffText(w io.Writer, d Diff, policyFormat string) {
 		if i > 0 {
 			_, _ = fmt.Fprintln(w)
 		}
+		pkg, typeName := sanitizeControl(sd.Package), sanitizeControl(sd.TypeName)
 		switch sd.Kind {
 		case ChangeAdded:
-			_, _ = fmt.Fprintf(w, "+ %s.%s (new config struct)\n", sd.Package, sd.TypeName)
+			_, _ = fmt.Fprintf(w, "+ %s.%s (new config struct)\n", pkg, typeName)
 			continue
 		case ChangeRemoved:
-			_, _ = fmt.Fprintf(w, "- %s.%s (config struct removed)\n", sd.Package, sd.TypeName)
+			_, _ = fmt.Fprintf(w, "- %s.%s (config struct removed)\n", pkg, typeName)
 			continue
 		}
 
-		_, _ = fmt.Fprintf(w, "%s.%s\n", sd.Package, sd.TypeName)
+		_, _ = fmt.Fprintf(w, "%s.%s\n", pkg, typeName)
 		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 		for _, fd := range sd.Fields {
+			path := sanitizeControl(fd.Path)
 			switch fd.Kind {
 			case ChangeAdded:
-				_, _ = fmt.Fprintf(tw, "  + %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+				_, _ = fmt.Fprintf(tw, "  + %s\t%s\t%s\n", path, sanitizeControl(fieldType(fd.Field)), sanitizeControl(fieldChain(fd.Field)))
 			case ChangeRemoved:
-				_, _ = fmt.Fprintf(tw, "  - %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+				_, _ = fmt.Fprintf(tw, "  - %s\t%s\t%s\n", path, sanitizeControl(fieldType(fd.Field)), sanitizeControl(fieldChain(fd.Field)))
 			default:
-				_, _ = fmt.Fprintf(tw, "  ~ %s\t\t\n", fd.Path)
+				_, _ = fmt.Fprintf(tw, "  ~ %s\t\t\n", path)
 				for _, a := range fd.Attrs {
-					_, _ = fmt.Fprintf(tw, "      %s\t%s -> %s\t\n", a.Name, blank(a.Base), blank(a.Head))
+					_, _ = fmt.Fprintf(tw, "      %s\t%s -> %s\t\n", sanitizeControl(a.Name), sanitizeControl(blank(a.Base)), sanitizeControl(blank(a.Head)))
 				}
 				for _, r := range fd.Refs {
-					_, _ = fmt.Fprintf(tw, "      %s\t%s\t\n", chainMarker(r), r.Ref)
+					_, _ = fmt.Fprintf(tw, "      %s\t%s\t\n", chainMarker(r), sanitizeControl(r.Ref))
 				}
 			}
 			if fd.BecameSensitive {
@@ -144,9 +138,16 @@ func privilegeSide(byScheme map[string][]string, marker, policyFormat string) []
 
 	var out []string
 	for _, scheme := range schemes {
+		// scheme and path both originate in an untrusted explain --json
+		// operand (see sanitizeControl), so they are sanitized before being
+		// composed into a line. The sanitized path is also what feeds
+		// concreteGrant, so the ARN/resource-name text it appends cannot
+		// carry a forged line either.
+		safeScheme := sanitizeControl(scheme)
 		for _, path := range byScheme[scheme] {
-			line := fmt.Sprintf("%s %s  %s", marker, scheme, path)
-			if grant := concreteGrant(scheme, path, policyFormat); grant != "" {
+			safePath := sanitizeControl(path)
+			line := fmt.Sprintf("%s %s  %s", marker, safeScheme, safePath)
+			if grant := concreteGrant(scheme, safePath, policyFormat); grant != "" {
 				line += "  " + grant
 			}
 			out = append(out, line)
@@ -159,18 +160,18 @@ func privilegeSide(byScheme map[string][]string, marker, policyFormat string) []
 // the chosen format has no vocabulary for that scheme.
 func concreteGrant(scheme, path, policyFormat string) string {
 	switch policyFormat {
-	case policyFormatAWSIAM:
+	case formatAWSIAM:
 		switch scheme {
 		case awsSMScheme:
 			return "secretsmanager:GetSecretValue on " + awsSecretARN(path)
 		case awsPSScheme:
 			return "ssm:GetParameter on " + awsParameterARN(path)
 		}
-	case policyFormatGCP:
+	case formatGCP:
 		if scheme == gcpSMScheme {
 			return gcpSecretAccessorRole + " on " + gcpResourceName(path)
 		}
-	case policyFormatExternalSecret:
+	case formatExternalSecret:
 		switch scheme {
 		case awsSMScheme, awsPSScheme, gcpSMScheme:
 			return "ExternalSecret remoteRef.key " + path
@@ -203,16 +204,17 @@ func renderDiffMarkdown(w io.Writer, d Diff, policyFormat string) {
 	}
 
 	for _, sd := range d.Structs {
+		pkg, typeName := mdEscape(sd.Package), mdEscape(sd.TypeName)
 		switch sd.Kind {
 		case ChangeAdded:
-			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nNew config struct.\n\n", sd.Package, sd.TypeName)
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nNew config struct.\n\n", pkg, typeName)
 			continue
 		case ChangeRemoved:
-			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nConfig struct removed.\n\n", sd.Package, sd.TypeName)
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nConfig struct removed.\n\n", pkg, typeName)
 			continue
 		}
 
-		_, _ = fmt.Fprintf(w, "### `%s.%s`\n\n", sd.Package, sd.TypeName)
+		_, _ = fmt.Fprintf(w, "### `%s.%s`\n\n", pkg, typeName)
 		_, _ = fmt.Fprintln(w, "| | Field | Change |")
 		_, _ = fmt.Fprintln(w, "| --- | --- | --- |")
 		for _, fd := range sd.Fields {
@@ -283,9 +285,29 @@ func mdFence(lines []string) string {
 }
 
 // mdEscape escapes the characters that would break a markdown table cell. A
-// pipe inside a validate: tag (e.g. oneof=a|b) is the realistic case.
+// pipe inside a validate: tag (e.g. oneof=a|b) is the realistic case; a
+// backtick or a control character (a stray "\r", say) is the adversarial
+// one, so sanitizeControl runs first to remove any structural threat before
+// the markdown-specific escaping below.
 func mdEscape(s string) string {
+	s = sanitizeControl(s)
 	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, "|", `\|`)
-	return strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+// sanitizeControl folds every C0 control character (plus DEL) to a space so
+// untrusted content cannot forge structure in any output format. A Diff is
+// decoded from an arbitrary JSON file rather than from compiler-constrained
+// Go source, so a scheme, path, ref, or tag value reaching a renderer is not
+// trusted: a carriage return would end a markdown table row, and a newline
+// would forge an extra line in the privilege delta. Folding to a space keeps
+// the value visible and its length honest rather than dropping it silently.
+func sanitizeControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == 0x7f || (r >= 0 && r < 0x20) {
+			return ' '
+		}
+		return r
+	}, s)
 }

--- a/cmd/mamori/diffrender_test.go
+++ b/cmd/mamori/diffrender_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderDiffTextEmpty(t *testing.T) {
+	var sb strings.Builder
+	renderDiffText(&sb, Diff{}, "")
+
+	got := sb.String()
+	if !strings.Contains(got, "no configuration surface changes") {
+		t.Errorf("want an explicit no-change line, got %q", got)
+	}
+}
+
+func TestRenderDiffTextFieldVerdicts(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{
+			{Path: "StripeKey", Kind: ChangeAdded, Field: &Field{
+				Path: "StripeKey", GoType: "secret.String",
+				Refs: []string{"aws-sm://prod/stripe#key"}, Sensitive: true}},
+			{Path: "LegacyKey", Kind: ChangeRemoved, Field: &Field{
+				Path: "LegacyKey", GoType: "secret.String",
+				Refs: []string{"aws-sm://prod/legacy#key"}, Sensitive: true}},
+		},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "acme/svc.Config") {
+		t.Errorf("want the struct header, got %q", got)
+	}
+	if !strings.Contains(got, "+ StripeKey") {
+		t.Errorf("want an added marker for StripeKey, got %q", got)
+	}
+	if !strings.Contains(got, "- LegacyKey") {
+		t.Errorf("want a removed marker for LegacyKey, got %q", got)
+	}
+}
+
+func TestRenderDiffTextCallsOutBecameSensitive(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{
+			Path: "Key", Kind: ChangeModified, BecameSensitive: true,
+			Attrs: []AttrChange{{Name: "Sensitive", Base: "false", Head: "true"}},
+		}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "now reads secret material") {
+		t.Errorf("want an explicit became-sensitive callout, got %q", got)
+	}
+}
+
+func TestRenderDiffTextChainChange(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{
+			Path: "Port", Kind: ChangeModified,
+			Refs: []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}},
+		}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "chain +") || !strings.Contains(got, "aws-ps://svc/port") {
+		t.Errorf("want a chain addition line, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesSchemeNeutralByDefault(t *testing.T) {
+	d := PrivilegeDelta{
+		Added:   map[string][]string{"aws-sm": {"prod/stripe"}},
+		Removed: map[string][]string{"vault": {"kv/data/old"}},
+	}
+
+	got := strings.Join(privilegeLines(d, ""), "\n")
+
+	if !strings.Contains(got, "+ aws-sm  prod/stripe") {
+		t.Errorf("want a neutral added line, got %q", got)
+	}
+	if !strings.Contains(got, "- vault  kv/data/old") {
+		t.Errorf("want a neutral removed line, got %q", got)
+	}
+	if strings.Contains(got, "arn:aws") {
+		t.Errorf("must not render ARNs without --policy-format, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesAWSIAM(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/stripe"},
+		"aws-ps": {"/svc/port"},
+	}}
+
+	got := strings.Join(privilegeLines(d, "aws-iam"), "\n")
+
+	if !strings.Contains(got, "secretsmanager:GetSecretValue") {
+		t.Errorf("want the SM action, got %q", got)
+	}
+	if !strings.Contains(got, "arn:aws:secretsmanager:*:*:secret:prod/stripe") {
+		t.Errorf("want the SM ARN, got %q", got)
+	}
+	if !strings.Contains(got, "ssm:GetParameter") {
+		t.Errorf("want the SSM action, got %q", got)
+	}
+	if !strings.Contains(got, "arn:aws:ssm:*:*:parameter/svc/port") {
+		t.Errorf("want the SSM ARN with no doubled slash, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesGCP(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{"gcp-sm": {"my-project/api-key"}}}
+
+	got := strings.Join(privilegeLines(d, "gcp"), "\n")
+
+	if !strings.Contains(got, "projects/my-project/secrets/api-key") {
+		t.Errorf("want the GCP resource name, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesKeepsUnrenderableSchemesVisible(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/stripe"},
+		"vault":  {"kv/data/api"},
+	}}
+
+	got := strings.Join(privilegeLines(d, "aws-iam"), "\n")
+
+	// vault has no IAM vocabulary but must not vanish from the report.
+	if !strings.Contains(got, "kv/data/api") {
+		t.Errorf("want the vault path still visible under --policy-format=aws-iam, got %q", got)
+	}
+}
+
+func TestRenderDiffTextIsDeterministic(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{{Path: "A", Kind: ChangeModified,
+				Attrs: []AttrChange{{Name: "GoType", Base: "int", Head: "int64"}}}},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{
+			"aws-sm": {"a", "b"}, "vault": {"c"}, "gcp-sm": {"d/e"},
+		}},
+	}
+
+	var first, second strings.Builder
+	renderDiffText(&first, d, "")
+	renderDiffText(&second, d, "")
+
+	if first.String() != second.String() {
+		t.Errorf("renderDiffText is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+	}
+}

--- a/cmd/mamori/diffrender_test.go
+++ b/cmd/mamori/diffrender_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -162,5 +164,119 @@ func TestRenderDiffTextIsDeterministic(t *testing.T) {
 
 	if first.String() != second.String() {
 		t.Errorf("renderDiffText is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+	}
+}
+
+func TestRenderDiffJSONRoundTrips(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{{
+				Path: "Key", Kind: ChangeModified, BecameSensitive: true,
+				Attrs: []AttrChange{{Name: "Sensitive", Base: "false", Head: "true"}},
+				Refs:  []RefChange{{Kind: ChangeAdded, Ref: "aws-sm://prod/stripe#key", BasePos: -1, HeadPos: 0}},
+			}},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/stripe"}}},
+	}
+
+	var stdout, stderr strings.Builder
+	if code := renderDiffJSON(&stdout, &stderr, d); code != 0 {
+		t.Fatalf("want exit 0, got %d (stderr: %q)", code, stderr.String())
+	}
+
+	var back Diff
+	if err := json.Unmarshal([]byte(stdout.String()), &back); err != nil {
+		t.Fatalf("output does not decode as a Diff: %v\n%s", err, stdout.String())
+	}
+	if !reflect.DeepEqual(back, d) {
+		t.Errorf("round trip mismatch\n got: %+v\nwant: %+v", back, d)
+	}
+}
+
+func TestRenderDiffJSONEmptyIsStillValidJSON(t *testing.T) {
+	var stdout, stderr strings.Builder
+	if code := renderDiffJSON(&stdout, &stderr, Diff{}); code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+
+	var back Diff
+	if err := json.Unmarshal([]byte(stdout.String()), &back); err != nil {
+		t.Fatalf("empty diff must still emit valid JSON: %v", err)
+	}
+	if !back.Empty() {
+		t.Error("want the decoded empty diff to report Empty()")
+	}
+}
+
+func TestRenderDiffMarkdownStructure(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{
+				{Path: "StripeKey", Kind: ChangeAdded, BecameSensitive: false, Field: &Field{
+					Path: "StripeKey", GoType: "secret.String", Refs: []string{"aws-sm://prod/stripe#key"}}},
+			},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/stripe"}}},
+	}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "### `acme/svc.Config`") {
+		t.Errorf("want a markdown struct heading, got %q", got)
+	}
+	if !strings.Contains(got, "| `StripeKey` |") {
+		t.Errorf("want a markdown table row for the field, got %q", got)
+	}
+	if !strings.Contains(got, "### Privilege delta") {
+		t.Errorf("want a privilege heading, got %q", got)
+	}
+	if !strings.Contains(got, "```") {
+		t.Errorf("want the privilege block fenced, got %q", got)
+	}
+}
+
+func TestRenderDiffMarkdownEmpty(t *testing.T) {
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, Diff{}, "")
+
+	if !strings.Contains(sb.String(), "No configuration surface changes") {
+		t.Errorf("want an explicit no-change line, got %q", sb.String())
+	}
+}
+
+func TestRenderDiffMarkdownEscapesPipes(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{Path: "V", Kind: ChangeModified,
+			Attrs: []AttrChange{{Name: "Validate", Base: "", Head: "oneof=a|b"}}}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if strings.Contains(got, "oneof=a|b") {
+		t.Errorf("a raw pipe would break the markdown table, got %q", got)
+	}
+	if !strings.Contains(got, `oneof=a\|b`) {
+		t.Errorf("want the pipe escaped, got %q", got)
+	}
+}
+
+func TestRenderDiffMarkdownIsDeterministic(t *testing.T) {
+	d := Diff{Privilege: PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"a", "b"}, "vault": {"c"}, "gcp-sm": {"d/e"},
+	}}}
+
+	var first, second strings.Builder
+	renderDiffMarkdown(&first, d, "aws-iam")
+	renderDiffMarkdown(&second, d, "aws-iam")
+
+	if first.String() != second.String() {
+		t.Errorf("renderDiffMarkdown is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
 	}
 }

--- a/cmd/mamori/diffrender_test.go
+++ b/cmd/mamori/diffrender_test.go
@@ -300,6 +300,134 @@ func TestRenderDiffMarkdownFenceSurvivesBacktickContent(t *testing.T) {
 	}
 }
 
+func TestRenderDiffMarkdownEscapesCarriageReturn(t *testing.T) {
+	// A lone \r is a CommonMark line ending: left unescaped, it would end the
+	// table row and let the rest of the cell's content render as fresh
+	// markdown outside the table, e.g. injecting a fake bold "reviewed"
+	// claim into a PR summary.
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{Path: "Port", Kind: ChangeModified,
+			Attrs: []AttrChange{{Name: "Source", Base: "",
+				Head: "env:PORT\r\r**Reviewed: no new permissions.**"}}}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "env:PORT") {
+			found = true
+			if !strings.Contains(l, "Reviewed: no new permissions.") {
+				t.Errorf("want the injected text to stay on the same table row, got line %q", l)
+			}
+			if !strings.HasPrefix(l, "| ~ |") {
+				t.Errorf("want the row to still start as a table row, got %q", l)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("want the Head value rendered somewhere, got %q", got)
+	}
+	if strings.Contains(got, "\r") {
+		t.Errorf("want the carriage return stripped, got %q", got)
+	}
+}
+
+func TestRenderDiffMarkdownEscapesBacktick(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{Path: "V", Kind: ChangeModified,
+			Attrs: []AttrChange{{Name: "Validate", Base: "", Head: "oneof=a`b"}}}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if strings.Contains(got, "oneof=a`b") {
+		t.Errorf("a raw backtick would break the inline code span, got %q", got)
+	}
+	if !strings.Contains(got, "oneof=a\\`b") {
+		t.Errorf("want the backtick escaped, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesSanitizesNewlineInPath(t *testing.T) {
+	// A newline in a ref path must not forge an extra privilege line: an
+	// attacker could otherwise fabricate a bogus "- aws-sm  prod/x" removal
+	// line, or pad with newlines to push the real "+" line out of a CI
+	// step summary's visible area.
+	d := PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/x\n- aws-sm  prod/x"},
+	}}
+
+	lines := privilegeLines(d, "")
+	if len(lines) != 1 {
+		t.Fatalf("want exactly one privilege line, got %d: %q", len(lines), lines)
+	}
+	if strings.Contains(lines[0], "\n") {
+		t.Errorf("want the newline sanitized out of the line, got %q", lines[0])
+	}
+}
+
+func TestRenderDiffTextSanitizesNewlineInPrivilegePath(t *testing.T) {
+	d := Diff{Privilege: PrivilegeDelta{Removed: map[string][]string{
+		"aws-sm": {"prod/x\n- aws-sm  prod/x"},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	count := 0
+	for _, l := range lines {
+		if strings.Contains(l, "aws-sm") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("want exactly one privilege line mentioning aws-sm, got %d in %q", count, got)
+	}
+}
+
+func TestRenderDiffMarkdownSanitizesNewlineInPrivilegePath(t *testing.T) {
+	d := Diff{Privilege: PrivilegeDelta{Removed: map[string][]string{
+		"aws-sm": {"prod/x\n- aws-sm  prod/x"},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	count := 0
+	for _, l := range lines {
+		if strings.Contains(l, "aws-sm") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("want exactly one privilege line mentioning aws-sm, got %d in %q", count, got)
+	}
+}
+
+func TestSanitizeControlFoldsC0AndDEL(t *testing.T) {
+	in := "a\rb\nc\td\x7fe"
+	got := sanitizeControl(in)
+	want := "a b c d e"
+	if got != want {
+		t.Errorf("sanitizeControl(%q) = %q, want %q", in, got, want)
+	}
+	if strings.ContainsAny(got, "\r\n\t\x7f") {
+		t.Errorf("want no control characters left, got %q", got)
+	}
+}
+
 func TestMdFenceLength(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/mamori/diffrender_test.go
+++ b/cmd/mamori/diffrender_test.go
@@ -280,3 +280,42 @@ func TestRenderDiffMarkdownIsDeterministic(t *testing.T) {
 		t.Errorf("renderDiffMarkdown is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
 	}
 }
+
+func TestRenderDiffMarkdownFenceSurvivesBacktickContent(t *testing.T) {
+	d := Diff{Privilege: PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/```evil"},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "prod/```evil") {
+		t.Errorf("want the path rendered verbatim, got %q", got)
+	}
+	// The fence must be longer than the longest backtick run in the content,
+	// so the block cannot be closed early.
+	if !strings.Contains(got, "````") {
+		t.Errorf("want a fence longer than the content's backtick run, got %q", got)
+	}
+}
+
+func TestMdFenceLength(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{name: "no backticks uses three", lines: []string{"+ aws-sm  prod/x"}, want: "```"},
+		{name: "one backtick still three", lines: []string{"a `b"}, want: "```"},
+		{name: "triple run grows to four", lines: []string{"a ``` b"}, want: "````"},
+		{name: "longest run across lines wins", lines: []string{"a ``` b", "c ````` d"}, want: "``````"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mdFence(tc.lines); got != tc.want {
+				t.Errorf("mdFence = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -50,7 +50,7 @@ const usage = `mamori is a CLI for the mamori configuration library.
 Usage:
   mamori <command> [arguments]
 
-Static commands (read source, never resolve):
+Static commands (never resolve):
   explain    Explain the config structs and source: refs found in a package
   schema     Emit a JSON Schema for a config struct
   policy     Emit a least-privilege access policy derived from source: refs

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -1,7 +1,9 @@
 // Command mamori is the mamori CLI. It has two halves that never mix:
-// static commands (explain, schema, policy) load Go source and extract
-// source: refs without resolving anything, and live commands (doctor,
-// status) are thin clients of a running process's admin endpoint.
+// static commands (explain, schema, policy, vet, diff) never resolve
+// anything, and live commands (doctor, status) are thin clients of a
+// running process's admin endpoint. Most static commands extract source:
+// refs from Go source; diff is the exception, comparing two prior
+// `explain --json` outputs, so it needs no source and no build.
 package main
 
 import (
@@ -52,6 +54,7 @@ Static commands (read source, never resolve):
   explain    Explain the config structs and source: refs found in a package
   schema     Emit a JSON Schema for a config struct
   policy     Emit a least-privilege access policy derived from source: refs
+  diff       Diff two "mamori explain --json" outputs, with a privilege delta
   vet        Report config fields that pull a secret into a plain string/[]byte
 
 Live commands (thin clients of a running process's admin endpoint):
@@ -88,6 +91,8 @@ func run(args []string) int {
 		return schemaCmd(args[1:], os.Stdout, os.Stderr)
 	case "policy":
 		return policyCmd(args[1:], os.Stdout, os.Stderr)
+	case "diff":
+		return diffCmd(args[1:], os.Stdout, os.Stderr)
 	case "vet":
 		return vetCmd(args[1:], os.Stdout, os.Stderr)
 	case "doctor":

--- a/cmd/mamori/testdata/diff/base.json
+++ b/cmd/mamori/testdata/diff/base.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT",
+        "Refs": ["env:PORT"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      },
+      {
+        "Path": "LegacyKey",
+        "GoType": "secret.String",
+        "Source": "aws-sm://prod/legacy#key",
+        "Refs": ["aws-sm://prod/legacy#key"],
+        "Default": "",
+        "HasDefault": false,
+        "Optional": false,
+        "Sensitive": true,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]

--- a/cmd/mamori/testdata/diff/head-minus.json
+++ b/cmd/mamori/testdata/diff/head-minus.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT,aws-ps://svc/port",
+        "Refs": ["env:PORT", "aws-ps://svc/port"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]

--- a/cmd/mamori/testdata/diff/head.json
+++ b/cmd/mamori/testdata/diff/head.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT,aws-ps://svc/port",
+        "Refs": ["env:PORT", "aws-ps://svc/port"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      },
+      {
+        "Path": "StripeKey",
+        "GoType": "secret.String",
+        "Source": "aws-sm://prod/stripe#key",
+        "Refs": ["aws-sm://prod/stripe#key"],
+        "Default": "",
+        "HasDefault": false,
+        "Optional": false,
+        "Sensitive": true,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]

--- a/cmd/mamori/testdata/diff/notarray.json
+++ b/cmd/mamori/testdata/diff/notarray.json
@@ -1,0 +1,1 @@
+{"Package": "acme/svc", "TypeName": "Config", "Fields": []}

--- a/docs/superpowers/plans/2026-07-30-cli-diff.md
+++ b/docs/superpowers/plans/2026-07-30-cli-diff.md
@@ -1,0 +1,2513 @@
+# mamori diff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `mamori diff`, a static CLI command that compares two `mamori explain --json` outputs and reports what changed about a service's configuration surface, including the delta in backend permissions that surface implies.
+
+**Architecture:** Three new files in `cmd/mamori`. `diffmodel.go` holds pure, IO-free comparison logic over the `[]StructInfo` type that `explain --json` already emits. `diffrender.go` holds the three output formats. `diff.go` holds argument parsing, the command entry point, and exit-code policy. The command never loads Go packages, never touches the network, and never resolves a ref: it reads two JSON files and prints.
+
+**Tech Stack:** Go (standard library only for this command: `encoding/json`, `text/tabwriter`, `io`, `os`, `sort`, `strings`, `fmt`). No new module dependencies. `cmd/mamori` is part of the root module `github.com/xavidop/mamori`.
+
+**Spec:** [docs/superpowers/specs/2026-07-30-cli-diff-design.md](../specs/2026-07-30-cli-diff-design.md)
+
+## Global Constraints
+
+- **Never use the em-dash character (U+2014)** anywhere: not in Go comments, usage text, docs, markdown output, or commit messages. Use a spaced hyphen ( - ), a colon, or parentheses.
+- **Documentation ships with the feature.** Task 7 is not optional and is part of the same stack layer.
+- **The static half of the CLI never resolves anything.** No network calls, no `packages.Load`, no secret managers contacted. `mamori diff` reads two JSON files and nothing else.
+- **Commit messages use Conventional Commits.** The changelog is generated from them. `feat:` triggers a release; `docs:`, `test:`, `chore:` do not.
+- **Existing exit-code conventions:** static commands return 0 on success and 1 on a usage or load error. `mamori diff` adds 2, meaning "findings present and `--exit-code` asked for them to be signalled". The top-level `run()` in `main.go` separately returns 2 for an unknown subcommand; this overlap is accepted because a typo'd subcommand under `--exit-code` fails closed (blocks a merge) rather than open.
+- **Output ordering must be totally deterministic.** Structs sort by package then type name, fields by path, attributes in a fixed declared order, scheme buckets by scheme name, paths within a bucket sorted. This output is pasted into pull request comments.
+- **Flags are hand parsed** in the `--flag=value` style used by `explain` and `policy` (see `parseExplainArgs` in `cmd/mamori/explain.go:75`), not via `flag.FlagSet`, which only the live commands use.
+- **Help is a success:** every command checks `wantsHelp(args)` first and returns `writeHelp(stdout, usage)`, which prints to stdout and returns 0. See `cmd/mamori/help.go`.
+
+---
+
+### Task 1: The diff model, struct and field matching
+
+**Files:**
+- Create: `cmd/mamori/diffmodel.go`
+- Test: `cmd/mamori/diffmodel_test.go`
+
+**Interfaces:**
+- Consumes: `StructInfo` and `Field` from `cmd/mamori/extract.go:29-52`. Do not modify either type.
+- Produces: the types `ChangeKind`, `AttrChange`, `RefChange`, `FieldDiff`, `StructDiff`, `PrivilegeDelta`, `Diff`, and the functions `computeDiff(base, head []StructInfo) Diff`, `diffAttrs(base, head Field) []AttrChange`. Tasks 2 through 6 all build on these exact names.
+
+The `Field` type you are comparing is declared as:
+
+```go
+type Field struct {
+	Path   string
+	GoType string
+	Source string
+	Refs []string
+	Default    string
+	HasDefault bool
+	Optional  bool
+	Sensitive bool
+	OnFail string
+	Validate string
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/mamori/diffmodel_test.go`:
+
+```go
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// si builds a one-struct slice with the given fields, for brevity in tests.
+func si(pkg, typeName string, fields ...Field) []StructInfo {
+	return []StructInfo{{Package: pkg, TypeName: typeName, Fields: fields}}
+}
+
+func TestComputeDiffStructAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config", Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Other", Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 2 {
+		t.Fatalf("want 2 struct diffs, got %d: %+v", len(got.Structs), got.Structs)
+	}
+	// Deterministic order: sorted by package then type name, so "Config" precedes "Other".
+	if got.Structs[0].TypeName != "Config" || got.Structs[0].Kind != ChangeRemoved {
+		t.Errorf("want Config removed, got %+v", got.Structs[0])
+	}
+	if got.Structs[1].TypeName != "Other" || got.Structs[1].Kind != ChangeAdded {
+		t.Errorf("want Other added, got %+v", got.Structs[1])
+	}
+}
+
+func TestComputeDiffFieldAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "Workers", GoType: "int", Source: "env:WORKERS", Refs: []string{"env:WORKERS"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 {
+		t.Fatalf("want 1 struct diff, got %d", len(got.Structs))
+	}
+	sd := got.Structs[0]
+	if sd.Kind != ChangeModified {
+		t.Errorf("want struct modified, got %q", sd.Kind)
+	}
+	if len(sd.Fields) != 2 {
+		t.Fatalf("want 2 field diffs, got %d: %+v", len(sd.Fields), sd.Fields)
+	}
+	// Fields sort by path: "Port" precedes "Workers".
+	if sd.Fields[0].Path != "Port" || sd.Fields[0].Kind != ChangeRemoved {
+		t.Errorf("want Port removed, got %+v", sd.Fields[0])
+	}
+	if sd.Fields[1].Path != "Workers" || sd.Fields[1].Kind != ChangeAdded {
+		t.Errorf("want Workers added, got %+v", sd.Fields[1])
+	}
+}
+
+func TestComputeDiffIdenticalIsEmpty(t *testing.T) {
+	in := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "int", Source: "env:PORT", Refs: []string{"env:PORT"}})
+
+	got := computeDiff(in, in)
+
+	if len(got.Structs) != 0 {
+		t.Errorf("want no struct diffs for identical input, got %+v", got.Structs)
+	}
+	if !got.Empty() {
+		t.Error("want Empty() true for identical input")
+	}
+}
+
+func TestDiffAttrsReportsEachAttributeOldToNew(t *testing.T) {
+	base := Field{Path: "W", GoType: "int", Source: "env:W", Refs: []string{"env:W"},
+		Default: "4", HasDefault: true, Optional: false, Sensitive: false, OnFail: "", Validate: "gte=1"}
+	head := Field{Path: "W", GoType: "int64", Source: "env:W", Refs: []string{"env:W"},
+		Default: "8", HasDefault: true, Optional: true, Sensitive: false, OnFail: "fail", Validate: "gte=1"}
+
+	got := diffAttrs(base, head)
+
+	want := []AttrChange{
+		{Name: "GoType", Base: "int", Head: "int64"},
+		{Name: "Default", Base: "4", Head: "8"},
+		{Name: "Optional", Base: "false", Head: "true"},
+		{Name: "OnFail", Base: "", Head: "fail"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diffAttrs mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestDiffAttrsHasDefaultTogglesShowAsPresence(t *testing.T) {
+	base := Field{Path: "W", Default: "", HasDefault: false}
+	head := Field{Path: "W", Default: "4", HasDefault: true}
+
+	got := diffAttrs(base, head)
+
+	want := []AttrChange{{Name: "Default", Base: "(none)", Head: "4"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diffAttrs mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestComputeDiff|TestDiffAttrs' -v`
+Expected: FAIL to build, with "undefined: computeDiff", "undefined: ChangeRemoved", and similar.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/mamori/diffmodel.go`:
+
+```go
+// This file holds the pure comparison logic behind `mamori diff`: it turns
+// two []StructInfo (each decoded from a `mamori explain --json` output) into
+// a Diff describing what changed. It performs no IO of any kind, which is
+// what lets every case be table-tested from literals rather than fixtures.
+//
+// Everything here sorts its output. `mamori diff` is meant to be pasted into
+// a pull request comment, where unstable ordering would produce phantom churn
+// between runs and train reviewers to ignore the tool.
+package main
+
+import (
+	"sort"
+	"strconv"
+)
+
+// ChangeKind is the verdict for one struct, field, or chain position.
+type ChangeKind string
+
+const (
+	ChangeAdded    ChangeKind = "added"
+	ChangeRemoved  ChangeKind = "removed"
+	ChangeModified ChangeKind = "modified"
+	// ChangeMoved is used only for a chain position whose ref is present on
+	// both sides but at a different index. Chain order is precedence, so a
+	// reorder is a real change even though the ref set is identical.
+	ChangeMoved ChangeKind = "moved"
+)
+
+// attrAbsent is what an unset Default renders as, so that "no default" and
+// "a default of the empty string" do not both print as nothing.
+const attrAbsent = "(none)"
+
+// AttrChange is one Field attribute that differs, reported old to new.
+type AttrChange struct {
+	Name string `json:"name"`
+	Base string `json:"base"`
+	Head string `json:"head"`
+}
+
+// RefChange is one precedence-chain position that differs.
+type RefChange struct {
+	Kind ChangeKind `json:"kind"`
+	Ref  string     `json:"ref"`
+	// BasePos and HeadPos are the ref's index in the base and head chains,
+	// or -1 where it is absent.
+	BasePos int `json:"base_pos"`
+	HeadPos int `json:"head_pos"`
+}
+
+// FieldDiff is one field's verdict.
+type FieldDiff struct {
+	Path string     `json:"path"`
+	Kind ChangeKind `json:"kind"`
+	// Attrs and Refs are populated only when Kind is ChangeModified.
+	Attrs []AttrChange `json:"attrs,omitempty"`
+	Refs  []RefChange  `json:"refs,omitempty"`
+	// BecameSensitive is true when Sensitive went false to true: the service
+	// began reading secret material where it previously read plain config.
+	BecameSensitive bool `json:"became_sensitive,omitempty"`
+	// Field is a snapshot used to render added and removed fields. It is the
+	// head field for ChangeAdded and the base field for ChangeRemoved, and
+	// nil for ChangeModified (where Attrs and Refs carry the detail).
+	Field *Field `json:"field,omitempty"`
+}
+
+// StructDiff groups the field diffs for one struct type.
+type StructDiff struct {
+	Package  string      `json:"package"`
+	TypeName string      `json:"type_name"`
+	Kind     ChangeKind  `json:"kind"`
+	Fields   []FieldDiff `json:"fields,omitempty"`
+}
+
+// PrivilegeDelta is the set of backend paths gained and lost, bucketed by
+// scheme. Populated by Task 3.
+type PrivilegeDelta struct {
+	Added   map[string][]string `json:"added,omitempty"`
+	Removed map[string][]string `json:"removed,omitempty"`
+}
+
+// Diff is the whole comparison of two explain outputs.
+type Diff struct {
+	Structs   []StructDiff   `json:"structs,omitempty"`
+	Privilege PrivilegeDelta `json:"privilege"`
+}
+
+// Empty reports whether nothing at all changed.
+func (d Diff) Empty() bool {
+	return len(d.Structs) == 0 && len(d.Privilege.Added) == 0 && len(d.Privilege.Removed) == 0
+}
+
+// structKey identifies a struct across the two sides.
+type structKey struct {
+	pkg      string
+	typeName string
+}
+
+// computeDiff compares two explain outputs. Structs match on
+// (Package, TypeName) and fields on (Package, TypeName, Path). The result is
+// sorted: structs by package then type name, fields by path.
+func computeDiff(base, head []StructInfo) Diff {
+	baseByKey := indexStructs(base)
+	headByKey := indexStructs(head)
+
+	keys := make([]structKey, 0, len(baseByKey)+len(headByKey))
+	seen := map[structKey]bool{}
+	for k := range baseByKey {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range headByKey {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].pkg != keys[j].pkg {
+			return keys[i].pkg < keys[j].pkg
+		}
+		return keys[i].typeName < keys[j].typeName
+	})
+
+	var out []StructDiff
+	for _, k := range keys {
+		b, inBase := baseByKey[k]
+		h, inHead := headByKey[k]
+		switch {
+		case inBase && !inHead:
+			out = append(out, StructDiff{Package: k.pkg, TypeName: k.typeName, Kind: ChangeRemoved})
+		case !inBase && inHead:
+			out = append(out, StructDiff{Package: k.pkg, TypeName: k.typeName, Kind: ChangeAdded})
+		default:
+			fields := diffFields(b.Fields, h.Fields)
+			if len(fields) == 0 {
+				continue
+			}
+			out = append(out, StructDiff{
+				Package: k.pkg, TypeName: k.typeName, Kind: ChangeModified, Fields: fields,
+			})
+		}
+	}
+	return Diff{Structs: out}
+}
+
+// indexStructs keys a slice of StructInfo by (Package, TypeName). A duplicate
+// key keeps the first occurrence, matching Extract's documented deterministic
+// order (packages sorted, structs in source declaration order).
+func indexStructs(in []StructInfo) map[structKey]StructInfo {
+	out := make(map[structKey]StructInfo, len(in))
+	for _, s := range in {
+		k := structKey{pkg: s.Package, typeName: s.TypeName}
+		if _, dup := out[k]; dup {
+			continue
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// diffFields compares the fields of two matched structs, sorted by path.
+func diffFields(base, head []Field) []FieldDiff {
+	baseByPath := indexFields(base)
+	headByPath := indexFields(head)
+
+	paths := make([]string, 0, len(baseByPath)+len(headByPath))
+	seen := map[string]bool{}
+	for p := range baseByPath {
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	for p := range headByPath {
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	var out []FieldDiff
+	for _, p := range paths {
+		b, inBase := baseByPath[p]
+		h, inHead := headByPath[p]
+		switch {
+		case inBase && !inHead:
+			snapshot := b
+			out = append(out, FieldDiff{Path: p, Kind: ChangeRemoved, Field: &snapshot})
+		case !inBase && inHead:
+			snapshot := h
+			out = append(out, FieldDiff{Path: p, Kind: ChangeAdded, Field: &snapshot})
+		default:
+			fd := FieldDiff{Path: p, Kind: ChangeModified, Attrs: diffAttrs(b, h)}
+			if len(fd.Attrs) == 0 {
+				continue
+			}
+			out = append(out, fd)
+		}
+	}
+	return out
+}
+
+func indexFields(in []Field) map[string]Field {
+	out := make(map[string]Field, len(in))
+	for _, f := range in {
+		if _, dup := out[f.Path]; dup {
+			continue
+		}
+		out[f.Path] = f
+	}
+	return out
+}
+
+// diffAttrs compares two matched fields attribute by attribute, in a fixed
+// declared order so output never churns. Source is deliberately NOT compared
+// here: it is the raw tag whose meaningful content is the chain, which Task 2
+// compares at ref granularity instead. Comparing both would report every
+// chain edit twice.
+func diffAttrs(base, head Field) []AttrChange {
+	var out []AttrChange
+	add := func(name, b, h string) {
+		if b != h {
+			out = append(out, AttrChange{Name: name, Base: b, Head: h})
+		}
+	}
+
+	add("GoType", base.GoType, head.GoType)
+	add("Default", defaultAttr(base), defaultAttr(head))
+	add("Optional", strconv.FormatBool(base.Optional), strconv.FormatBool(head.Optional))
+	add("Sensitive", strconv.FormatBool(base.Sensitive), strconv.FormatBool(head.Sensitive))
+	add("OnFail", base.OnFail, head.OnFail)
+	add("Validate", base.Validate, head.Validate)
+	return out
+}
+
+// defaultAttr renders a field's default, distinguishing "no default: tag" from
+// "a default: tag whose value is the empty string".
+func defaultAttr(f Field) string {
+	if !f.HasDefault {
+		return attrAbsent
+	}
+	return f.Default
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./cmd/mamori/ -run 'TestComputeDiff|TestDiffAttrs' -v`
+Expected: PASS, five tests.
+
+Note: `TestDiffAttrsReportsEachAttributeOldToNew` expects exactly four changes and does not include `Sensitive`, because that fixture keeps `Sensitive` false on both sides. This is intentional.
+
+- [ ] **Step 5: Run the whole package to confirm nothing regressed**
+
+Run: `go test ./cmd/mamori/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/mamori/diffmodel.go cmd/mamori/diffmodel_test.go
+git commit -m "feat(cli): diff model for struct and field comparison"
+```
+
+---
+
+### Task 2: Chain-level ref diffing and the Sensitive escalation
+
+**Files:**
+- Modify: `cmd/mamori/diffmodel.go` (add `diffChain`, call it from `diffFields`)
+- Test: `cmd/mamori/diffmodel_test.go` (append)
+
+**Interfaces:**
+- Consumes: `RefChange`, `ChangeKind`, `FieldDiff`, `diffFields` from Task 1.
+- Produces: `diffChain(base, head []string) []RefChange`, and `FieldDiff.Refs` / `FieldDiff.BecameSensitive` now populated. Task 4, 5, and 6 renderers read both.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/mamori/diffmodel_test.go`:
+
+```go
+func TestDiffChainAddedRemovedMoved(t *testing.T) {
+	cases := []struct {
+		name string
+		base []string
+		head []string
+		want []RefChange
+	}{
+		{
+			name: "position added at the end",
+			base: []string{"env:PORT"},
+			head: []string{"env:PORT", "aws-ps://svc/port"},
+			want: []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}},
+		},
+		{
+			name: "position removed",
+			base: []string{"env:PORT", "aws-ps://svc/port"},
+			head: []string{"env:PORT"},
+			want: []RefChange{{Kind: ChangeRemoved, Ref: "aws-ps://svc/port", BasePos: 1, HeadPos: -1}},
+		},
+		{
+			name: "same refs reordered is a precedence change",
+			base: []string{"env:PORT", "aws-ps://svc/port"},
+			head: []string{"aws-ps://svc/port", "env:PORT"},
+			want: []RefChange{
+				{Kind: ChangeMoved, Ref: "aws-ps://svc/port", BasePos: 1, HeadPos: 0},
+				{Kind: ChangeMoved, Ref: "env:PORT", BasePos: 0, HeadPos: 1},
+			},
+		},
+		{
+			name: "identical chain reports nothing",
+			base: []string{"env:PORT"},
+			head: []string{"env:PORT"},
+			want: nil,
+		},
+		{
+			name: "added and removed at once",
+			base: []string{"env:PORT", "aws-ps://old"},
+			head: []string{"env:PORT", "aws-ps://new"},
+			want: []RefChange{
+				{Kind: ChangeAdded, Ref: "aws-ps://new", BasePos: -1, HeadPos: 1},
+				{Kind: ChangeRemoved, Ref: "aws-ps://old", BasePos: 1, HeadPos: -1},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffChain(tc.base, tc.head)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("diffChain mismatch\n got: %+v\nwant: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeDiffPopulatesChainChanges(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "string", Source: "env:PORT", Refs: []string{"env:PORT"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "Port", GoType: "string", Source: "env:PORT,aws-ps://svc/port",
+			Refs: []string{"env:PORT", "aws-ps://svc/port"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 || len(got.Structs[0].Fields) != 1 {
+		t.Fatalf("want one field diff, got %+v", got.Structs)
+	}
+	fd := got.Structs[0].Fields[0]
+	if fd.Kind != ChangeModified {
+		t.Errorf("want modified, got %q", fd.Kind)
+	}
+	want := []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}}
+	if !reflect.DeepEqual(fd.Refs, want) {
+		t.Errorf("Refs mismatch\n got: %+v\nwant: %+v", fd.Refs, want)
+	}
+	if len(fd.Attrs) != 0 {
+		t.Errorf("want no attr changes for a pure chain edit, got %+v", fd.Attrs)
+	}
+}
+
+func TestComputeDiffFlagsBecameSensitive(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "string", Source: "env:KEY", Refs: []string{"env:KEY"}, Sensitive: false})
+	head := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "secret.String", Source: "aws-sm://prod/stripe#key",
+			Refs: []string{"aws-sm://prod/stripe#key"}, Sensitive: true})
+
+	fd := computeDiff(base, head).Structs[0].Fields[0]
+
+	if !fd.BecameSensitive {
+		t.Error("want BecameSensitive true when Sensitive goes false to true")
+	}
+}
+
+func TestComputeDiffDoesNotFlagSensitiveGoingAway(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "secret.String", Source: "aws-sm://prod/k", Refs: []string{"aws-sm://prod/k"}, Sensitive: true})
+	head := si("acme/svc", "Config",
+		Field{Path: "Key", GoType: "string", Source: "env:KEY", Refs: []string{"env:KEY"}, Sensitive: false})
+
+	fd := computeDiff(base, head).Structs[0].Fields[0]
+
+	if fd.BecameSensitive {
+		t.Error("want BecameSensitive false when Sensitive goes true to false")
+	}
+	// It is still reported as an ordinary attribute change.
+	found := false
+	for _, a := range fd.Attrs {
+		if a.Name == "Sensitive" && a.Base == "true" && a.Head == "false" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a Sensitive true->false attr change, got %+v", fd.Attrs)
+	}
+}
+
+func TestComputeDiffChainOnlyChangeStillCountsAsModified(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "P", Source: "env:A", Refs: []string{"env:A"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "P", Source: "env:B", Refs: []string{"env:B"}})
+
+	got := computeDiff(base, head)
+
+	if len(got.Structs) != 1 {
+		t.Fatalf("a chain-only change must still produce a struct diff, got %+v", got.Structs)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestDiffChain|TestComputeDiffPopulates|TestComputeDiffFlags|TestComputeDiffDoesNot|TestComputeDiffChainOnly' -v`
+Expected: FAIL to build with "undefined: diffChain", and once that compiles, failures on `Refs` and `BecameSensitive` being empty.
+
+- [ ] **Step 3: Add `diffChain` to `cmd/mamori/diffmodel.go`**
+
+Append this function to the file:
+
+```go
+// diffChain compares two precedence chains at ref granularity. A chain is an
+// ordered list, and its order IS precedence, so this reports three things: a
+// ref only in head (added), a ref only in base (removed), and a ref in both
+// but at a different index (moved). Reporting a chain edit as one opaque
+// Source string change would hide that a service acquired a new backend
+// dependency, which is the whole point of the command.
+//
+// Output is sorted by ref so a chain edit renders identically on every run.
+// A duplicated ref within one chain is compared at its first index; refs are
+// not meaningfully repeatable in a chain (a second occurrence can never win),
+// so no attempt is made to pair up duplicates positionally.
+func diffChain(base, head []string) []RefChange {
+	basePos := firstIndexOf(base)
+	headPos := firstIndexOf(head)
+
+	refs := make([]string, 0, len(basePos)+len(headPos))
+	seen := map[string]bool{}
+	for r := range basePos {
+		if !seen[r] {
+			seen[r] = true
+			refs = append(refs, r)
+		}
+	}
+	for r := range headPos {
+		if !seen[r] {
+			seen[r] = true
+			refs = append(refs, r)
+		}
+	}
+	sort.Strings(refs)
+
+	var out []RefChange
+	for _, r := range refs {
+		b, inBase := basePos[r]
+		h, inHead := headPos[r]
+		switch {
+		case inBase && !inHead:
+			out = append(out, RefChange{Kind: ChangeRemoved, Ref: r, BasePos: b, HeadPos: -1})
+		case !inBase && inHead:
+			out = append(out, RefChange{Kind: ChangeAdded, Ref: r, BasePos: -1, HeadPos: h})
+		case b != h:
+			out = append(out, RefChange{Kind: ChangeMoved, Ref: r, BasePos: b, HeadPos: h})
+		}
+	}
+	return out
+}
+
+// firstIndexOf maps each ref to its first index in the chain.
+func firstIndexOf(chain []string) map[string]int {
+	out := make(map[string]int, len(chain))
+	for i, r := range chain {
+		if _, dup := out[r]; dup {
+			continue
+		}
+		out[r] = i
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Wire it into `diffFields`**
+
+In `cmd/mamori/diffmodel.go`, replace the `default:` arm of the switch inside `diffFields` with:
+
+```go
+		default:
+			fd := FieldDiff{
+				Path:            p,
+				Kind:            ChangeModified,
+				Attrs:           diffAttrs(b, h),
+				Refs:            diffChain(b.Refs, h.Refs),
+				BecameSensitive: !b.Sensitive && h.Sensitive,
+			}
+			if len(fd.Attrs) == 0 && len(fd.Refs) == 0 {
+				continue
+			}
+			out = append(out, fd)
+		}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./cmd/mamori/ -run 'TestDiffChain|TestComputeDiff' -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/mamori/diffmodel.go cmd/mamori/diffmodel_test.go
+git commit -m "feat(cli): chain-level ref diffing and sensitive escalation"
+```
+
+---
+
+### Task 3: The privilege delta
+
+**Files:**
+- Modify: `cmd/mamori/diffmodel.go` (add `computePrivilegeDelta`, `PrivilegeGrew`, call from `computeDiff`)
+- Test: `cmd/mamori/diffmodel_test.go` (append)
+
+**Interfaces:**
+- Consumes: `collectPolicyRefs(structs []StructInfo) policyRefs` from `cmd/mamori/policy.go:207`. `policyRefs` is `map[string][]string`, keyed by scheme, values already deduplicated and sorted, holding ref *paths* (not whole refs).
+- Produces: `computePrivilegeDelta(base, head []StructInfo) PrivilegeDelta` and `func (d Diff) PrivilegeGrew() bool`. Task 6 and Task 7 both use `PrivilegeGrew`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/mamori/diffmodel_test.go`:
+
+```go
+func TestComputePrivilegeDeltaAddedAndRemoved(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/legacy#k", Refs: []string{"aws-sm://prod/legacy#k"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/stripe#k", Refs: []string{"aws-sm://prod/stripe#k"}})
+
+	got := computePrivilegeDelta(base, head)
+
+	if want := []string{"prod/stripe"}; !reflect.DeepEqual(got.Added["aws-sm"], want) {
+		t.Errorf("added mismatch\n got: %+v\nwant: %+v", got.Added["aws-sm"], want)
+	}
+	if want := []string{"prod/legacy"}; !reflect.DeepEqual(got.Removed["aws-sm"], want) {
+		t.Errorf("removed mismatch\n got: %+v\nwant: %+v", got.Removed["aws-sm"], want)
+	}
+}
+
+func TestComputePrivilegeDeltaIgnoresUnchangedPaths(t *testing.T) {
+	in := si("acme/svc", "Config",
+		Field{Path: "A", Source: "aws-sm://prod/db#p", Refs: []string{"aws-sm://prod/db#p"}})
+
+	got := computePrivilegeDelta(in, in)
+
+	if len(got.Added) != 0 || len(got.Removed) != 0 {
+		t.Errorf("want empty delta, got %+v", got)
+	}
+}
+
+func TestComputePrivilegeDeltaCoversNonPolicySchemes(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}},
+		Field{Path: "B", Source: "vault://kv/data/api#token", Refs: []string{"vault://kv/data/api#token"}})
+
+	got := computePrivilegeDelta(base, head)
+
+	// vault has no IAM vocabulary, but it must still appear in the neutral view.
+	if want := []string{"kv/data/api"}; !reflect.DeepEqual(got.Added["vault"], want) {
+		t.Errorf("want vault path surfaced, got %+v", got.Added)
+	}
+}
+
+func TestPrivilegeGrew(t *testing.T) {
+	grew := Diff{Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/new"}}}}
+	if !grew.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew true when a path was added")
+	}
+
+	shrank := Diff{Privilege: PrivilegeDelta{Removed: map[string][]string{"aws-sm": {"prod/old"}}}}
+	if shrank.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew false when the surface only shrank")
+	}
+
+	var none Diff
+	if none.PrivilegeGrew() {
+		t.Error("want PrivilegeGrew false for an empty diff")
+	}
+}
+
+func TestComputeDiffIncludesPrivilegeDelta(t *testing.T) {
+	base := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}})
+	head := si("acme/svc", "Config",
+		Field{Path: "A", Source: "env:X", Refs: []string{"env:X"}},
+		Field{Path: "B", Source: "aws-sm://prod/stripe#k", Refs: []string{"aws-sm://prod/stripe#k"}, Sensitive: true})
+
+	got := computeDiff(base, head)
+
+	if !got.PrivilegeGrew() {
+		t.Errorf("computeDiff must populate Privilege, got %+v", got.Privilege)
+	}
+	if got.Empty() {
+		t.Error("want Empty() false")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestComputePrivilege|TestPrivilegeGrew|TestComputeDiffIncludes' -v`
+Expected: FAIL to build with "undefined: computePrivilegeDelta" and "d.PrivilegeGrew undefined".
+
+- [ ] **Step 3: Add the implementation to `cmd/mamori/diffmodel.go`**
+
+Append:
+
+```go
+// computePrivilegeDelta reports which backend paths the head surface gained
+// and lost relative to base, bucketed by scheme.
+//
+// It reuses collectPolicyRefs (policy.go) unchanged, which is why this costs
+// almost nothing: that function already takes exactly the []StructInfo that
+// `explain --json` emits, already buckets every ref by scheme, and already
+// deduplicates and sorts each bucket. Every scheme it collects is compared
+// here, not only the three that policy.go knows how to render as an IAM or
+// GCP artifact, so a change to a vault:// or k8s-secret:// ref is never
+// silently dropped from the privilege view just because no IAM vocabulary
+// exists for it.
+func computePrivilegeDelta(base, head []StructInfo) PrivilegeDelta {
+	baseRefs := collectPolicyRefs(base)
+	headRefs := collectPolicyRefs(head)
+
+	out := PrivilegeDelta{}
+	for _, scheme := range unionSchemes(baseRefs, headRefs) {
+		if added := missingFrom(headRefs[scheme], baseRefs[scheme]); len(added) > 0 {
+			if out.Added == nil {
+				out.Added = map[string][]string{}
+			}
+			out.Added[scheme] = added
+		}
+		if removed := missingFrom(baseRefs[scheme], headRefs[scheme]); len(removed) > 0 {
+			if out.Removed == nil {
+				out.Removed = map[string][]string{}
+			}
+			out.Removed[scheme] = removed
+		}
+	}
+	return out
+}
+
+// unionSchemes returns every scheme present in either side, sorted.
+func unionSchemes(a, b policyRefs) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(a)+len(b))
+	for s := range a {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for s := range b {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// missingFrom returns every element of want that does not appear in have,
+// preserving want's order (collectPolicyRefs already sorted it).
+func missingFrom(want, have []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	inHave := make(map[string]bool, len(have))
+	for _, h := range have {
+		inHave[h] = true
+	}
+	var out []string
+	for _, w := range want {
+		if !inHave[w] {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// PrivilegeGrew reports whether the head surface reads any backend path the
+// base surface did not. This is the condition worth blocking a merge on:
+// a surface that only SHRANK is not a finding, because losing access is not
+// a risk to gate.
+func (d Diff) PrivilegeGrew() bool {
+	return len(d.Privilege.Added) > 0
+}
+```
+
+- [ ] **Step 4: Populate `Privilege` in `computeDiff`**
+
+In `cmd/mamori/diffmodel.go`, change the final `return` of `computeDiff` from:
+
+```go
+	return Diff{Structs: out}
+```
+
+to:
+
+```go
+	return Diff{Structs: out, Privilege: computePrivilegeDelta(base, head)}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./cmd/mamori/ -run 'TestComputePrivilege|TestPrivilegeGrew|TestComputeDiff|TestDiffChain|TestDiffAttrs' -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/mamori/diffmodel.go cmd/mamori/diffmodel_test.go
+git commit -m "feat(cli): privilege delta from collectPolicyRefs"
+```
+
+---
+
+### Task 4: The text renderer
+
+**Files:**
+- Create: `cmd/mamori/diffrender.go`
+- Test: `cmd/mamori/diffrender_test.go`
+
+**Interfaces:**
+- Consumes: `Diff`, `StructDiff`, `FieldDiff`, `AttrChange`, `RefChange`, `ChangeKind` constants, `PrivilegeDelta` from Tasks 1 to 3. Also `awsSecretARN(path string) string`, `awsParameterARN(path string) string`, `gcpResourceName(path string) string` from `cmd/mamori/policy.go`.
+- Produces: `renderDiffText(w io.Writer, d Diff, policyFormat string)` and the shared helper `privilegeLines(d PrivilegeDelta, policyFormat string) []string`. Task 6's markdown renderer reuses `privilegeLines`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/mamori/diffrender_test.go`:
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderDiffTextEmpty(t *testing.T) {
+	var sb strings.Builder
+	renderDiffText(&sb, Diff{}, "")
+
+	got := sb.String()
+	if !strings.Contains(got, "no configuration surface changes") {
+		t.Errorf("want an explicit no-change line, got %q", got)
+	}
+}
+
+func TestRenderDiffTextFieldVerdicts(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{
+			{Path: "StripeKey", Kind: ChangeAdded, Field: &Field{
+				Path: "StripeKey", GoType: "secret.String",
+				Refs: []string{"aws-sm://prod/stripe#key"}, Sensitive: true}},
+			{Path: "LegacyKey", Kind: ChangeRemoved, Field: &Field{
+				Path: "LegacyKey", GoType: "secret.String",
+				Refs: []string{"aws-sm://prod/legacy#key"}, Sensitive: true}},
+		},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "acme/svc.Config") {
+		t.Errorf("want the struct header, got %q", got)
+	}
+	if !strings.Contains(got, "+ StripeKey") {
+		t.Errorf("want an added marker for StripeKey, got %q", got)
+	}
+	if !strings.Contains(got, "- LegacyKey") {
+		t.Errorf("want a removed marker for LegacyKey, got %q", got)
+	}
+}
+
+func TestRenderDiffTextCallsOutBecameSensitive(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{
+			Path: "Key", Kind: ChangeModified, BecameSensitive: true,
+			Attrs: []AttrChange{{Name: "Sensitive", Base: "false", Head: "true"}},
+		}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "now reads secret material") {
+		t.Errorf("want an explicit became-sensitive callout, got %q", got)
+	}
+}
+
+func TestRenderDiffTextChainChange(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{
+			Path: "Port", Kind: ChangeModified,
+			Refs: []RefChange{{Kind: ChangeAdded, Ref: "aws-ps://svc/port", BasePos: -1, HeadPos: 1}},
+		}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffText(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "chain +") || !strings.Contains(got, "aws-ps://svc/port") {
+		t.Errorf("want a chain addition line, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesSchemeNeutralByDefault(t *testing.T) {
+	d := PrivilegeDelta{
+		Added:   map[string][]string{"aws-sm": {"prod/stripe"}},
+		Removed: map[string][]string{"vault": {"kv/data/old"}},
+	}
+
+	got := strings.Join(privilegeLines(d, ""), "\n")
+
+	if !strings.Contains(got, "+ aws-sm  prod/stripe") {
+		t.Errorf("want a neutral added line, got %q", got)
+	}
+	if !strings.Contains(got, "- vault  kv/data/old") {
+		t.Errorf("want a neutral removed line, got %q", got)
+	}
+	if strings.Contains(got, "arn:aws") {
+		t.Errorf("must not render ARNs without --policy-format, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesAWSIAM(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/stripe"},
+		"aws-ps": {"/svc/port"},
+	}}
+
+	got := strings.Join(privilegeLines(d, "aws-iam"), "\n")
+
+	if !strings.Contains(got, "secretsmanager:GetSecretValue") {
+		t.Errorf("want the SM action, got %q", got)
+	}
+	if !strings.Contains(got, "arn:aws:secretsmanager:*:*:secret:prod/stripe") {
+		t.Errorf("want the SM ARN, got %q", got)
+	}
+	if !strings.Contains(got, "ssm:GetParameter") {
+		t.Errorf("want the SSM action, got %q", got)
+	}
+	if !strings.Contains(got, "arn:aws:ssm:*:*:parameter/svc/port") {
+		t.Errorf("want the SSM ARN with no doubled slash, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesGCP(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{"gcp-sm": {"my-project/api-key"}}}
+
+	got := strings.Join(privilegeLines(d, "gcp"), "\n")
+
+	if !strings.Contains(got, "projects/my-project/secrets/api-key") {
+		t.Errorf("want the GCP resource name, got %q", got)
+	}
+}
+
+func TestPrivilegeLinesKeepsUnrenderableSchemesVisible(t *testing.T) {
+	d := PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"prod/stripe"},
+		"vault":  {"kv/data/api"},
+	}}
+
+	got := strings.Join(privilegeLines(d, "aws-iam"), "\n")
+
+	// vault has no IAM vocabulary but must not vanish from the report.
+	if !strings.Contains(got, "kv/data/api") {
+		t.Errorf("want the vault path still visible under --policy-format=aws-iam, got %q", got)
+	}
+}
+
+func TestRenderDiffTextIsDeterministic(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{{Path: "A", Kind: ChangeModified,
+				Attrs: []AttrChange{{Name: "GoType", Base: "int", Head: "int64"}}}},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{
+			"aws-sm": {"a", "b"}, "vault": {"c"}, "gcp-sm": {"d/e"},
+		}},
+	}
+
+	var first, second strings.Builder
+	renderDiffText(&first, d, "")
+	renderDiffText(&second, d, "")
+
+	if first.String() != second.String() {
+		t.Errorf("renderDiffText is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestRenderDiffText|TestPrivilegeLines' -v`
+Expected: FAIL to build with "undefined: renderDiffText" and "undefined: privilegeLines".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/mamori/diffrender.go`:
+
+```go
+// This file renders a Diff (diffmodel.go) in the three formats `mamori diff`
+// supports. Rendering is kept separate from computation so every format can
+// be tested against a Diff literal, with no files and no JSON round trip.
+//
+// All three formats share privilegeLines, so the privilege section cannot
+// drift between the text a human reads in a terminal and the markdown a
+// reviewer reads in a pull request.
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// Policy format names accepted by --policy-format. The empty string means the
+// scheme-neutral default.
+const (
+	policyFormatAWSIAM         = "aws-iam"
+	policyFormatGCP            = "gcp"
+	policyFormatExternalSecret = "external-secret"
+)
+
+// renderDiffText writes the default human-readable report: one section per
+// changed struct, then the privilege delta.
+func renderDiffText(w io.Writer, d Diff, policyFormat string) {
+	if d.Empty() {
+		_, _ = fmt.Fprintln(w, "no configuration surface changes")
+		return
+	}
+
+	for i, sd := range d.Structs {
+		if i > 0 {
+			_, _ = fmt.Fprintln(w)
+		}
+		switch sd.Kind {
+		case ChangeAdded:
+			_, _ = fmt.Fprintf(w, "+ %s.%s (new config struct)\n", sd.Package, sd.TypeName)
+			continue
+		case ChangeRemoved:
+			_, _ = fmt.Fprintf(w, "- %s.%s (config struct removed)\n", sd.Package, sd.TypeName)
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "%s.%s\n", sd.Package, sd.TypeName)
+		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		for _, fd := range sd.Fields {
+			switch fd.Kind {
+			case ChangeAdded:
+				_, _ = fmt.Fprintf(tw, "  + %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+			case ChangeRemoved:
+				_, _ = fmt.Fprintf(tw, "  - %s\t%s\t%s\n", fd.Path, fieldType(fd.Field), fieldChain(fd.Field))
+			default:
+				_, _ = fmt.Fprintf(tw, "  ~ %s\t\t\n", fd.Path)
+				for _, a := range fd.Attrs {
+					_, _ = fmt.Fprintf(tw, "      %s\t%s -> %s\t\n", a.Name, blank(a.Base), blank(a.Head))
+				}
+				for _, r := range fd.Refs {
+					_, _ = fmt.Fprintf(tw, "      %s\t%s\t\n", chainMarker(r), r.Ref)
+				}
+			}
+			if fd.BecameSensitive {
+				_, _ = fmt.Fprintf(tw, "      !\tnow reads secret material\t\n")
+			}
+		}
+		_ = tw.Flush()
+	}
+
+	lines := privilegeLines(d.Privilege, policyFormat)
+	if len(lines) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "privilege delta")
+	for _, l := range lines {
+		_, _ = fmt.Fprintf(w, "  %s\n", l)
+	}
+}
+
+// chainMarker renders a RefChange's verdict as a short prefix.
+func chainMarker(r RefChange) string {
+	switch r.Kind {
+	case ChangeAdded:
+		return "chain +"
+	case ChangeRemoved:
+		return "chain -"
+	default:
+		return fmt.Sprintf("chain ~ (position %d -> %d)", r.BasePos, r.HeadPos)
+	}
+}
+
+// blank renders an empty attribute value visibly, so "" to "fail" does not
+// print as a line that appears to start with an arrow.
+func blank(s string) string {
+	if s == "" {
+		return `""`
+	}
+	return s
+}
+
+func fieldType(f *Field) string {
+	if f == nil {
+		return ""
+	}
+	return f.GoType
+}
+
+func fieldChain(f *Field) string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(f.Refs, ", ")
+}
+
+// privilegeLines renders the privilege delta as one line per path. With an
+// empty policyFormat it is scheme neutral, which works for every provider and
+// presumes no cloud. With a policyFormat it additionally renders the concrete
+// grant for the schemes that format knows how to address, reusing policy.go's
+// own ARN and resource-name helpers so the identifiers match what
+// `mamori policy` would emit for the same refs.
+//
+// A scheme the chosen format cannot address still gets its neutral line: a
+// change to a vault:// or k8s-secret:// ref must never vanish from the report
+// just because no IAM vocabulary exists for it.
+func privilegeLines(d PrivilegeDelta, policyFormat string) []string {
+	var out []string
+	out = append(out, privilegeSide(d.Added, "+", policyFormat)...)
+	out = append(out, privilegeSide(d.Removed, "-", policyFormat)...)
+	return out
+}
+
+func privilegeSide(byScheme map[string][]string, marker, policyFormat string) []string {
+	if len(byScheme) == 0 {
+		return nil
+	}
+	schemes := make([]string, 0, len(byScheme))
+	for s := range byScheme {
+		schemes = append(schemes, s)
+	}
+	sort.Strings(schemes)
+
+	var out []string
+	for _, scheme := range schemes {
+		for _, path := range byScheme[scheme] {
+			line := fmt.Sprintf("%s %s  %s", marker, scheme, path)
+			if grant := concreteGrant(scheme, path, policyFormat); grant != "" {
+				line += "  " + grant
+			}
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// concreteGrant renders the artifact-specific grant for one path, or "" when
+// the chosen format has no vocabulary for that scheme.
+func concreteGrant(scheme, path, policyFormat string) string {
+	switch policyFormat {
+	case policyFormatAWSIAM:
+		switch scheme {
+		case awsSMScheme:
+			return "secretsmanager:GetSecretValue on " + awsSecretARN(path)
+		case awsPSScheme:
+			return "ssm:GetParameter on " + awsParameterARN(path)
+		}
+	case policyFormatGCP:
+		if scheme == gcpSMScheme {
+			return gcpSecretAccessorRole + " on " + gcpResourceName(path)
+		}
+	case policyFormatExternalSecret:
+		switch scheme {
+		case awsSMScheme, awsPSScheme, gcpSMScheme:
+			return "ExternalSecret remoteRef.key " + path
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Confirm the scheme constants exist**
+
+`awsSMScheme`, `awsPSScheme`, `gcpSMScheme`, and `gcpSecretAccessorRole` are referenced above and are expected to already be declared in `cmd/mamori/policy.go`.
+
+Run: `grep -n 'awsSMScheme\|awsPSScheme\|gcpSMScheme\|gcpSecretAccessorRole' cmd/mamori/policy.go`
+
+If any is missing or spelled differently, use the actual identifier from `policy.go` rather than introducing a duplicate constant. Do not redeclare them in `diffrender.go`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./cmd/mamori/ -run 'TestRenderDiffText|TestPrivilegeLines' -v`
+Expected: PASS, nine tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/mamori/diffrender.go cmd/mamori/diffrender_test.go
+git commit -m "feat(cli): text renderer and privilege delta lines"
+```
+
+---
+
+### Task 5: The JSON and markdown renderers
+
+**Files:**
+- Modify: `cmd/mamori/diffrender.go`
+- Test: `cmd/mamori/diffrender_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Diff`, `privilegeLines` from Task 4.
+- Produces: `renderDiffJSON(stdout, stderr io.Writer, d Diff) int` and `renderDiffMarkdown(w io.Writer, d Diff, policyFormat string)`. Task 6 dispatches to both.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/mamori/diffrender_test.go`:
+
+```go
+func TestRenderDiffJSONRoundTrips(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{{
+				Path: "Key", Kind: ChangeModified, BecameSensitive: true,
+				Attrs: []AttrChange{{Name: "Sensitive", Base: "false", Head: "true"}},
+				Refs:  []RefChange{{Kind: ChangeAdded, Ref: "aws-sm://prod/stripe#key", BasePos: -1, HeadPos: 0}},
+			}},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/stripe"}}},
+	}
+
+	var stdout, stderr strings.Builder
+	if code := renderDiffJSON(&stdout, &stderr, d); code != 0 {
+		t.Fatalf("want exit 0, got %d (stderr: %q)", code, stderr.String())
+	}
+
+	var back Diff
+	if err := json.Unmarshal([]byte(stdout.String()), &back); err != nil {
+		t.Fatalf("output does not decode as a Diff: %v\n%s", err, stdout.String())
+	}
+	if !reflect.DeepEqual(back, d) {
+		t.Errorf("round trip mismatch\n got: %+v\nwant: %+v", back, d)
+	}
+}
+
+func TestRenderDiffJSONEmptyIsStillValidJSON(t *testing.T) {
+	var stdout, stderr strings.Builder
+	if code := renderDiffJSON(&stdout, &stderr, Diff{}); code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+
+	var back Diff
+	if err := json.Unmarshal([]byte(stdout.String()), &back); err != nil {
+		t.Fatalf("empty diff must still emit valid JSON: %v", err)
+	}
+	if !back.Empty() {
+		t.Error("want the decoded empty diff to report Empty()")
+	}
+}
+
+func TestRenderDiffMarkdownStructure(t *testing.T) {
+	d := Diff{
+		Structs: []StructDiff{{
+			Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+			Fields: []FieldDiff{
+				{Path: "StripeKey", Kind: ChangeAdded, BecameSensitive: false, Field: &Field{
+					Path: "StripeKey", GoType: "secret.String", Refs: []string{"aws-sm://prod/stripe#key"}}},
+			},
+		}},
+		Privilege: PrivilegeDelta{Added: map[string][]string{"aws-sm": {"prod/stripe"}}},
+	}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if !strings.Contains(got, "### `acme/svc.Config`") {
+		t.Errorf("want a markdown struct heading, got %q", got)
+	}
+	if !strings.Contains(got, "| `StripeKey` |") {
+		t.Errorf("want a markdown table row for the field, got %q", got)
+	}
+	if !strings.Contains(got, "### Privilege delta") {
+		t.Errorf("want a privilege heading, got %q", got)
+	}
+	if !strings.Contains(got, "```") {
+		t.Errorf("want the privilege block fenced, got %q", got)
+	}
+}
+
+func TestRenderDiffMarkdownEmpty(t *testing.T) {
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, Diff{}, "")
+
+	if !strings.Contains(sb.String(), "No configuration surface changes") {
+		t.Errorf("want an explicit no-change line, got %q", sb.String())
+	}
+}
+
+func TestRenderDiffMarkdownEscapesPipes(t *testing.T) {
+	d := Diff{Structs: []StructDiff{{
+		Package: "acme/svc", TypeName: "Config", Kind: ChangeModified,
+		Fields: []FieldDiff{{Path: "V", Kind: ChangeModified,
+			Attrs: []AttrChange{{Name: "Validate", Base: "", Head: "oneof=a|b"}}}},
+	}}}
+
+	var sb strings.Builder
+	renderDiffMarkdown(&sb, d, "")
+	got := sb.String()
+
+	if strings.Contains(got, "oneof=a|b") {
+		t.Errorf("a raw pipe would break the markdown table, got %q", got)
+	}
+	if !strings.Contains(got, `oneof=a\|b`) {
+		t.Errorf("want the pipe escaped, got %q", got)
+	}
+}
+
+func TestRenderDiffMarkdownIsDeterministic(t *testing.T) {
+	d := Diff{Privilege: PrivilegeDelta{Added: map[string][]string{
+		"aws-sm": {"a", "b"}, "vault": {"c"}, "gcp-sm": {"d/e"},
+	}}}
+
+	var first, second strings.Builder
+	renderDiffMarkdown(&first, d, "aws-iam")
+	renderDiffMarkdown(&second, d, "aws-iam")
+
+	if first.String() != second.String() {
+		t.Errorf("renderDiffMarkdown is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+	}
+}
+```
+
+Add `"encoding/json"` and `"reflect"` to the import block at the top of `cmd/mamori/diffrender_test.go`, so it reads:
+
+```go
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestRenderDiffJSON|TestRenderDiffMarkdown' -v`
+Expected: FAIL to build with "undefined: renderDiffJSON" and "undefined: renderDiffMarkdown".
+
+- [ ] **Step 3: Append the implementation to `cmd/mamori/diffrender.go`**
+
+```go
+// renderDiffJSON writes the whole Diff as indented JSON. It mirrors
+// writeExplainJSON (explain.go): the only failure mode is an encoding error,
+// which cannot happen for this plain data, and is reported on stderr with
+// exit 1 rather than being swallowed.
+func renderDiffJSON(stdout, stderr io.Writer, d Diff) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(d); err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: encoding JSON: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// renderDiffMarkdown writes a report suited to a pull request comment or a
+// GitHub step summary: one table per changed struct, then the privilege delta
+// in a fenced block so its alignment survives.
+func renderDiffMarkdown(w io.Writer, d Diff, policyFormat string) {
+	if d.Empty() {
+		_, _ = fmt.Fprintln(w, "No configuration surface changes.")
+		return
+	}
+
+	for _, sd := range d.Structs {
+		switch sd.Kind {
+		case ChangeAdded:
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nNew config struct.\n\n", sd.Package, sd.TypeName)
+			continue
+		case ChangeRemoved:
+			_, _ = fmt.Fprintf(w, "### `%s.%s`\n\nConfig struct removed.\n\n", sd.Package, sd.TypeName)
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "### `%s.%s`\n\n", sd.Package, sd.TypeName)
+		_, _ = fmt.Fprintln(w, "| | Field | Change |")
+		_, _ = fmt.Fprintln(w, "| --- | --- | --- |")
+		for _, fd := range sd.Fields {
+			switch fd.Kind {
+			case ChangeAdded:
+				_, _ = fmt.Fprintf(w, "| + | `%s` | %s `%s` |\n",
+					mdEscape(fd.Path), mdEscape(fieldType(fd.Field)), mdEscape(fieldChain(fd.Field)))
+			case ChangeRemoved:
+				_, _ = fmt.Fprintf(w, "| - | `%s` | %s `%s` |\n",
+					mdEscape(fd.Path), mdEscape(fieldType(fd.Field)), mdEscape(fieldChain(fd.Field)))
+			default:
+				for _, a := range fd.Attrs {
+					_, _ = fmt.Fprintf(w, "| ~ | `%s` | %s: %s to %s |\n",
+						mdEscape(fd.Path), mdEscape(a.Name), mdEscape(blank(a.Base)), mdEscape(blank(a.Head)))
+				}
+				for _, r := range fd.Refs {
+					_, _ = fmt.Fprintf(w, "| ~ | `%s` | %s `%s` |\n",
+						mdEscape(fd.Path), mdEscape(chainMarker(r)), mdEscape(r.Ref))
+				}
+			}
+			if fd.BecameSensitive {
+				_, _ = fmt.Fprintf(w, "| ! | `%s` | **now reads secret material** |\n", mdEscape(fd.Path))
+			}
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	lines := privilegeLines(d.Privilege, policyFormat)
+	if len(lines) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "### Privilege delta")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "```")
+	for _, l := range lines {
+		_, _ = fmt.Fprintln(w, l)
+	}
+	_, _ = fmt.Fprintln(w, "```")
+}
+
+// mdEscape escapes the characters that would break a markdown table cell. A
+// pipe inside a validate: tag (e.g. oneof=a|b) is the realistic case.
+func mdEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.ReplaceAll(s, "\n", " ")
+}
+```
+
+Add `"encoding/json"` to the import block at the top of `cmd/mamori/diffrender.go`, so it reads:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./cmd/mamori/ -run 'TestRenderDiff|TestPrivilegeLines' -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/mamori/diffrender.go cmd/mamori/diffrender_test.go
+git commit -m "feat(cli): json and markdown renderers for diff"
+```
+
+---
+
+### Task 6: Command wiring, argument parsing, and exit codes
+
+**Files:**
+- Create: `cmd/mamori/diff.go`
+- Modify: `cmd/mamori/main.go:51-64` (usage text) and `cmd/mamori/main.go:78-100` (dispatch switch)
+- Test: `cmd/mamori/diff_test.go`
+- Create: `cmd/mamori/testdata/diff/base.json`, `cmd/mamori/testdata/diff/head.json`, `cmd/mamori/testdata/diff/head-minus.json`, `cmd/mamori/testdata/diff/notarray.json`
+
+**Interfaces:**
+- Consumes: `computeDiff`, `Diff.Empty`, `Diff.PrivilegeGrew` from Tasks 1 to 3; `renderDiffText`, `renderDiffJSON`, `renderDiffMarkdown` from Tasks 4 and 5; `wantsHelp(args []string) bool` and `writeHelp(stdout io.Writer, usage string) int` from `cmd/mamori/help.go`.
+- Produces: `diffCmd(args []string, stdout, stderr io.Writer) int`, dispatched from `run()` in `main.go`.
+
+- [ ] **Step 1: Create the test fixtures**
+
+Create `cmd/mamori/testdata/diff/base.json`:
+
+```json
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT",
+        "Refs": ["env:PORT"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      },
+      {
+        "Path": "LegacyKey",
+        "GoType": "secret.String",
+        "Source": "aws-sm://prod/legacy#key",
+        "Refs": ["aws-sm://prod/legacy#key"],
+        "Default": "",
+        "HasDefault": false,
+        "Optional": false,
+        "Sensitive": true,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]
+```
+
+Create `cmd/mamori/testdata/diff/head.json`:
+
+```json
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT,aws-ps://svc/port",
+        "Refs": ["env:PORT", "aws-ps://svc/port"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      },
+      {
+        "Path": "StripeKey",
+        "GoType": "secret.String",
+        "Source": "aws-sm://prod/stripe#key",
+        "Refs": ["aws-sm://prod/stripe#key"],
+        "Default": "",
+        "HasDefault": false,
+        "Optional": false,
+        "Sensitive": true,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]
+```
+
+Create `cmd/mamori/testdata/diff/head-minus.json`. This is `head.json` with the
+`StripeKey` field removed, so that `head.json` compared against it is a **pure
+privilege shrink**: one `aws-sm` path is lost and nothing is gained. Reversing
+`base.json` and `head.json` would NOT work for that test, because `base.json`
+carries `prod/legacy`, which `head.json` lacks, so the reversal adds a path.
+
+```json
+[
+  {
+    "Package": "acme/svc",
+    "TypeName": "Config",
+    "Fields": [
+      {
+        "Path": "Port",
+        "GoType": "string",
+        "Source": "env:PORT,aws-ps://svc/port",
+        "Refs": ["env:PORT", "aws-ps://svc/port"],
+        "Default": "8080",
+        "HasDefault": true,
+        "Optional": false,
+        "Sensitive": false,
+        "OnFail": "",
+        "Validate": ""
+      }
+    ]
+  }
+]
+```
+
+Create `cmd/mamori/testdata/diff/notarray.json`:
+
+```json
+{"Package": "acme/svc", "TypeName": "Config", "Fields": []}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `cmd/mamori/diff_test.go`:
+
+```go
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	baseFixture      = "testdata/diff/base.json"
+	headFixture      = "testdata/diff/head.json"
+	headMinusFixture = "testdata/diff/head-minus.json"
+	notArrayFixture  = "testdata/diff/notarray.json"
+)
+
+func runDiff(t *testing.T, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut strings.Builder
+	code = diffCmd(args, &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestDiffCmdHelpIsSuccessOnStdout(t *testing.T) {
+	code, stdout, stderr := runDiff(t, "--help")
+
+	if code != 0 {
+		t.Errorf("want exit 0 for help, got %d", code)
+	}
+	if !strings.Contains(stdout, "usage: mamori diff") {
+		t.Errorf("want usage on stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("want empty stderr for help, got %q", stderr)
+	}
+}
+
+func TestDiffCmdDefaultExitsZeroDespiteFindings(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture)
+
+	if code != 0 {
+		t.Errorf("want exit 0 without --exit-code, got %d", code)
+	}
+	if !strings.Contains(stdout, "StripeKey") {
+		t.Errorf("want the added field reported, got %q", stdout)
+	}
+}
+
+func TestDiffCmdExitCodeAny(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code=any")
+	if code != 2 {
+		t.Errorf("want exit 2 when findings exist with --exit-code=any, got %d", code)
+	}
+}
+
+func TestDiffCmdBareExitCodeMeansAny(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code")
+	if code != 2 {
+		t.Errorf("want a bare --exit-code to behave as any, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodeAnyOnIdenticalInput(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, baseFixture, "--exit-code=any")
+	if code != 0 {
+		t.Errorf("want exit 0 when nothing changed, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodePrivilegeSignalsOnGrowth(t *testing.T) {
+	code, _, _ := runDiff(t, baseFixture, headFixture, "--exit-code=privilege")
+	if code != 2 {
+		t.Errorf("want exit 2 when the privilege surface grew, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodePrivilegeIgnoresShrink(t *testing.T) {
+	// head to head-minus is a pure shrink: aws-sm prod/stripe is lost and
+	// nothing is gained. Reversing base and head would NOT be a pure shrink,
+	// because base carries prod/legacy, which head lacks.
+	code, _, _ := runDiff(t, headFixture, headMinusFixture, "--exit-code=privilege")
+	if code != 0 {
+		t.Errorf("want exit 0 when the privilege surface only shrank, got %d", code)
+	}
+}
+
+func TestDiffCmdExitCodeAnyStillSignalsOnPureShrink(t *testing.T) {
+	// The same pair under --exit-code=any IS a finding: something changed.
+	code, _, _ := runDiff(t, headFixture, headMinusFixture, "--exit-code=any")
+	if code != 2 {
+		t.Errorf("want exit 2 for a shrink under --exit-code=any, got %d", code)
+	}
+}
+
+func TestDiffCmdMissingFileIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, filepath.Join("testdata", "diff", "nope.json"), headFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a missing file, got %d", code)
+	}
+	if !strings.Contains(stderr, "nope.json") {
+		t.Errorf("want the failing path named on stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCmdNonArrayJSONIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, notArrayFixture, headFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a non-array top level, got %d", code)
+	}
+	if !strings.Contains(stderr, notArrayFixture) {
+		t.Errorf("want the offending file named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdWrongOperandCountIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture)
+
+	if code != 1 {
+		t.Errorf("want exit 1 for one operand, got %d", code)
+	}
+	if !strings.Contains(stderr, "usage: mamori diff") {
+		t.Errorf("want usage echoed on stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCmdJSONAndMarkdownAreMutuallyExclusive(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--json", "--markdown")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for conflicting formats, got %d", code)
+	}
+	if !strings.Contains(stderr, "mutually exclusive") {
+		t.Errorf("want an explicit conflict message, got %q", stderr)
+	}
+}
+
+func TestDiffCmdUnknownFlagIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--nope")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for an unknown flag, got %d", code)
+	}
+	if !strings.Contains(stderr, "--nope") {
+		t.Errorf("want the unknown flag named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdBadExitCodeValueIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--exit-code=maybe")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for a bad --exit-code value, got %d", code)
+	}
+	if !strings.Contains(stderr, "maybe") {
+		t.Errorf("want the bad value named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdBadPolicyFormatIsExitOne(t *testing.T) {
+	code, _, stderr := runDiff(t, baseFixture, headFixture, "--policy-format=azure")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for an unsupported policy format, got %d", code)
+	}
+	if !strings.Contains(stderr, "azure") {
+		t.Errorf("want the bad format named, got %q", stderr)
+	}
+}
+
+func TestDiffCmdMarkdownOutput(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--markdown")
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	if !strings.Contains(stdout, "### `acme/svc.Config`") {
+		t.Errorf("want markdown output, got %q", stdout)
+	}
+}
+
+func TestDiffCmdJSONOutput(t *testing.T) {
+	code, stdout, _ := runDiff(t, baseFixture, headFixture, "--json")
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stdout), "{") {
+		t.Errorf("want a JSON object, got %q", stdout)
+	}
+}
+
+func TestDiffCmdStdinOperand(t *testing.T) {
+	data, err := os.ReadFile(headFixture)
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+
+	var out, errOut strings.Builder
+	c := &diffConfig{stdin: bytes.NewReader(data)}
+	code := c.run([]string{baseFixture, "-"}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d (stderr: %q)", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "StripeKey") {
+		t.Errorf("want the head read from stdin, got %q", out.String())
+	}
+}
+
+func TestDiffCmdRejectsTwoStdinOperands(t *testing.T) {
+	code, _, stderr := runDiff(t, "-", "-")
+
+	if code != 1 {
+		t.Errorf("want exit 1 for two stdin operands, got %d", code)
+	}
+	if !strings.Contains(stderr, "only one operand") {
+		t.Errorf("want an explicit message, got %q", stderr)
+	}
+}
+
+func TestRunDispatchesDiff(t *testing.T) {
+	// `mamori diff` with no operands must reach diffCmd (exit 1), not the
+	// top-level unknown-subcommand path (exit 2).
+	if code := run([]string{"diff", "--help"}); code != 0 {
+		t.Errorf("want run() to dispatch diff --help to exit 0, got %d", code)
+	}
+}
+```
+
+Add `"bytes"` and `"os"` to the import block, so it reads:
+
+```go
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `go test ./cmd/mamori/ -run 'TestDiffCmd|TestRunDispatchesDiff' -v`
+Expected: FAIL to build with "undefined: diffCmd" and "undefined: diffConfig".
+
+- [ ] **Step 4: Write the implementation**
+
+Create `cmd/mamori/diff.go`:
+
+```go
+// This file implements `mamori diff`: it compares two `mamori explain --json`
+// outputs and reports what changed about a service's configuration surface,
+// including the delta in backend permissions that surface implies.
+//
+// It is the fourth static command (decision D1: the CLI's static commands read
+// source and never resolve anything), and the only one that does not even read
+// Go source: its inputs are two JSON files, so it needs no build, no module
+// graph, and no network. That is deliberate. The rejected alternative was
+// taking git revisions and running packages.Load against a historical tree,
+// whose failure mode is "your base commit no longer builds" - worse than no
+// tool at all for something meant to run on every pull request.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var diffUsage = `usage: mamori diff <base.json> <head.json> [--json|--markdown]
+                   [--exit-code[=any|privilege]] [--policy-format=<f>]
+
+Diff compares two "mamori explain --json" outputs and reports what changed
+about a config surface: fields added, removed, and modified, precedence
+chains gained and lost, and the backend paths the service newly reads or
+stops reading. It never resolves anything (no network calls, no secret
+managers contacted) and never loads Go source: both operands are JSON files.
+
+  <base.json>       the earlier explain output. "-" reads it from stdin.
+  <head.json>       the later explain output. "-" reads it from stdin.
+                    At most one operand may be "-".
+  --json            emit the whole diff as JSON instead of a text report
+  --markdown        emit markdown suited to a pull request comment or
+                    $GITHUB_STEP_SUMMARY. Mutually exclusive with --json.
+  --exit-code       signal findings through the exit code (see below).
+                    A bare --exit-code means "any".
+  --policy-format   additionally render the concrete grant for each changed
+                    backend path, in one of: aws-iam, gcp, external-secret.
+                    Without it the privilege delta is scheme neutral, which
+                    works for every provider and presumes no cloud.
+
+Typical CI use:
+
+  git checkout "$BASE" && mamori explain ./... --json > /tmp/base.json
+  git checkout "$HEAD" && mamori explain ./... --json > /tmp/head.json
+  mamori diff /tmp/base.json /tmp/head.json --markdown >> "$GITHUB_STEP_SUMMARY"
+
+  # and, to block a merge that grows the permission surface:
+  mamori diff /tmp/base.json /tmp/head.json --exit-code=privilege
+
+Exit codes:
+  0   success. Also the result when findings exist but --exit-code was not
+      given: showing a diff is not a failure.
+  1   usage error, unreadable operand, or JSON that is not an explain output
+  2   findings present, and --exit-code asked for them to be signalled.
+      --exit-code=any signals on any change; --exit-code=privilege signals
+      only when the permission surface GREW, since losing access is not a
+      risk worth gating a merge on.
+`
+
+// exit-code modes.
+const (
+	exitCodeOff       = ""
+	exitCodeAny       = "any"
+	exitCodePrivilege = "privilege"
+)
+
+// diffConfig carries the injectable stdin, so the "-" operand is testable
+// without touching the real os.Stdin. It mirrors liveFlags.stdin (flags.go).
+type diffConfig struct {
+	stdin io.Reader
+}
+
+// diffCmd is the mamori diff subcommand, using the real stdin.
+func diffCmd(args []string, stdout, stderr io.Writer) int {
+	c := &diffConfig{}
+	return c.run(args, stdout, stderr)
+}
+
+func (c *diffConfig) run(args []string, stdout, stderr io.Writer) int {
+	if wantsHelp(args) {
+		return writeHelp(stdout, diffUsage)
+	}
+
+	opts, err := parseDiffArgs(args)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprint(stderr, diffUsage)
+		return 1
+	}
+
+	base, err := c.loadExplainJSON(opts.baseFile)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: %v\n", err)
+		return 1
+	}
+	head, err := c.loadExplainJSON(opts.headFile)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "mamori diff: %v\n", err)
+		return 1
+	}
+
+	d := computeDiff(base, head)
+
+	switch {
+	case opts.jsonOut:
+		if code := renderDiffJSON(stdout, stderr, d); code != 0 {
+			return code
+		}
+	case opts.markdown:
+		renderDiffMarkdown(stdout, d, opts.policyFormat)
+	default:
+		renderDiffText(stdout, d, opts.policyFormat)
+	}
+
+	switch opts.exitCode {
+	case exitCodeAny:
+		if !d.Empty() {
+			return 2
+		}
+	case exitCodePrivilege:
+		if d.PrivilegeGrew() {
+			return 2
+		}
+	}
+	return 0
+}
+
+// diffOptions is the parsed command line.
+type diffOptions struct {
+	baseFile     string
+	headFile     string
+	jsonOut      bool
+	markdown     bool
+	exitCode     string
+	policyFormat string
+}
+
+// parseDiffArgs scans by recognized flag shape rather than using
+// flag.FlagSet, so operands and flags may appear in either order, matching
+// parseExplainArgs and parsePolicyArgs.
+func parseDiffArgs(args []string) (diffOptions, error) {
+	var o diffOptions
+	var operands []string
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json" || a == "-json":
+			o.jsonOut = true
+		case a == "--markdown" || a == "-markdown":
+			o.markdown = true
+		case a == "--exit-code" || a == "-exit-code":
+			o.exitCode = exitCodeAny
+		case strings.HasPrefix(a, "--exit-code="):
+			o.exitCode = strings.TrimPrefix(a, "--exit-code=")
+		case strings.HasPrefix(a, "-exit-code="):
+			o.exitCode = strings.TrimPrefix(a, "-exit-code=")
+		case strings.HasPrefix(a, "--policy-format="):
+			o.policyFormat = strings.TrimPrefix(a, "--policy-format=")
+		case strings.HasPrefix(a, "-policy-format="):
+			o.policyFormat = strings.TrimPrefix(a, "-policy-format=")
+		case a == "--policy-format" || a == "-policy-format":
+			i++
+			if i >= len(args) {
+				return diffOptions{}, fmt.Errorf("mamori diff: %s requires a value", a)
+			}
+			o.policyFormat = args[i]
+		case a == "-":
+			// The stdin operand, not a flag.
+			operands = append(operands, a)
+		case strings.HasPrefix(a, "-"):
+			return diffOptions{}, fmt.Errorf("mamori diff: unknown flag %q", a)
+		default:
+			operands = append(operands, a)
+		}
+	}
+
+	if len(operands) != 2 {
+		return diffOptions{}, fmt.Errorf("mamori diff: need exactly two operands (base and head), got %d", len(operands))
+	}
+	o.baseFile, o.headFile = operands[0], operands[1]
+	if o.baseFile == "-" && o.headFile == "-" {
+		return diffOptions{}, fmt.Errorf("mamori diff: only one operand may be \"-\"")
+	}
+
+	if o.jsonOut && o.markdown {
+		return diffOptions{}, fmt.Errorf("mamori diff: --json and --markdown are mutually exclusive")
+	}
+
+	switch o.exitCode {
+	case exitCodeOff, exitCodeAny, exitCodePrivilege:
+	default:
+		return diffOptions{}, fmt.Errorf("mamori diff: unknown --exit-code value %q (want any or privilege)", o.exitCode)
+	}
+
+	switch o.policyFormat {
+	case "", policyFormatAWSIAM, policyFormatGCP, policyFormatExternalSecret:
+	default:
+		return diffOptions{}, fmt.Errorf("mamori diff: unknown --policy-format %q (want aws-iam, gcp, or external-secret)", o.policyFormat)
+	}
+
+	return o, nil
+}
+
+// loadExplainJSON reads one operand and decodes it as an explain output.
+//
+// Decoding is deliberately tolerant of unknown object fields (the default for
+// encoding/json, stated here because it is load-bearing rather than
+// incidental): base.json is typically a stored CI artifact produced weeks
+// earlier, possibly by an older mamori binary, so a newer binary's output must
+// stay readable by an older diff and vice versa. See the stability promise
+// documented on `mamori explain --json`: fields may be added to that JSON,
+// never removed and never retyped.
+//
+// A top-level value that is not an array is rejected by name, since the
+// likeliest cause is a file produced by a different command.
+func (c *diffConfig) loadExplainJSON(path string) ([]StructInfo, error) {
+	var r io.Reader
+	if path == "-" {
+		r = c.stdin
+		if r == nil {
+			r = os.Stdin
+		}
+	} else {
+		fh, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = fh.Close() }()
+		r = fh
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var out []StructInfo
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("%s is not a \"mamori explain --json\" output: %w", path, err)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Wire the subcommand into `main.go`**
+
+In `cmd/mamori/main.go`, add the dispatch case immediately after the `policy` case:
+
+```go
+	case "diff":
+		return diffCmd(args[1:], os.Stdout, os.Stderr)
+```
+
+And in the same file's `usage` constant, add this line to the "Static commands" block, immediately after the `policy` line:
+
+```
+  diff       Diff two "mamori explain --json" outputs, with a privilege delta
+```
+
+Also update the package doc comment at `cmd/mamori/main.go:1-4` so it lists the new command:
+
+```go
+// Command mamori is the mamori CLI. It has two halves that never mix:
+// static commands (explain, schema, policy, diff) load Go source and extract
+// source: refs without resolving anything, and live commands (doctor,
+// status) are thin clients of a running process's admin endpoint.
+```
+
+Note: `diff` is the one static command that does not load Go source at all, since both its operands are JSON. The comment above still holds for the group.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./cmd/mamori/ -run 'TestDiffCmd|TestRunDispatchesDiff' -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 7: Run the whole package and the linter**
+
+Run: `go test ./cmd/mamori/... && go vet ./cmd/mamori/... && golangci-lint run ./cmd/mamori/...`
+Expected: PASS with no findings. If `golangci-lint` is not installed, run `make lint` if the Makefile provides it, otherwise note it and continue.
+
+- [ ] **Step 8: Verify the command end to end by hand**
+
+Run:
+
+```bash
+go run ./cmd/mamori diff cmd/mamori/testdata/diff/base.json cmd/mamori/testdata/diff/head.json
+go run ./cmd/mamori diff cmd/mamori/testdata/diff/base.json cmd/mamori/testdata/diff/head.json --policy-format=aws-iam
+go run ./cmd/mamori diff cmd/mamori/testdata/diff/base.json cmd/mamori/testdata/diff/head.json --markdown
+go run ./cmd/mamori diff cmd/mamori/testdata/diff/base.json cmd/mamori/testdata/diff/head.json --exit-code=privilege; echo "exit=$?"
+```
+
+Expected: the first three print a report naming `StripeKey`, `LegacyKey`, and the `aws-ps://svc/port` chain addition; the second includes `arn:aws:secretsmanager:*:*:secret:prod/stripe`; the last prints `exit=2`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cmd/mamori/diff.go cmd/mamori/diff_test.go cmd/mamori/main.go cmd/mamori/testdata/diff/
+git commit -m "feat(cli): mamori diff command wiring and exit codes"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Create: `site/src/pages/docs/cli/diff.md`
+- Modify: `site/src/layouts/DocsLayout.astro` (Tooling nav group)
+- Modify: `site/src/pages/docs/cli/index.md`
+- Modify: `site/src/pages/docs/cli/explain.md`
+- Modify: `README.md` (CLI section)
+- Modify: `skills/mamori/SKILL.md`
+
+**Interfaces:**
+- Consumes: the finished command from Task 6. Every flag, exit code, and output shape documented here must match `diffUsage` in `cmd/mamori/diff.go` exactly.
+
+- [ ] **Step 1: Write the docs page**
+
+Create `site/src/pages/docs/cli/diff.md`, following the frontmatter and structure of the sibling pages (open `site/src/pages/docs/cli/policy.md` first and match its heading style and tone):
+
+```markdown
+---
+layout: ../../../layouts/DocsLayout.astro
+title: diff
+---
+
+# mamori diff
+
+`mamori diff` compares two [`mamori explain --json`](/docs/cli/explain) outputs
+and reports what changed about a service's configuration surface: fields added,
+removed, and modified, precedence chains gained and lost, and the backend paths
+the service newly reads or stops reading.
+
+It is the only static command that does not read Go source. Both operands are
+JSON files, so it needs no build, no module graph, and no network.
+
+## Why
+
+A pull request that adds one struct field can change which secrets a service
+reads and which permissions its role needs to start. In review that is usually
+invisible: the reviewer sees a one-line struct tag, and has to reconstruct the
+consequence by hand. `mamori diff` states it outright.
+
+## Usage
+
+```
+mamori diff <base.json> <head.json> [--json|--markdown]
+            [--exit-code[=any|privilege]] [--policy-format=<f>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `<base.json>` | The earlier explain output. `-` reads from stdin. |
+| `<head.json>` | The later explain output. `-` reads from stdin. At most one operand may be `-`. |
+| `--json` | Emit the whole diff as JSON. Mutually exclusive with `--markdown`. |
+| `--markdown` | Emit markdown for a pull request comment or `$GITHUB_STEP_SUMMARY`. |
+| `--exit-code` | Signal findings through the exit code. A bare `--exit-code` means `any`. |
+| `--policy-format` | Render the concrete grant per changed path: `aws-iam`, `gcp`, or `external-secret`. |
+
+## In CI
+
+```bash
+git checkout "$BASE" && mamori explain ./... --json > /tmp/base.json
+git checkout "$HEAD" && mamori explain ./... --json > /tmp/head.json
+mamori diff /tmp/base.json /tmp/head.json --markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
+To block a merge that grows the permission surface:
+
+```bash
+mamori diff /tmp/base.json /tmp/head.json --exit-code=privilege
+```
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. Also the result when findings exist but `--exit-code` was not given: showing a diff is not a failure. |
+| 1 | Usage error, unreadable operand, or JSON that is not an explain output. |
+| 2 | Findings present, and `--exit-code` asked for them to be signalled. |
+
+`--exit-code=any` signals on any change. `--exit-code=privilege` signals only
+when the permission surface **grew**: a surface that only shrinks is not a
+finding, because losing access is not a risk worth gating a merge on.
+
+## What counts as a change
+
+Structs match on package and type name, fields on their dotted path. A matched
+field is compared attribute by attribute (`GoType`, `Default`, `Optional`,
+`Sensitive`, `OnFail`, `Validate`), and each difference is reported old to new.
+
+Two cases are called out specially rather than listed as ordinary attribute
+changes:
+
+- **A field becoming sensitive.** When `Sensitive` goes from false to true, the
+  service began reading secret material where it previously read plain
+  configuration. That gets its own marker in every output format.
+- **A precedence chain gaining or losing a position.** `env:PORT` becoming
+  `env:PORT,aws-ps://svc/port` is reported as a ref-level addition, not as one
+  opaque string edit, because it means the service acquired a new backend
+  dependency. Reordering is reported too, since chain order is precedence.
+
+## Privilege delta
+
+The privilege section lists the backend paths gained and lost, bucketed by
+scheme. By default it is scheme neutral, which works for every provider:
+
+```
+privilege delta
+  + aws-sm  prod/stripe
+  + aws-ps  /svc/port
+  - aws-sm  prod/legacy
+```
+
+`--policy-format` additionally renders each path as the concrete grant that
+[`mamori policy`](/docs/cli/policy) would emit for it:
+
+```
+privilege delta
+  + aws-sm  prod/stripe  secretsmanager:GetSecretValue on arn:aws:secretsmanager:*:*:secret:prod/stripe
+```
+
+A scheme the chosen format has no vocabulary for (`vault://`, `k8s-secret://`,
+and most others) still gets its neutral line. Nothing is dropped from the
+report just because no IAM equivalent exists for it.
+
+## Determinism
+
+Output ordering is total: structs by package then type name, fields by path,
+attributes in a fixed order, scheme buckets and paths sorted. The same input
+pair always renders byte for byte identically, so a diff pasted into a pull
+request comment does not churn between runs.
+```
+
+- [ ] **Step 2: Add the nav entry**
+
+In `site/src/layouts/DocsLayout.astro`, in the `Tooling` group, add this line immediately after the `cli/policy` entry:
+
+```js
+      { slug: "cli/diff", title: "diff", indent: true },
+```
+
+- [ ] **Step 3: List the command on the CLI index page**
+
+In `site/src/pages/docs/cli/index.md`, there are two places that enumerate the static commands. Update both.
+
+First, the bullet list. Replace this line:
+
+```markdown
+- **Static commands** ([`explain`](/docs/cli/explain/), [`schema`](/docs/cli/schema/), [`policy`](/docs/cli/policy/), [`vet`](/docs/cli/vet/)) read your Go source and never resolve anything.
+```
+
+with:
+
+```markdown
+- **Static commands** ([`explain`](/docs/cli/explain/), [`schema`](/docs/cli/schema/), [`policy`](/docs/cli/policy/), [`vet`](/docs/cli/vet/), [`diff`](/docs/cli/diff/)) never resolve anything. The first four read your Go source; `diff` reads two `explain --json` outputs and needs no source at all.
+```
+
+Second, the mermaid diagram immediately below it. Replace this line:
+
+```
+  CLI --> S["Static: explain, schema, policy, vet"]
+```
+
+with:
+
+```
+  CLI --> S["Static: explain, schema, policy, vet, diff"]
+```
+
+- [ ] **Step 4: Add the stability promise to the explain page**
+
+In `site/src/pages/docs/cli/explain.md`, add a section documenting the `--json` compatibility commitment. Place it after the existing `--json` discussion:
+
+```markdown
+## JSON stability
+
+The `--json` output is consumed by [`mamori diff`](/docs/cli/diff), which is
+typically given a `base.json` stored as a CI artifact and produced weeks
+earlier, possibly by an older `mamori` binary. That makes this output a
+compatibility surface, and it is treated as one:
+
+**Fields may be added to this JSON. They will not be removed and will not be
+retyped.**
+
+The top level is a JSON array of struct records and will stay an array. Consumers
+should ignore unknown fields, which is what `encoding/json` does by default, so
+a newer binary's output stays readable by an older consumer and the reverse.
+```
+
+- [ ] **Step 5: Update the root README**
+
+In `README.md`, in the `## CLI` section, replace this exact paragraph:
+
+```markdown
+[`cmd/mamori`](cmd/mamori/) is a standalone CLI with two halves that never mix: `explain`/`schema`/`policy` statically read your Go source and never resolve anything (struct field tables, JSON Schema, least-privilege IAM/GCP/ExternalSecret artifacts), while `doctor`/`status` are thin clients of a running process's admin endpoint (`WithAdminHTTP` above), exiting `0`-`4` so a script can tell a broken config apart from one it merely couldn't reach.
+```
+
+with these two paragraphs:
+
+```markdown
+[`cmd/mamori`](cmd/mamori/) is a standalone CLI with two halves that never mix: `explain`/`schema`/`policy`/`diff` never resolve anything (struct field tables, JSON Schema, least-privilege IAM/GCP/ExternalSecret artifacts, and the config-surface delta between two revisions), while `doctor`/`status` are thin clients of a running process's admin endpoint (`WithAdminHTTP` above), exiting `0`-`4` so a script can tell a broken config apart from one it merely couldn't reach.
+
+`mamori diff` is built for pull request review: given two `mamori explain --json` outputs it reports which fields and precedence chains changed, flags any field that newly reads secret material, and shows the **privilege delta**, the backend paths the service starts and stops reading, optionally rendered as concrete IAM or GCP grants. `--exit-code=privilege` turns that into a merge gate that fires only when the permission surface grows.
+```
+
+Note the first paragraph drops "statically read your Go source and", because `diff` is now in that list and it alone reads no Go source.
+
+- [ ] **Step 6: Update the agent skill**
+
+Two edits in `skills/mamori/SKILL.md`.
+
+First, the frontmatter `description` on line 3. Replace this substring:
+
+```
+or using the mamori CLI (explain, schema, policy, vet, doctor, status)
+```
+
+with:
+
+```
+or using the mamori CLI (explain, schema, policy, diff, vet, doctor, status)
+```
+
+Second, in the `## The mamori CLI` section, insert this bullet immediately after the `mamori policy` bullet and before the `mamori vet` bullet, matching the surrounding one-line-per-command style:
+
+```markdown
+- `mamori diff <base.json> <head.json>` - compare two `mamori explain --json` outputs: fields and chains added, removed, or modified, fields that newly read secret material, and the privilege delta (backend paths gained and lost). Built for pull request CI: `--markdown` suits a PR comment, and `--exit-code=privilege` fails the build only when the permission surface grows.
+```
+
+- [ ] **Step 7: Verify the docs site builds**
+
+Run: `cd site && npm run build`
+Expected: a successful build with the new page rendered. Confirm `site/dist` contains a `docs/cli/diff` entry.
+
+If `node_modules` is absent, run `npm ci` first.
+
+- [ ] **Step 8: Check for em-dashes across everything added**
+
+Run:
+
+```bash
+grep -rn "—" cmd/mamori/diff.go cmd/mamori/diffmodel.go cmd/mamori/diffrender.go \
+  site/src/pages/docs/cli/diff.md README.md skills/mamori/SKILL.md \
+  site/src/pages/docs/cli/explain.md site/src/pages/docs/cli/index.md
+```
+
+Expected: no matches. Any hit must be replaced with a spaced hyphen, a colon, or parentheses.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add site/src/pages/docs/cli/diff.md site/src/layouts/DocsLayout.astro \
+  site/src/pages/docs/cli/index.md site/src/pages/docs/cli/explain.md \
+  README.md skills/mamori/SKILL.md
+git commit -m "docs: mamori diff command and explain --json stability promise"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite for the root module**
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Run the linter**
+
+Run: `golangci-lint run` (or `make lint`)
+Expected: no findings.
+
+- [ ] **Confirm the static half stayed static**
+
+Run: `grep -n 'packages.Load\|http\.\|net/http' cmd/mamori/diff.go cmd/mamori/diffmodel.go cmd/mamori/diffrender.go`
+Expected: no matches. `mamori diff` must not load Go packages or make network calls.

--- a/docs/superpowers/plans/2026-07-30-cli-diff.md
+++ b/docs/superpowers/plans/2026-07-30-cli-diff.md
@@ -2195,16 +2195,16 @@ And in the same file's `usage` constant, add this line to the "Static commands" 
   diff       Diff two "mamori explain --json" outputs, with a privilege delta
 ```
 
-Also update the package doc comment at `cmd/mamori/main.go:1-4` so it lists the new command:
+Also update the package doc comment at `cmd/mamori/main.go:1-4`. The current text says the static commands "load Go source and extract source: refs", which is no longer true of the whole group: `diff` reads two JSON files and no Go source at all. Replace the comment with:
 
 ```go
 // Command mamori is the mamori CLI. It has two halves that never mix:
-// static commands (explain, schema, policy, diff) load Go source and extract
-// source: refs without resolving anything, and live commands (doctor,
-// status) are thin clients of a running process's admin endpoint.
+// static commands (explain, schema, policy, vet, diff) never resolve
+// anything, and live commands (doctor, status) are thin clients of a
+// running process's admin endpoint. Most static commands extract source:
+// refs from Go source; diff is the exception, comparing two prior
+// `explain --json` outputs, so it needs no source and no build.
 ```
-
-Note: `diff` is the one static command that does not load Go source at all, since both its operands are JSON. The comment above still holds for the group.
 
 - [ ] **Step 6: Run the tests to verify they pass**
 

--- a/docs/superpowers/specs/2026-07-30-cli-diff-design.md
+++ b/docs/superpowers/specs/2026-07-30-cli-diff-design.md
@@ -1,0 +1,209 @@
+# mamori diff design
+
+**Status:** approved
+**Date:** 2026-07-30
+
+Adds a fourth static command to the CLI:
+
+```
+mamori diff <base.json> <head.json> [--json|--markdown]
+            [--exit-code=any|privilege] [--policy-format=aws-iam|gcp|external-secret]
+```
+
+It compares two `mamori explain --json` outputs and reports what changed about a
+service's configuration surface, including the delta in the backend permissions
+that surface implies.
+
+## What this is for
+
+A pull request that adds one struct field can change what secrets a service
+reads and what IAM permissions it needs to start. Today that is invisible in
+review: the reviewer sees a one-line struct tag, and the consequence (this
+service now reads `prod/stripe`, and its role needs
+`secretsmanager:GetSecretValue` on a new ARN) has to be reconstructed by hand,
+correctly, by someone who noticed the tag mattered.
+
+`mamori explain --json` already extracts everything needed to answer that
+([cmd/mamori/explain.go](../../../cmd/mamori/explain.go)), and
+`collectPolicyRefs` already turns a `[]StructInfo` into the set of backend
+paths it touches ([cmd/mamori/policy.go](../../../cmd/mamori/policy.go)).
+Nothing consumes either as a *change*. This command is that missing consumer:
+it turns the privilege impact of a config change into something a reviewer
+reads in the PR, from static analysis, with no credentials and no running
+process.
+
+This is a review primitive no Go configuration library ships, and it exists here
+only because the static half of the CLI was built to never resolve anything.
+
+## Inputs, and the rejected directions
+
+Both operands are files written by `mamori explain --json`. A single `-` reads
+that operand from stdin. In CI:
+
+```bash
+git checkout "$BASE" && mamori explain ./... --json > /tmp/base.json
+git checkout "$HEAD" && mamori explain ./... --json > /tmp/head.json
+mamori diff /tmp/base.json /tmp/head.json --markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
+**Rejected: git revisions.** `mamori diff --base origin/main ./...` would be one
+command instead of four, but it would have to shell out to `git` for a temporary
+checkout and then run `packages.Load` against a historical tree. That needs the
+old revision to still build: a resolvable module graph, possibly a populated
+module cache, possibly the network. A review tool whose failure mode is "your
+base commit no longer builds" is worse than no tool. Taking JSON keeps the
+command total, testable from fixtures, and usable in any CI system.
+
+**Rejected: package patterns for the head side.** `mamori diff base.json ./...`
+is genuinely convenient, since head is usually just the working tree. It is
+excluded anyway because it reintroduces exactly the `packages.Load` dependency
+the previous paragraph rules out, for the operand where it is least necessary.
+Recorded here as a considered exclusion rather than an oversight.
+
+## The diff model
+
+Structs match on `(Package, TypeName)`. Fields match on
+`(Package, TypeName, Path)`. Each produces one of three verdicts: **added**,
+**removed**, or **changed**.
+
+"Changed" compares every attribute `Field` carries
+([cmd/mamori/extract.go](../../../cmd/mamori/extract.go)): `GoType`, `Source`,
+`Refs`, `Default`, `HasDefault`, `Optional`, `Sensitive`, `OnFail`, and
+`Validate`. Each differing attribute is reported as old to new, not as a bare
+"changed", because the whole point is that the reviewer should not have to open
+the diff to learn what actually moved.
+
+Ordering is total and deterministic: structs by package then type name, fields
+by path, attributes in the order declared above. This output is pasted into pull
+request comments, where unstable ordering would produce phantom churn between
+runs and train reviewers to ignore it.
+
+Two cases are deliberately not treated as ordinary attribute changes:
+
+**`Sensitive` flipping false to true** gets its own callout in every output
+format. It means the service began reading secret material where it previously
+read plain configuration. That is the single most review-worthy fact this tool
+can surface, and listing it as one row among eight attribute changes would waste
+it.
+
+**A precedence chain gaining or losing a position** is reported at ref
+granularity, not as one opaque `Source` string change. `env:PORT` becoming
+`env:PORT,aws-ps://svc/port` is not a string edit, it is the service acquiring a
+new backend dependency, and it should read like one. `Field.Refs` is already the
+chain-split list, so the comparison is over two ordered ref sequences: added
+positions, removed positions, and reordering are each distinguishable, and
+reordering matters because chain order is precedence.
+
+## Privilege delta
+
+`collectPolicyRefs` takes `[]StructInfo` and nothing else, so it runs unchanged
+on both sides. Diffing the resulting per-scheme buckets yields the backend paths
+added and removed.
+
+The default rendering is **scheme neutral**: "reads 1 new `aws-sm` path:
+`prod/stripe`". This works for all thirty-eight providers and presumes no cloud,
+which matters because most users of this command are not on AWS.
+
+`--policy-format=aws-iam|gcp|external-secret` additionally renders the added and
+removed grants in that artifact's vocabulary, reusing the existing `awsSecretARN`,
+`awsParameterARN`, and `gcpResourceName` helpers so the ARNs and resource names
+match what `mamori policy` would emit for the same refs. It is opt in because
+defaulting to a specific cloud would presume one.
+
+Only the schemes those helpers know how to address (`aws-sm`, `aws-ps`,
+`gcp-sm`) can be rendered concretely. Every other scheme still appears in the
+scheme-neutral section, so a change to a `vault://` or `k8s-secret://` ref is
+never silently dropped from the privilege view just because no IAM vocabulary
+exists for it.
+
+## Output and exit codes
+
+Three formats: an aligned text table by default (matching `explain`'s table
+style), `--json` (matching `explain`'s flag), and `--markdown` for direct
+consumption by `gh pr comment` and `$GITHUB_STEP_SUMMARY`.
+
+Exit codes follow `git diff` rather than `diff(1)`: findings do not fail the
+command unless asked. The common case is posting a diff as a PR comment, and a
+tool that exits non-zero for "there was a change" breaks a naive CI step for
+doing exactly what it was asked to do.
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. Also the result when findings exist but no `--exit-code` was given. |
+| 1 | Usage error, unreadable file, or unparseable JSON. Matches `explain`. |
+| 2 | Findings present and `--exit-code` asked for them to be signalled. |
+
+`--exit-code=any` signals on any structural or privilege change.
+`--exit-code=privilege` signals only when the privilege surface **grows**, which
+is the security gate worth blocking a merge on. A privilege surface that only
+shrinks is not a finding under `privilege`, since losing access is not a risk to
+gate.
+
+A bare `--exit-code` with no value means `any`, matching `git diff --exit-code`,
+whose convention this section already borrows. `--json` and `--markdown` are
+mutually exclusive; supplying both is a usage error (exit 1) rather than a
+silent precedence rule. Flags are hand parsed in the `--flag=value` style
+`explain` and `policy` already use, not via `flag.FlagSet`, which the live
+commands use but the static ones do not.
+
+## The `explain --json` stability promise
+
+`explain --json` currently writes a bare `[]StructInfo` array with no version
+envelope. That was adequate while it was a human convenience. This command
+promotes it to a compatibility surface, because `base.json` is typically a
+stored CI artifact produced weeks earlier, possibly by an older `mamori` binary
+than the one running the diff.
+
+The envelope is **not** being added. Wrapping the array would break every
+existing consumer of `explain --json` to solve a problem that has not occurred,
+and the schema is a flat record of struct tags whose shape is driven by the tag
+vocabulary itself, which only grows.
+
+Instead:
+
+- `diff` decodes both operands tolerantly: unknown object fields are ignored, so
+  a newer binary's output remains readable by an older `diff`, and an older
+  file remains readable by a newer one.
+- A missing attribute decodes to its zero value and is compared as such. This is
+  correct for every attribute in `Field`, whose zero values (`""`, `false`) each
+  already mean "tag absent".
+- `cli/explain.md` gains an explicit stability promise: fields may be added to
+  this JSON, never removed and never retyped. That is a real commitment and is
+  documented as one.
+- `diff` rejects an operand that is not a JSON array at the top level with exit
+  code 1 and a message naming the file, since the likeliest cause is a file
+  produced by a different command.
+
+## Testing
+
+Golden-file table tests in `cmd/mamori`, matching the style of `explain_test.go`
+and `policy_test.go`. Each case is a pair of fixture JSON files plus the
+expected output for every format and the expected exit code. No `packages.Load`,
+no network, no git, so the suite stays fast and hermetic.
+
+Coverage includes: struct added and removed; field added and removed; each
+attribute changing individually; `Sensitive` false to true (and true to false,
+which is not specially called out); chain position added, removed, and reordered;
+privilege growth, shrink, and both at once; every `--exit-code` mode against
+each; both `--policy-format` renderings; an empty diff in all three formats;
+stdin via `-`; and the three exit-code-1 failure modes (missing file, malformed
+JSON, top-level non-array).
+
+Determinism is tested directly: the same input pair rendered twice must produce
+byte-identical output.
+
+## Documentation
+
+Per this project's standard that documentation ships with the feature:
+
+- `site/src/pages/docs/cli/diff.md`, a new page covering the CI recipe, the
+  three formats, the exit-code table, and the privilege delta.
+- `site/src/layouts/DocsLayout.astro`, adding the `cli/diff` nav entry under
+  Tooling, after `cli/policy`.
+- `site/src/pages/docs/cli/explain.md`, adding the `--json` stability promise.
+- `site/src/pages/docs/cli/index.md`, listing `diff` among the static commands.
+- `cmd/mamori/help.go`, the command list and `diffUsage` text.
+- Root `README.md`, in the CLI section, since the static/live split described
+  there now has a fourth static command.
+- `skills/mamori/SKILL.md`, so an agent knows the command exists and when to
+  reach for it.

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -145,6 +145,7 @@ const groups = [
       { slug: "cli/explain", title: "explain", indent: true },
       { slug: "cli/schema", title: "schema", indent: true },
       { slug: "cli/policy", title: "policy", indent: true },
+      { slug: "cli/diff", title: "diff", indent: true },
       { slug: "cli/vet", title: "vet", indent: true },
       { slug: "cli/doctor-status", title: "doctor & status", indent: true },
       { slug: "testing", title: "Testing" },

--- a/site/src/pages/docs/cli/diff.md
+++ b/site/src/pages/docs/cli/diff.md
@@ -79,6 +79,13 @@ changes:
   opaque string edit, because it means the service acquired a new backend
   dependency. Reordering is reported too, since chain order is precedence.
 
+`Sensitive` is frozen at `explain` time from whatever `--secret-schemes` was
+passed then, not recomputed by `diff`. If `base.json` and `head.json` were
+produced with different `--secret-schemes` settings, every field using the
+scheme that only one side knew about reports a spurious `Sensitive: true` to
+`false` (or the reverse). Produce both operands with the same
+`--secret-schemes` value to avoid this.
+
 ## Privilege delta
 
 The privilege section lists the backend paths gained and lost, bucketed by

--- a/site/src/pages/docs/cli/diff.md
+++ b/site/src/pages/docs/cli/diff.md
@@ -1,0 +1,111 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: diff
+---
+
+# mamori diff
+
+`mamori diff` compares two [`mamori explain --json`](/docs/cli/explain) outputs
+and reports what changed about a service's configuration surface: fields added,
+removed, and modified, precedence chains gained and lost, and the backend paths
+the service newly reads or stops reading.
+
+It is the only static command that does not read Go source. Both operands are
+JSON files, so it needs no build, no module graph, and no network.
+
+## Why
+
+A pull request that adds one struct field can change which secrets a service
+reads and which permissions its role needs to start. In review that is usually
+invisible: the reviewer sees a one-line struct tag, and has to reconstruct the
+consequence by hand. `mamori diff` states it outright.
+
+## Usage
+
+```
+mamori diff <base.json> <head.json> [--json|--markdown]
+            [--exit-code[=any|privilege]] [--policy-format=<f>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `<base.json>` | The earlier explain output. `-` reads from stdin. |
+| `<head.json>` | The later explain output. `-` reads from stdin. At most one operand may be `-`. |
+| `--json` | Emit the whole diff as JSON. Mutually exclusive with `--markdown`. |
+| `--markdown` | Emit markdown for a pull request comment or `$GITHUB_STEP_SUMMARY`. |
+| `--exit-code` | Signal findings through the exit code. A bare `--exit-code` means `any`. |
+| `--policy-format` | Render the concrete grant per changed path: `aws-iam`, `gcp`, or `external-secret`. |
+
+## In CI
+
+```bash
+git checkout "$BASE" && mamori explain ./... --json > /tmp/base.json
+git checkout "$HEAD" && mamori explain ./... --json > /tmp/head.json
+mamori diff /tmp/base.json /tmp/head.json --markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
+To block a merge that grows the permission surface:
+
+```bash
+mamori diff /tmp/base.json /tmp/head.json --exit-code=privilege
+```
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. Also the result when findings exist but `--exit-code` was not given: showing a diff is not a failure. |
+| 1 | Usage error, unreadable operand, or JSON that is not an explain output. |
+| 2 | Findings present, and `--exit-code` asked for them to be signalled. |
+
+`--exit-code=any` signals on any change. `--exit-code=privilege` signals only
+when the permission surface **grew**: a surface that only shrinks is not a
+finding, because losing access is not a risk worth gating a merge on.
+
+## What counts as a change
+
+Structs match on package and type name, fields on their dotted path. A matched
+field is compared attribute by attribute (`GoType`, `Default`, `Optional`,
+`Sensitive`, `OnFail`, `Validate`), and each difference is reported old to new.
+
+Two cases are called out specially rather than listed as ordinary attribute
+changes:
+
+- **A field becoming sensitive.** When `Sensitive` goes from false to true, the
+  service began reading secret material where it previously read plain
+  configuration. That gets its own marker in every output format.
+- **A precedence chain gaining or losing a position.** `env:PORT` becoming
+  `env:PORT,aws-ps://svc/port` is reported as a ref-level addition, not as one
+  opaque string edit, because it means the service acquired a new backend
+  dependency. Reordering is reported too, since chain order is precedence.
+
+## Privilege delta
+
+The privilege section lists the backend paths gained and lost, bucketed by
+scheme. By default it is scheme neutral, which works for every provider:
+
+```
+privilege delta
+  + aws-ps  svc/port
+  + aws-sm  prod/stripe
+  - aws-sm  prod/legacy
+```
+
+`--policy-format` additionally renders each path as the concrete grant that
+[`mamori policy`](/docs/cli/policy) would emit for it:
+
+```
+privilege delta
+  + aws-sm  prod/stripe  secretsmanager:GetSecretValue on arn:aws:secretsmanager:*:*:secret:prod/stripe
+```
+
+A scheme the chosen format has no vocabulary for (`vault://`, `k8s-secret://`,
+and most others) still gets its neutral line. Nothing is dropped from the
+report just because no IAM equivalent exists for it.
+
+## Determinism
+
+Output ordering is total: structs by package then type name, fields by path,
+attributes in a fixed order, scheme buckets and paths sorted. The same input
+pair always renders byte for byte identically, so a diff pasted into a pull
+request comment does not churn between runs.

--- a/site/src/pages/docs/cli/diff.md
+++ b/site/src/pages/docs/cli/diff.md
@@ -92,11 +92,14 @@ privilege delta
 ```
 
 `--policy-format` additionally renders each path as the concrete grant that
-[`mamori policy`](/docs/cli/policy) would emit for it:
+[`mamori policy`](/docs/cli/policy) would emit for it, for the same fixture
+pair as above:
 
 ```
 privilege delta
+  + aws-ps  svc/port  ssm:GetParameter on arn:aws:ssm:*:*:parameter/svc/port
   + aws-sm  prod/stripe  secretsmanager:GetSecretValue on arn:aws:secretsmanager:*:*:secret:prod/stripe
+  - aws-sm  prod/legacy  secretsmanager:GetSecretValue on arn:aws:secretsmanager:*:*:secret:prod/legacy
 ```
 
 A scheme the chosen format has no vocabulary for (`vault://`, `k8s-secret://`,

--- a/site/src/pages/docs/cli/explain.md
+++ b/site/src/pages/docs/cli/explain.md
@@ -49,6 +49,20 @@ mamori explain --secret-schemes=mysecrets ./...
 
 Pass several as a comma-separated list. The flag adds to the built-in set rather than replacing it, and takes a bare scheme token (`mysecrets`), not a full ref.
 
+## JSON stability
+
+The `--json` output is consumed by [`mamori diff`](/docs/cli/diff), which is
+typically given a `base.json` stored as a CI artifact and produced weeks
+earlier, possibly by an older `mamori` binary. That makes this output a
+compatibility surface, and it is treated as one:
+
+**Fields may be added to this JSON. They will not be removed and will not be
+retyped.**
+
+The top level is a JSON array of struct records and will stay an array. Consumers
+should ignore unknown fields, which is what `encoding/json` does by default, so
+a newer binary's output stays readable by an older consumer and the reverse.
+
 ## See also
 
 [`mamori schema`](/docs/cli/schema/) turns the same structs into a JSON Schema; [`mamori policy`](/docs/cli/policy/) turns their refs into an access artifact. [CLI overview](/docs/cli/).

--- a/site/src/pages/docs/cli/index.md
+++ b/site/src/pages/docs/cli/index.md
@@ -15,7 +15,7 @@ flowchart TD
   CLI[mamori CLI]
   CLI --> S["Static: explain, schema, policy, vet, diff"]
   CLI --> L["Live: doctor, status"]
-  S -->|"read Go source, never resolve"| Src[("your config structs")]
+  S -->|"most read Go source, none resolve"| Src[("your config structs")]
   L -->|"GET / on the admin endpoint"| Proc[("a running process")]
 ```
 
@@ -68,6 +68,7 @@ $ echo $?
 - [`mamori explain`](/docs/cli/explain/) - list every config struct and its `source:` refs.
 - [`mamori schema`](/docs/cli/schema/) - emit a JSON Schema for a config struct.
 - [`mamori policy`](/docs/cli/policy/) - emit a least-privilege access artifact.
+- [`mamori diff`](/docs/cli/diff/) - compare two `explain --json` outputs and report the config and privilege delta.
 - [`mamori vet`](/docs/cli/vet/) - flag secret-bearing sources stored in plain `string`/`[]byte`.
 - [`mamori doctor` and `status`](/docs/cli/doctor-status/) - check a running process, with exit codes.
 

--- a/site/src/pages/docs/cli/index.md
+++ b/site/src/pages/docs/cli/index.md
@@ -7,13 +7,13 @@ title: CLI
 
 `mamori` (import path `github.com/xavidop/mamori/cmd/mamori`) is a standalone CLI built around the same `source:` tag conventions and `Report` shape the library uses. It has two halves that never mix:
 
-- **Static commands** ([`explain`](/docs/cli/explain/), [`schema`](/docs/cli/schema/), [`policy`](/docs/cli/policy/), [`vet`](/docs/cli/vet/)) read your Go source and never resolve anything.
+- **Static commands** ([`explain`](/docs/cli/explain/), [`schema`](/docs/cli/schema/), [`policy`](/docs/cli/policy/), [`vet`](/docs/cli/vet/), [`diff`](/docs/cli/diff/)) never resolve anything. The first four read your Go source; `diff` reads two `explain --json` outputs and needs no source at all.
 - **Live commands** ([`doctor` and `status`](/docs/cli/doctor-status/)) query a running process's admin endpoint and set an exit code.
 
 ```mermaid
 flowchart TD
   CLI[mamori CLI]
-  CLI --> S["Static: explain, schema, policy, vet"]
+  CLI --> S["Static: explain, schema, policy, vet, diff"]
   CLI --> L["Live: doctor, status"]
   S -->|"read Go source, never resolve"| Src[("your config structs")]
   L -->|"GET / on the admin endpoint"| Proc[("a running process")]

--- a/skills/mamori/SKILL.md
+++ b/skills/mamori/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mamori
-description: Use when writing Go code that loads configuration or secrets, wiring providers (env, files, AWS, Vault, GCP, Azure, Kubernetes, Consul, databases, feature flags), watching config for live changes without a restart, validating config structs, keeping secrets redacted, or using the mamori CLI (explain, schema, policy, vet, doctor, status). Covers github.com/xavidop/mamori.
+description: Use when writing Go code that loads configuration or secrets, wiring providers (env, files, AWS, Vault, GCP, Azure, Kubernetes, Consul, databases, feature flags), watching config for live changes without a restart, validating config structs, keeping secrets redacted, or using the mamori CLI (explain, schema, policy, diff, vet, doctor, status). Covers github.com/xavidop/mamori.
 ---
 
 # mamori: typed, validated, watchable config and secrets for Go
@@ -166,6 +166,7 @@ Precedence chains: a `source:` tag may list several refs comma-separated
 - `mamori explain ./...` - list every `source:` ref in a package's config structs.
 - `mamori schema ./...` - emit JSON Schema from field types and `validate:` tags.
 - `mamori policy ./... --format=aws-iam|gcp|external-secret` - least-privilege access artifact.
+- `mamori diff <base.json> <head.json>` - compare two `mamori explain --json` outputs: fields and chains added, removed, or modified, fields that newly read secret material, and the privilege delta (backend paths gained and lost). Built for pull request CI: `--markdown` suits a PR comment, and `--exit-code=privilege` fails the build only when the permission surface grows.
 - `mamori vet ./...` - flag secret-bearing sources stored in a plain `string`/`[]byte`. Also works as a `go vet` tool: `go vet -vettool=$(which mamori) ./...`.
 - `--secret-schemes=mysecrets` - accepted by `explain`, `schema`, `policy`, `vet`, and `doctor --compare`; adds a custom provider's scheme to the built-in secret-bearing set so every command agrees on what is a secret.
 - `mamori doctor --endpoint <ep>` / `mamori status` - probe a running process's admin endpoint; exit codes 0 healthy, 1 unhealthy, 2 admin off, 3 unreachable, 4 auth failed.


### PR DESCRIPTION
Adds `mamori diff`, a fourth static command that compares two `mamori explain --json` outputs and reports what changed about a service's configuration surface, including the delta in backend permissions that surface implies.

```
mamori diff <base.json> <head.json> [--json|--markdown]
            [--exit-code[=any|privilege]] [--policy-format=<f>]
```

## Why

A pull request that adds one struct field can change which secrets a service reads and which permissions its role needs to start. In review that is invisible: the reviewer sees a one-line struct tag and has to reconstruct the consequence by hand. This states it outright.

```
$ mamori diff base.json head.json --policy-format=aws-iam
acme/svc.Config
  - LegacyKey  secret.String      aws-sm://prod/legacy#key
  ~ Port
      chain +  aws-ps://svc/port
  + StripeKey  secret.String      aws-sm://prod/stripe#key

privilege delta
  + aws-ps  svc/port     ssm:GetParameter on arn:aws:ssm:*:*:parameter/svc/port
  + aws-sm  prod/stripe  secretsmanager:GetSecretValue on arn:...:secret:prod/stripe
  - aws-sm  prod/legacy  secretsmanager:GetSecretValue on arn:...:secret:prod/legacy
```

In CI, `--markdown` suits a PR comment or `$GITHUB_STEP_SUMMARY`, and `--exit-code=privilege` becomes a merge gate that fires only when the permission surface **grows**. A surface that only shrinks is not a finding: losing access is not a risk worth gating on.

## Design notes

**Inputs are two JSON files, not git revisions.** `mamori diff --base origin/main ./...` would be one command instead of four, but it would have to run `packages.Load` against a historical tree, which needs the old revision to still build. A review tool whose failure mode is "your base commit no longer builds" is worse than no tool. Taking JSON keeps the command total, testable from fixtures, and usable in any CI system.

**The privilege delta is scheme neutral by default.** It reuses `collectPolicyRefs` unchanged, so it covers every scheme, not just the three `mamori policy` can render as IAM. A change to a `vault://` or `k8s-secret://` ref is never dropped from the report just because no IAM vocabulary exists for it. `--policy-format` additionally renders concrete grants using `policy.go`'s own ARN helpers, so identifiers match what `mamori policy` would emit.

**Two cases are escalated rather than listed as ordinary attribute changes.** A field whose `Sensitive` flips false to true gets its own callout: the service began reading secret material where it previously read plain config. And a precedence chain gaining or losing a position is reported at ref granularity, because a new chain position is a new backend dependency, not a string edit.

**No version envelope was added to `explain --json`.** This PR promotes that output to a compatibility surface, since `base.json` is typically a stored CI artifact. Wrapping the array would break existing consumers to solve a problem that has not happened. Instead `diff` decodes tolerantly, and `cli/explain.md` now carries an explicit promise: fields may be added, never removed and never retyped. `explain`'s existing golden test pins the shape, so a rename breaks CI loudly rather than degrading `diff` silently.

## Security

Output is meant to be trusted by a reviewer deciding whether to approve a PR, so the renderers treat their input as untrusted. A `Diff` is decoded from an arbitrary JSON file, and review found two working injections, both fixed in 9fc1d8b:

- A carriage return in a field terminated a markdown table row, letting following content render outside the table.
- A newline in a ref path forged an extra privilege-delta line, which could fake a removal or push a real addition out of view.

Either one lets a crafted struct tag inject text like *"Reviewed: no new permissions"* into the summary a reviewer is reading. All C0 controls and DEL are now folded to a space before any renderer composes output, and the markdown fence grows past any backtick run in its content so it cannot be closed early. Both exploits were reproduced against a compiled binary and confirmed neutralized in text and markdown.

Known and accepted: backslash-escaping a backtick inside a markdown code span is a no-op, since CommonMark does not process escapes there. Nothing escapes the table row, and emphasis inside a cell was already reachable via unescaped `*`. Structural forging is closed; what remains is cosmetic injection within a single cell.

## Testing

Table and golden-style tests at every layer, all hermetic: no `packages.Load`, no network, no git. Coverage includes each verdict and attribute, chain positions added / removed / reordered, privilege growth and shrink and both at once, every `--exit-code` mode, both `--policy-format` renderings, stdin via `-`, the three exit-code-1 failure modes, determinism (same input renders byte identically), and the control-character injections above.

All eight exit-code cases were verified against a compiled binary rather than `go run`, which masks exit codes.

## Docs

`site/src/pages/docs/cli/diff.md` (new), the nav entry, the CLI index, the `explain --json` stability promise, the root README, and `skills/mamori/SKILL.md`. The CLI's "static commands read Go source" framing was corrected throughout: `diff` is static but reads no Go source at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `mamori diff` command to compare two `mamori explain --json` outputs.
  * Reports configuration changes, precedence updates, newly sensitive fields, and privilege additions or removals.
  * Supports text, JSON, and Markdown output, stdin input, policy-specific grant formats, and privilege-growth exit codes.
* **Documentation**
  * Added CLI documentation, usage examples, navigation, and JSON compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->