### PR TITLE
docs(site): count the three new providers on the landing

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -42,8 +42,8 @@ const categories = [
   },
   {
     name: "Secret managers",
-    count: 8,
-    items: "AWS · Vault · GCP · Azure · Doppler · 1Password · SOPS",
+    count: 9,
+    items: "AWS · Vault · GCP · Azure · Scaleway · Doppler · 1Password · SOPS",
     href: `${base}docs/providers/aws`,
   },
   {
@@ -60,8 +60,8 @@ const categories = [
   },
   {
     name: "KV, app config & Kubernetes",
-    count: 6,
-    items: "Consul · etcd · AWS AppConfig · Azure AppConfig · Kubernetes Secret · ConfigMap",
+    count: 8,
+    items: "Consul · etcd · AWS AppConfig · Azure AppConfig · Vercel Global Config · Cloudflare Workers KV · Kubernetes Secret · ConfigMap",
     href: `${base}docs/providers/kubernetes`,
   },
   {


### PR DESCRIPTION
## What & why

The landing page summarises providers by category and computes its own total from those counts, so it went stale the moment the three new providers merged in v1.6.0.

| Category | Was | Now |
|---|---|---|
| Secret managers | 8 | 9 (Scaleway Secret Manager) |
| KV, app config & Kubernetes | 6 | 8 (Vercel Global Config, Cloudflare Workers KV) |
| **Total** | **41** | **44** |

## Why it was missed three times

None of the three provider plans listed `site/src/pages/index.astro`. Each covered the root README table, the site provider matrix, the site nav, the agent skill reference, and the Dependabot entry, and each was reviewed against its own file list, so the omission was invisible at every gate.

It is the same shape as several other findings on those branches: a document that enumerates something, with nothing tying the enumeration to the code. Worth adding to the provider checklist rather than fixing once, since the next provider will hit it again.

## Type of change

- [x] Docs / examples

## Checklist

- [x] `make site-linkcheck` passes: 97 pages, no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)