### PR TITLE
fix(docs): highlight the clicked section in the on-this-page TOC

### DIFF
--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -796,14 +796,54 @@ const next = idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] : null;
       if (slug) linkBySlug.get(slug)?.classList.add("page-toc__link--active");
     };
 
+    // A click on a TOC link wins over the scroll-spy until the reader scrolls
+    // again. Without this, clicking an entry whose section sits in the last
+    // screenful highlights a different one the moment the smooth scroll
+    // settles, because that heading can never reach the activation line (see
+    // the bottom-of-page case in update below).
+    let pinned: string | null = null;
+
     const update = () => {
+      if (pinned) {
+        setActive(pinned);
+        return;
+      }
+
       let current = headingEls[0];
       for (const h of headingEls) {
         if (h.getBoundingClientRect().top - 100 <= 0) current = h;
         else break;
       }
+
+      // Once the page is scrolled to the bottom, every remaining heading is
+      // stuck below the activation line forever: there is no scroll left to
+      // bring it up. The reader is looking at the last section, so say so
+      // rather than leaving the previous one highlighted.
+      const doc = document.documentElement;
+      const atBottom =
+        Math.ceil(window.scrollY + window.innerHeight) >= doc.scrollHeight - 1;
+      if (atBottom) {
+        const last = headingEls[headingEls.length - 1];
+        if (last) current = last;
+      }
+
       setActive(current ? current.id : null);
     };
+
+    // Pin on click, release on the reader's next deliberate scroll. A plain
+    // scroll listener cannot release it, because the click's own smooth scroll
+    // fires scroll events too.
+    for (const a of tocLinks) {
+      a.addEventListener("click", () => {
+        const slug = a.getAttribute("data-toc-link");
+        if (!slug) return;
+        pinned = slug;
+        setActive(slug);
+      });
+    }
+    for (const ev of ["wheel", "touchmove", "keydown"]) {
+      window.addEventListener(ev, () => { pinned = null; }, { passive: true });
+    }
 
     let ticking = false;
     window.addEventListener(


### PR DESCRIPTION
Clicking an entry in the floating "On this page" TOC scrolled to the right section but highlighted the **previous** one.

## Why

Two facts interacted badly:

- `scroll-padding-top: 84px` puts a clicked heading 84px from the viewport top.
- The scroll-spy marked a heading active only once `top - 100 <= 0`.

That works for every heading except the ones in the final screenful. The **last** section can never reach the activation line, because the page hits its scroll limit first. So it never became active and the previous section stayed highlighted forever.

Reproduced in a real browser against the built site. At the position reached by clicking the last entry on `/docs/`, the old algorithm computes:

```
oldWouldHighlight: "how-it-works"      <- the bug
actualNow:         "where-to-go-next"  <- with this fix
```

## The fix

**Bottom-of-page fallback.** Once the page is scrolled to the bottom, the remaining headings are stuck below the activation line permanently, so the last heading becomes active. This fixes manual scrolling to the end.

**Click pins its own entry** until the reader's next deliberate scroll (`wheel`, `touchmove`, `keydown`). A plain scroll listener cannot release the pin, because the click's own smooth scroll fires scroll events too. This covers targets that settle below the line without the page being fully at the bottom, which is the exact case in the report.

## Verification

Driven in a browser against `astro preview`:

| Check | Result |
| --- | --- |
| Click each of the 4 TOC entries | each highlights itself |
| Manual scroll sweep, no clicks | install → quick-start → how-it-works → where-to-go-next |
| Scroll to absolute bottom | last section active |
| Old algorithm at the failing position | reproduces `how-it-works`, confirming the diagnosis |

Heading offsets were checked against the activation line at each step, so the sweep is verified against arithmetic rather than eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)