### PR TITLE
fix(providers): bound and drain HTTP error bodies, and pin the guards that were unpinned

### DIFF
--- a/providers/cloudflare-kv/cloudflarekv_integration_test.go
+++ b/providers/cloudflare-kv/cloudflarekv_integration_test.go
@@ -119,3 +119,46 @@ func TestIntegrationResolveBatchAgreesWithResolve(t *testing.T) {
 		t.Errorf("Resolve and ResolveBatch disagree on Version for %q", key)
 	}
 }
+
+// TestIntegrationResolveBatchTwoKeysOmitsAbsent closes #108's one remaining
+// gap in this file: every test above resolves a single-key batch, which can
+// confirm this provider's bulk parsing against the fake's own encoding of
+// "an absent key is omitted from result.values", but never against what
+// Cloudflare's real API actually returns for a batch that mixes a present
+// key with an absent one. Cloudflare's published SDK types make values
+// non-nullable, so this was not expected to be a defect, but a two-key live
+// batch closes the gap for good at no added setup cost: it reuses
+// CLOUDFLARE_KV_TEST_KEY (no new required environment variable) alongside a
+// second key deterministically derived from it that is overwhelmingly
+// unlikely to exist in any real namespace.
+func TestIntegrationResolveBatchTwoKeysOmitsAbsent(t *testing.T) {
+	token, account, namespace, key := liveCreds(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	p := New(WithAPIToken(token), WithAccountID(account), WithNamespaceID(namespace))
+
+	presentRef := liveRef(t, key)
+	absentKey := key + "-mamori-integration-test-absent-key-should-not-exist"
+	absentRef := liveRef(t, absentKey)
+
+	batch, err := p.ResolveBatch(ctx, []mamori.Ref{presentRef, absentRef})
+	if err != nil {
+		t.Fatalf("ResolveBatch(%q, %q): %v", key, absentKey, err)
+	}
+
+	present, ok := batch[presentRef.Raw]
+	if !ok {
+		t.Fatalf("ResolveBatch(%q, %q) omitted %q, but it must exist per CLOUDFLARE_KV_TEST_KEY's contract", key, absentKey, key)
+	}
+	if len(present.Bytes) == 0 {
+		t.Fatalf("ResolveBatch(%q) returned an empty value for the present key", key)
+	}
+
+	if _, ok := batch[absentRef.Raw]; ok {
+		t.Fatalf("ResolveBatch included %q, which is expected to be absent; if this environment genuinely has a "+
+			"key of this derived name, pick a CLOUDFLARE_KV_TEST_KEY whose derived sibling does not collide", absentKey)
+	}
+
+	t.Logf("present key %q: %d byte(s); absent key %q correctly omitted from result.values", key, len(present.Bytes), absentKey)
+}

--- a/providers/cloudflare-kv/resolve.go
+++ b/providers/cloudflare-kv/resolve.go
@@ -21,6 +21,17 @@ import (
 // error at all.
 const bulkMaxKeys = 100
 
+// errBodyLimit bounds how much of a non-200 response body get and bulkGet
+// read, so a hostile or broken upstream cannot put an unbounded response
+// into an error string. Both functions' 404 branches drain within this same
+// bound (see get's doc comment on why an absent key needs that drain), and
+// both 200 paths now drain within it too - get already does by reading the
+// whole body via io.ReadAll, and bulkGet's Decode-based path drains
+// explicitly right after decoding - so every branch that can be entered
+// shares one connection-reuse discipline rather than the 200 and 404 paths
+// silently differing.
+const errBodyLimit = 4096
+
 // Resolve fetches the value for ref from Workers KV.
 //
 // There is deliberately no cache and no TTL: mamori.Refresh and mamori.Doctor
@@ -211,12 +222,12 @@ func (p *Provider) bulkGet(ctx context.Context, s settings, keys []string) (map[
 		// treats an absent key: this chunk's keys are skipped so their refs
 		// fall back to their defaults, rather than one bad namespace failing
 		// every sibling ref in the batch.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 		return nil, fmt.Errorf("mamori/cloudflare-kv: namespace not found for bulk get of %d key(s): %w", len(keys), mamori.ErrNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
 		statusErr := fmt.Errorf("mamori/cloudflare-kv: unexpected status %d from bulk get of %d key(s): %s",
 			resp.StatusCode, len(keys), strings.TrimSpace(string(msg)))
 		return nil, classifyStatus(resp.StatusCode, statusErr)
@@ -226,6 +237,12 @@ func (p *Provider) bulkGet(ctx context.Context, s settings, keys []string) (map[
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return nil, fmt.Errorf("mamori/cloudflare-kv: decoding bulk response: %w: %w", mamori.ErrInvalid, err)
 	}
+	// Decode consumes a well-formed single JSON value, so this is normally a
+	// no-op; draining explicitly, rather than relying on that, is what makes
+	// this path's connection-reuse behavior a decision instead of an
+	// accident of Decode's internals, matching the 404 branch above and
+	// get's own 200 path (see errBodyLimit's doc comment).
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 	if !body.Success {
 		// A 200 status carrying "success":false is Cloudflare's own reported
 		// failure, distinct from an HTTP-level status code, and is a malformed
@@ -283,16 +300,19 @@ func (p *Provider) get(ctx context.Context, s settings, key string) ([]byte, err
 		// every poll tick, and leaving the body unread here would prevent
 		// the connection being reused, paying a fresh TCP and TLS handshake
 		// on every one of those ticks.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 		return nil, fmt.Errorf("mamori/cloudflare-kv: key %q not found: %w", key, mamori.ErrNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
 		statusErr := fmt.Errorf("mamori/cloudflare-kv: unexpected status %d reading key %q: %s",
 			resp.StatusCode, key, strings.TrimSpace(string(msg)))
 		return nil, classifyStatus(resp.StatusCode, statusErr)
 	}
+	// The 200 path needs no matching drain step: it already reads the whole
+	// body via io.ReadAll below, so the connection is already fully consumed
+	// by the time this function returns (see errBodyLimit's doc comment).
 	return io.ReadAll(resp.Body)
 }
 

--- a/providers/cloudflare-kv/resolve_test.go
+++ b/providers/cloudflare-kv/resolve_test.go
@@ -3,7 +3,9 @@ package cloudflarekv
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -461,4 +463,65 @@ func TestResolveBatchMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
 		t.Fatal("want an error from a malformed base URL")
 	}
 	assertNoCredentialLeak(t, err)
+}
+
+// TestGetErrorBodyIsBounded pins errBodyLimit on get's single-key path: the
+// diagnostic read in its non-200, non-404 branch must never let a hostile or
+// broken upstream put an unbounded response into an error string. Every
+// other test in this file serves bodies far smaller than the bound, so none
+// of them would notice if io.LimitReader(resp.Body, errBodyLimit) were
+// replaced with resp.Body directly; this one sends a body far larger than
+// the bound with a distinctive trailing marker, so an unbounded read would
+// carry the marker straight into the returned error.
+func TestGetErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	oversized := strings.Repeat("A", 20000) + marker
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIToken(testToken), WithAccountID(testAccount), WithNamespaceID(testNamespace), WithBaseURL(srv.URL))
+
+	_, err := p.Resolve(context.Background(), ref(t, "cloudflare-kv://k"))
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 10000 {
+		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
+	}
+}
+
+// TestBulkGetErrorBodyIsBounded is TestGetErrorBodyIsBounded's counterpart
+// for bulkGet's own, separate errBodyLimit read: get and bulkGet each build
+// their own statusErr from their own LimitReader call, so a mutation
+// dropping the bound from one would not be caught by a test that only
+// exercises the other.
+func TestBulkGetErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	oversized := strings.Repeat("A", 20000) + marker
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIToken(testToken), WithAccountID(testAccount), WithNamespaceID(testNamespace), WithBaseURL(srv.URL))
+
+	_, err := p.ResolveBatch(context.Background(), []mamori.Ref{ref(t, "cloudflare-kv://k")})
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 10000 {
+		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
+	}
 }

--- a/providers/doppler/doppler.go
+++ b/providers/doppler/doppler.go
@@ -50,6 +50,18 @@ const defaultBaseURL = "https://api.doppler.com"
 // scheme is the URL scheme this provider handles.
 const scheme = "doppler"
 
+// errBodyLimit bounds how much of a non-200 response body Resolve reads for
+// diagnostics, so a hostile or broken upstream cannot put an unbounded
+// response into an error string. The 404 branch below reads nothing at all
+// rather than reading up to this bound and discarding it: the not-found
+// message is already the whole story, so there is no diagnostic worth
+// paying a read for. The 200 path explicitly drains any bytes its own
+// decode did not consume, within this same bound, so that path and the
+// error path share one connection-reuse discipline instead of two silently
+// different ones; see the decode call below for why that drain is
+// deliberate rather than a hedge against Decode misbehaving.
+const errBodyLimit = 4096
+
 // Provider resolves doppler:// refs against the Doppler REST API. It is safe for
 // concurrent use.
 type Provider struct {
@@ -162,7 +174,7 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 		return mamori.Value{}, fmt.Errorf("mamori/doppler: secret %q not found in %s/%s: %w", name, project, config, mamori.ErrNotFound)
 	default:
 		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
 		statusErr := fmt.Errorf("mamori/doppler: unexpected status %d fetching secret %q: %s", resp.StatusCode, name, strings.TrimSpace(string(msg)))
 		return mamori.Value{}, classifyDopplerStatus(resp.StatusCode, statusErr)
 	}
@@ -171,6 +183,12 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
 		return mamori.Value{}, fmt.Errorf("mamori/doppler: decoding secret %q: %w", name, err)
 	}
+	// Decode consumes a well-formed single JSON value, so this is normally a
+	// no-op; draining explicitly, rather than relying on that, is what makes
+	// the 200 path's connection-reuse behavior a decision instead of an
+	// accident of Decode's internals, matching the bound this provider's
+	// error path already applies (see errBodyLimit).
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 
 	// Prefer the computed value (references resolved); fall back to raw.
 	val := sr.Value.Computed

--- a/providers/doppler/doppler_test.go
+++ b/providers/doppler/doppler_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -416,6 +418,37 @@ func TestResolveClassifiesRealStatus(t *testing.T) {
 	}
 	if got := mamori.ErrorKind(err); got != mamori.KindPermissionDenied {
 		t.Fatalf("ErrorKind(err) = %q, want %q; classifyDopplerStatus may not be wired into Resolve", got, mamori.KindPermissionDenied)
+	}
+}
+
+// TestResolveErrorBodyIsBounded pins errBodyLimit: the diagnostic read in
+// Resolve's default status branch must never let a hostile or broken
+// upstream put an unbounded response into an error string. Every other test
+// in this file uses response bodies far smaller than the bound, so none of
+// them would notice if io.LimitReader(resp.Body, errBodyLimit) were replaced
+// with resp.Body directly; this one sends a body far larger than the bound
+// with a distinctive trailing marker, so an unbounded read would carry the
+// marker straight into the returned error.
+func TestResolveErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	oversized := strings.Repeat("A", 20000) + marker
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	p := New(WithBaseURL(srv.URL), WithToken(testToken), WithHTTPClient(srv.Client()))
+	_, err := p.Resolve(context.Background(), mustRef(t, "doppler://"+testProject+"/"+testConfig+"#K"))
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 10000 {
+		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
 	}
 }
 

--- a/providers/scaleway-sm/resolve.go
+++ b/providers/scaleway-sm/resolve.go
@@ -15,6 +15,15 @@ import (
 	"github.com/xavidop/mamori"
 )
 
+// errBodyLimit bounds how much of a non-200 response body access reads, so
+// a hostile or broken upstream cannot put an unbounded response into an
+// error string. The 404 branch drains within this same bound (see access's
+// doc comment on why an absent secret needs that drain), and the 200 path
+// now drains within it too, right after its own Decode call, so every
+// branch that can be entered shares one connection-reuse discipline rather
+// than the 200 and 404 paths silently differing.
+const errBodyLimit = 4096
+
 // Resolve fetches ref's secret from Secret Manager.
 //
 // There is deliberately no cache and no TTL: mamori.Refresh and mamori.Doctor
@@ -107,12 +116,12 @@ func (p *Provider) access(ctx context.Context, s settings, path, name, revision 
 		// absent secret is read again on every poll tick, and leaving the
 		// body unread here would prevent the connection being reused, paying
 		// a fresh TCP and TLS handshake on every one of those ticks.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 		return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: secret %q not found: %w", name, mamori.ErrNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
 		statusErr := fmt.Errorf("mamori/scaleway-sm: unexpected status %d accessing secret %q: %s",
 			resp.StatusCode, name, strings.TrimSpace(string(msg)))
 		return accessResponse{}, classifyStatus(resp.StatusCode, statusErr)
@@ -122,6 +131,12 @@ func (p *Provider) access(ctx context.Context, s settings, path, name, revision 
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: decoding access response for secret %q: %w: %w", name, mamori.ErrInvalid, err)
 	}
+	// Decode consumes a well-formed single JSON value, so this is normally a
+	// no-op; draining explicitly, rather than relying on that, is what makes
+	// this path's connection-reuse behavior a decision instead of an
+	// accident of Decode's internals, matching the 404 branch above (see
+	// errBodyLimit's doc comment).
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 	return body, nil
 }
 

--- a/providers/scaleway-sm/resolve_test.go
+++ b/providers/scaleway-sm/resolve_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -625,5 +626,75 @@ func TestResolveErrorBodyIsBounded(t *testing.T) {
 	}
 	if len(err.Error()) > 10000 {
 		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
+	}
+}
+
+// TestResolveRegionIsPathEscaped pins #108's scaleway-sm region-escape gap:
+// access builds the request URL as ".../regions/" + url.PathEscape(s.region)
+// + "/...", but every other test in this package uses testRegion
+// ("test-region"), which needs no escaping at all, so dropping
+// url.PathEscape(s.region) in favor of the bare region would leave every
+// other test green.
+//
+// This uses a region containing a literal slash rather than a space:
+// net/http's own request-line writer normalizes an unescaped space back to
+// "%20" regardless of whether application code called url.PathEscape, which
+// would make a space a false discriminator here. A raw slash is not
+// "unsafe" the same way - url.Parse treats it as a genuine path-segment
+// boundary and leaves it alone - so without url.PathEscape(s.region) it
+// splits the region across two path segments instead of one, which the
+// exact-segment comparison below catches.
+func TestResolveRegionIsPathEscaped(t *testing.T) {
+	const region = "region/with-slash"
+	var gotEscapedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"not found"}`)
+	}))
+	defer srv.Close()
+
+	p := New(WithSecretKey(testSecretKey), WithProjectID(testProjectID), WithRegion(region), WithBaseURL(srv.URL))
+
+	_, _ = p.Resolve(context.Background(), ref(t, "scaleway-sm://k"))
+
+	_, rest, ok := strings.Cut(gotEscapedPath, "/regions/")
+	if !ok {
+		t.Fatalf("request path %q has no /regions/ segment", gotEscapedPath)
+	}
+	gotRegionSegment, _, ok := strings.Cut(rest, "/secrets-by-path/versions/")
+	if !ok {
+		t.Fatalf("request path %q has no /secrets-by-path/versions/ marker after /regions/", gotEscapedPath)
+	}
+	want := url.PathEscape(region)
+	if gotRegionSegment != want {
+		t.Fatalf("region segment in request path = %q, want %q (url.PathEscape(region), one path segment); full path was %q", gotRegionSegment, want, gotEscapedPath)
+	}
+}
+
+// TestDefaultBaseURLIsV1Beta1 pins #108's scaleway-sm defaultBaseURL gap:
+// TestWithBaseURLEmptyIsNoOp only compares p.baseURL against the
+// defaultBaseURL constant itself, so mutating the constant's value (for
+// example "v1beta1" to "v1") survives that test tautologically - it changes
+// what the constant IS, and the test just checks the field still holds
+// whatever the constant currently says. This test instead asserts the
+// literal API version segment that reaches the wire, hardcoded here rather
+// than read from the constant under test.
+func TestDefaultBaseURLIsV1Beta1(t *testing.T) {
+	f := newFakeSM()
+	f.set("/", "k", []byte("v"))
+	p := f.provider(WithBaseURL("")) // "" is a no-op; New's default must still be v1beta1
+
+	if _, err := p.Resolve(context.Background(), ref(t, "scaleway-sm://k")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	f.mu.Lock()
+	path := f.lastPath
+	f.mu.Unlock()
+	const wantSegment = "/secret-manager/v1beta1/regions/"
+	if !strings.Contains(path, wantSegment) {
+		t.Fatalf("request path %q does not contain %q; defaultBaseURL must still name the v1beta1 API version", path, wantSegment)
 	}
 }

--- a/providers/scaleway-sm/resolve_test.go
+++ b/providers/scaleway-sm/resolve_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -592,4 +594,36 @@ func TestResolveMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
 		t.Fatal("want an error from a malformed base URL")
 	}
 	assertNoCredentialLeak(t, err)
+}
+
+// TestResolveErrorBodyIsBounded pins errBodyLimit: the diagnostic read in
+// access's non-200, non-404 branch must never let a hostile or broken
+// upstream put an unbounded response into an error string. Every other test
+// in this file serves bodies far smaller than the bound, so none of them
+// would notice if io.LimitReader(resp.Body, errBodyLimit) were replaced with
+// resp.Body directly; this one sends a body far larger than the bound with a
+// distinctive trailing marker, so an unbounded read would carry the marker
+// straight into the returned error.
+func TestResolveErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	oversized := strings.Repeat("A", 20000) + marker
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	p := New(WithSecretKey(testSecretKey), WithProjectID(testProjectID), WithRegion(testRegion), WithBaseURL(srv.URL))
+
+	_, err := p.Resolve(context.Background(), ref(t, "scaleway-sm://k"))
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 10000 {
+		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
+	}
 }

--- a/providers/vercel-gc/batch_test.go
+++ b/providers/vercel-gc/batch_test.go
@@ -173,3 +173,39 @@ func TestProviderIsNotWatchable(t *testing.T) {
 		t.Fatal("vercel-gc must not implement WatchableProvider: Vercel has no native change notification")
 	}
 }
+
+// TestResolveBatchSharedKeyNameAcrossStores pins that two stores in one
+// batch, each holding a key of the SAME name, resolve their own store's
+// value independently. TestResolveBatchIsOneRequestPerStore already covers
+// grouping-by-store, but its two stores use disjoint key names ("a","b","c"
+// vs "d"), so a bug merging the two stores' snapshot item maps together
+// would not be caught there: a wrong/merged map would simply be missing "d"
+// (or "a"/"b"/"c"), which already fails that test's key-count assertion for
+// an unrelated reason. Using the same key name in both stores here means a
+// merge bug instead returns the WRONG STORE'S VALUE for one of the two refs,
+// with the right number of keys - the specific failure mode a disjoint-key
+// test cannot distinguish from correct behavior.
+func TestResolveBatchSharedKeyNameAcrossStores(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "shared", `"default-value"`)
+	f.set("ecfg_other", "shared", `"other-value"`)
+	p := f.provider()
+
+	refs := []mamori.Ref{
+		ref(t, "vercel-gc://shared"),
+		ref(t, "vercel-gc://ecfg_other/shared"),
+	}
+	got, err := p.ResolveBatch(context.Background(), refs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d values, want 2", len(got))
+	}
+	if s := string(got["vercel-gc://shared"].Bytes); s != "default-value" {
+		t.Errorf("default store's shared key: got %q, want %q", s, "default-value")
+	}
+	if s := string(got["vercel-gc://ecfg_other/shared"].Bytes); s != "other-value" {
+		t.Errorf("ecfg_other's shared key: got %q, want %q", s, "other-value")
+	}
+}

--- a/providers/vercel-gc/errors_test.go
+++ b/providers/vercel-gc/errors_test.go
@@ -46,3 +46,23 @@ func TestClassifyStatusPreservesChain(t *testing.T) {
 		t.Fatalf("underlying status error no longer reachable: %v", wrapped)
 	}
 }
+
+// TestClassifyStatusUnauthorizedIsNotPermissionDenied is the negative half of
+// TestClassifyStatusPreservesChain's 403 case: 401 and 403 sit next to each
+// other in classifyStatus's switch, and every existing test only asserts what
+// each code DOES satisfy, never what it must NOT. A copy-paste swap of the
+// two cases (401 mapped to ErrPermissionDenied, 403 to ErrUnauthenticated)
+// would still pass every positive assertion elsewhere in this package - each
+// status would just be asserted against the wrong sentinel by a test that
+// only checks its own code - so this pins the negative directly.
+func TestClassifyStatusUnauthorizedIsNotPermissionDenied(t *testing.T) {
+	base := errors.New(`mamori/vercel-gc: unexpected status 401 from items of store ecfg_test: unauthorized`)
+	got := classifyStatus(http.StatusUnauthorized, base)
+
+	if !errors.Is(got, mamori.ErrUnauthenticated) {
+		t.Fatalf("classifyStatus(401, base) = %v, want an error satisfying mamori.ErrUnauthenticated", got)
+	}
+	if errors.Is(got, mamori.ErrPermissionDenied) {
+		t.Fatalf("classifyStatus(401, base) = %v, must not satisfy mamori.ErrPermissionDenied", got)
+	}
+}

--- a/providers/vercel-gc/fake_test.go
+++ b/providers/vercel-gc/fake_test.go
@@ -31,14 +31,41 @@ type fakeGC struct {
 	digestReq int
 	itemsReq  int
 	lastAuth  string
+
+	// malformedItems is store id -> whether its /items endpoint should serve
+	// a body that fails to json.Unmarshal into map[string]jsonRaw, until the
+	// test replaces the fake. It powers TestResolveItemsDecodeFailureIsInvalid.
+	malformedItems map[string]bool
+
+	// callOrder records every request's endpoint ("digest" or "items"), in
+	// the order the fake's handler observed them, regardless of outcome
+	// (success, injected failure, or unknown store). It powers
+	// TestResolveFetchesDigestBeforeItems.
+	callOrder []string
 }
 
 func newFake() *fakeGC {
 	return &fakeGC{
-		stores:   map[string]map[string]jsonRaw{},
-		rev:      map[string]int{},
-		failCode: map[string]map[string]int{},
+		stores:         map[string]map[string]jsonRaw{},
+		rev:            map[string]int{},
+		failCode:       map[string]map[string]int{},
+		malformedItems: map[string]bool{},
 	}
+}
+
+// setMalformedItems makes store's /items endpoint serve a body that fails to
+// json.Unmarshal into map[string]jsonRaw, until the test replaces the fake.
+func (f *fakeGC) setMalformedItems(store string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.malformedItems[store] = true
+}
+
+// order returns every request's endpoint observed so far, in arrival order.
+func (f *fakeGC) order() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.callOrder...)
 }
 
 // set writes a raw JSON value and bumps the store digest, exactly as a real
@@ -123,6 +150,7 @@ func (f *fakeGC) handle(w http.ResponseWriter, r *http.Request) {
 
 	f.mu.Lock()
 	f.lastAuth = r.Header.Get("Authorization")
+	f.callOrder = append(f.callOrder, endpoint)
 	if code, ok := f.failCodeFor(store, endpoint); ok {
 		f.mu.Unlock()
 		w.WriteHeader(code)
@@ -153,6 +181,16 @@ func (f *fakeGC) handle(w http.ResponseWriter, r *http.Request) {
 		// TestDigestShapes covers the object form as well.
 		_, _ = io.WriteString(w, strconv.Quote("rev"+strconv.Itoa(rev)))
 	case "items":
+		f.mu.Lock()
+		malformed := f.malformedItems[store]
+		f.mu.Unlock()
+		if malformed {
+			// Deliberately invalid JSON: fetchItems's json.Unmarshal into
+			// map[string]jsonRaw must fail on this, exercising the decode
+			// failure branch TestResolveItemsDecodeFailureIsInvalid pins.
+			_, _ = io.WriteString(w, `{not valid json`)
+			return
+		}
 		out := map[string]json.RawMessage{}
 		f.mu.Lock()
 		for k, v := range items {

--- a/providers/vercel-gc/resolve.go
+++ b/providers/vercel-gc/resolve.go
@@ -12,6 +12,18 @@ import (
 	"github.com/xavidop/mamori"
 )
 
+// errBodyLimit bounds how much of a non-200 response body get reads, so a
+// hostile or broken upstream cannot put an unbounded response into an error
+// string. The 404 branch reads within this same bound and folds the result
+// into the returned not-found error (rather than building it and discarding
+// it, which is what this provider used to do), which doubles as the drain
+// that lets net/http reuse the connection - the same reason the other
+// branch below reads a bounded amount rather than none at all. The 200 path
+// needs no matching drain step: it already reads the whole body via
+// io.ReadAll, so the connection is already fully consumed by the time this
+// function returns.
+const errBodyLimit = 4096
+
 // Resolve fetches the value for ref.
 //
 // Every call requests the store digest, which Vercel replaces on any edit, and
@@ -167,13 +179,21 @@ func (p *Provider) get(ctx context.Context, c connection, store, endpoint string
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		statusErr := fmt.Errorf("mamori/vercel-gc: unexpected status %d from %s of store %s: %s",
-			resp.StatusCode, endpoint, store, strings.TrimSpace(string(msg)))
+		// Read a bounded amount of the error body for diagnostics (and, on the
+		// 404 branch below, fold it into the returned error instead of
+		// discarding it: this is the one place a store-not-found body such as
+		// "edge_config_not_found" would tell a caller what actually went
+		// wrong). Never log it.
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
+		trimmed := strings.TrimSpace(string(msg))
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w", store, mamori.ErrNotFound)
+			if trimmed == "" {
+				return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w", store, mamori.ErrNotFound)
+			}
+			return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w: %s", store, mamori.ErrNotFound, trimmed)
 		}
+		statusErr := fmt.Errorf("mamori/vercel-gc: unexpected status %d from %s of store %s: %s",
+			resp.StatusCode, endpoint, store, trimmed)
 		return nil, classifyStatus(resp.StatusCode, statusErr)
 	}
 	return io.ReadAll(resp.Body)

--- a/providers/vercel-gc/resolve_test.go
+++ b/providers/vercel-gc/resolve_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -386,5 +389,63 @@ func TestResolveHonorsContextCancellation(t *testing.T) {
 
 	if _, err := p.Resolve(ctx, ref(t, "vercel-gc://k")); !errors.Is(err, context.Canceled) {
 		t.Fatalf("got %v, want context.Canceled", err)
+	}
+}
+
+// TestGetErrorBodyIsBounded pins errBodyLimit: the diagnostic read in get's
+// non-200 branch must never let a hostile or broken upstream put an
+// unbounded response into an error string. Every other test in this file
+// serves bodies far smaller than the bound, so none of them would notice if
+// io.LimitReader(resp.Body, errBodyLimit) were replaced with resp.Body
+// directly; this one sends a body far larger than the bound with a
+// distinctive trailing marker, so an unbounded read would carry the marker
+// straight into the returned error.
+func TestGetErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	oversized := strings.Repeat("A", 20000) + marker
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	p := New(WithConnectionString(fmt.Sprintf("https://global-config.vercel.com/%s?token=%s", testStore, testToken)), WithBaseURL(srv.URL))
+
+	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 10000 {
+		t.Fatalf("error message is %d bytes long; the diagnostic read must be bounded well below the %d-byte oversized body", len(err.Error()), len(oversized))
+	}
+}
+
+// TestGetNotFoundIncludesBodyDiagnostic pins the fix for #107 item 3: get's
+// 404 branch used to read the error body into a diagnostic, then discard it
+// in favor of a bare "store not found" error with no body content at all.
+// The body is the one place a real Global Config 404 - which carries a
+// "code" such as "edge_config_not_found" - would tell a caller what
+// actually went wrong, so it must survive into the returned error.
+func TestGetNotFoundIncludesBodyDiagnostic(t *testing.T) {
+	const diagnostic = "edge_config_not_found"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":"`+diagnostic+`"}}`)
+	}))
+	defer srv.Close()
+
+	p := New(WithConnectionString(fmt.Sprintf("https://global-config.vercel.com/%s?token=%s", testStore, testToken)), WithBaseURL(srv.URL))
+
+	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+	if !errors.Is(err, mamori.ErrNotFound) {
+		t.Fatalf("got %v, want an error satisfying mamori.ErrNotFound", err)
+	}
+	if !strings.Contains(err.Error(), diagnostic) {
+		t.Fatalf("got %v, want the 404 body's diagnostic (%q) to survive into the error instead of being discarded", err, diagnostic)
 	}
 }

--- a/providers/vercel-gc/resolve_test.go
+++ b/providers/vercel-gc/resolve_test.go
@@ -175,8 +175,16 @@ func TestResolveTwoStoresAreIndependent(t *testing.T) {
 	if _, err := p.Resolve(ctx, ref(t, "vercel-gc://k")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := p.Resolve(ctx, ref(t, "vercel-gc://ecfg_other/k")); err != nil {
+	// Asserting this first resolved value, not just its error, is what makes
+	// an incorrectly-keyed snapshot cache (for example one that mixed up two
+	// stores' maps) fail deterministically right here, rather than depending
+	// on TestResolveConcurrentAcrossStores to carry that load by accident.
+	first, err := p.Resolve(ctx, ref(t, "vercel-gc://ecfg_other/k"))
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(first.Bytes) != "b1" {
+		t.Fatalf("got %q, want %q: the second store's own value must come back, not the default store's", first.Bytes, "b1")
 	}
 	_, itemsBefore := f.counts()
 
@@ -376,6 +384,89 @@ func TestResolveUnknownStoreIsNotFound(t *testing.T) {
 	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://ecfg_missing/k"))
 	if !errors.Is(err, mamori.ErrNotFound) {
 		t.Fatalf("got %v, want an error satisfying mamori.ErrNotFound", err)
+	}
+}
+
+// TestResolveTwoFragmentsOfSameKeyAreIndependent pins that two refs
+// differing only by fragment - vercel-gc://cfg#a and vercel-gc://cfg#b -
+// each resolve their own selected field of the SAME underlying item,
+// verified correct by inspection during review (Resolve looks up snap.items
+// once per call and valueFor's selection is stateless per call, so nothing
+// caches a selected result keyed only by store+path while ignoring the
+// fragment), but nothing in this package exercised two such refs side by
+// side before this test.
+func TestResolveTwoFragmentsOfSameKeyAreIndependent(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "cfg", `{"a":"1","b":"2"}`)
+	p := f.provider()
+	ctx := context.Background()
+
+	va, err := p.Resolve(ctx, ref(t, "vercel-gc://cfg#a"))
+	if err != nil {
+		t.Fatalf("resolving #a: unexpected error: %v", err)
+	}
+	if string(va.Bytes) != "1" {
+		t.Fatalf("vercel-gc://cfg#a: got %q, want %q", va.Bytes, "1")
+	}
+
+	vb, err := p.Resolve(ctx, ref(t, "vercel-gc://cfg#b"))
+	if err != nil {
+		t.Fatalf("resolving #b: unexpected error: %v", err)
+	}
+	if string(vb.Bytes) != "2" {
+		t.Fatalf("vercel-gc://cfg#b: got %q, want %q", vb.Bytes, "2")
+	}
+
+	// Re-resolving #a after #b must still return #a's own field, not #b's
+	// (or the whole object), which is what would happen if selection were
+	// somehow cached keyed only on store+path.
+	va2, err := p.Resolve(ctx, ref(t, "vercel-gc://cfg#a"))
+	if err != nil {
+		t.Fatalf("re-resolving #a: unexpected error: %v", err)
+	}
+	if string(va2.Bytes) != "1" {
+		t.Fatalf("re-resolving vercel-gc://cfg#a: got %q, want %q", va2.Bytes, "1")
+	}
+}
+
+// TestResolveItemsDecodeFailureIsInvalid pins fetchItems's decode-failure
+// branch: an /items response that is not valid JSON must surface as
+// mamori.ErrInvalid, not some other error class. Nothing in this package
+// exercised a malformed /items body before this test; TestDigestShapesRejected
+// covers parseDigest's own failure shapes, but fetchItems has an entirely
+// separate json.Unmarshal call with its own error-wrapping line.
+func TestResolveItemsDecodeFailureIsInvalid(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "k", `"v"`)
+	f.setMalformedItems(testStore)
+	p := f.provider()
+
+	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+	if !errors.Is(err, mamori.ErrInvalid) {
+		t.Fatalf("got %v, want an error satisfying mamori.ErrInvalid", err)
+	}
+}
+
+// TestResolveFetchesDigestBeforeItems pins the invariant the package doc
+// comment on snapshotFor relies on: an /items response fetched after
+// observing digest D must reflect content at least as new as D, which only
+// holds if the digest request actually happens first. Nothing asserted the
+// order before this test; TestResolveDigestGatesItemFetches and its siblings
+// only assert request COUNTS, which stay identical whichever order the two
+// requests happen in.
+func TestResolveFetchesDigestBeforeItems(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "k", `"v"`)
+	p := f.provider()
+
+	if _, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := f.order()
+	want := []string{"digest", "items"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("got request order %v, want %v", got, want)
 	}
 }
 

--- a/providers/vercel-gc/value_test.go
+++ b/providers/vercel-gc/value_test.go
@@ -36,6 +36,35 @@ func TestRawToBytes(t *testing.T) {
 	}
 }
 
+// TestRawToBytesErrorBranches pins rawToBytes's two error branches, neither
+// of which was tested before this: the empty-after-trim case (only a key
+// stored as the JSON literal null hits the "value exists" path; an actually
+// empty or whitespace-only raw value is rejected instead) and the malformed-
+// JSON-string case (a value starting with '"' whose content does not decode
+// as a valid JSON string). Both are unreachable from Resolve today, because
+// fetchItems's json.Unmarshal into map[string]jsonRaw already validates every
+// stored value before rawToBytes ever sees it - confirmed by inspection, not
+// asserted here - so this is defense in depth for any future or direct
+// caller of rawToBytes, not a path Resolve exercises.
+func TestRawToBytesErrorBranches(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "whitespace only", raw: "   "},
+		{name: "malformed string literal", raw: `"unterminated`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rawToBytes(jsonRaw(tc.raw))
+			if !errors.Is(err, mamori.ErrInvalid) {
+				t.Fatalf("got %v, want an error satisfying mamori.ErrInvalid", err)
+			}
+		})
+	}
+}
+
 func TestValueForSelectsKey(t *testing.T) {
 	ref := mamori.Ref{Scheme: scheme, Path: "api-config", Key: "timeout", Raw: "vercel-gc://api-config#timeout"}
 
@@ -66,6 +95,32 @@ func TestValueForSelectingFieldOfStringIsInvalid(t *testing.T) {
 	_, err := valueFor(jsonRaw(`"info"`), ref, "ecfg_abc", "dig1")
 	if !errors.Is(err, mamori.ErrInvalid) {
 		t.Fatalf("got %v, want an error satisfying mamori.ErrInvalid", err)
+	}
+}
+
+// TestValueForSelectingFieldOfStringDiscriminatesUnwrapOrder is
+// TestValueForSelectingFieldOfStringIsInvalid's sharper sibling. That test's
+// raw value is the JSON string "info", which fails selection whichever order
+// unwrap-then-select happens in: selecting a field of the STRING "info"
+// fails, and so does selecting a field of the raw JSON text `"info"` (quotes
+// included), so the test proves only that selecting into a string fails, not
+// that unwrapping happens first. Here the raw value is a JSON string whose
+// DECODED content is itself a JSON object: selecting after unwrapping reaches
+// that object and finds "timeout" inside it; selecting before unwrapping
+// would instead try to select a field of the raw quoted text and fail. Only
+// the unwrap-first order can produce "5s" here.
+func TestValueForSelectingFieldOfStringDiscriminatesUnwrapOrder(t *testing.T) {
+	ref := mamori.Ref{Scheme: scheme, Path: "api-config", Key: "timeout", Raw: "vercel-gc://api-config#timeout"}
+
+	// The stored value is a JSON string whose own text is a JSON object.
+	raw := jsonRaw(`"{\"timeout\":\"5s\"}"`)
+
+	v, err := valueFor(raw, ref, "ecfg_abc", "dig1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v (selection must unwrap the string first, then select #timeout from its decoded object content)", err)
+	}
+	if string(v.Bytes) != "5s" {
+		t.Fatalf("got %q, want %q", v.Bytes, "5s")
 	}
 }
 

--- a/providers/vercel-gc/vercelgc_test.go
+++ b/providers/vercel-gc/vercelgc_test.go
@@ -82,6 +82,12 @@ func TestParsePath(t *testing.T) {
 		{name: "leading slash tolerated", path: "/log-level", defaultStore: "ecfg_def", wantStore: "ecfg_def", wantKey: "log-level"},
 		{name: "one segment with no default store", path: "log-level", defaultStore: "", wantErr: "no store"},
 		{name: "empty path", path: "", defaultStore: "ecfg_def", wantErr: "requires a key"},
+		// Both the key and the store are missing here, which is the only case
+		// that actually pins parsePath's check ORDER (key before store): the
+		// two cases above each leave one of the two non-empty, so neither can
+		// tell which check runs first. If store were checked first, this case
+		// would report "no store" instead.
+		{name: "empty path and no default store: key is checked before store", path: "", defaultStore: "", wantErr: "requires a key"},
 		{name: "three segments", path: "a/b/c", defaultStore: "ecfg_def", wantErr: "at most"},
 		{name: "empty key in two-segment form", path: "ecfg_abc/", defaultStore: "", wantErr: "requires a key"},
 	}


### PR DESCRIPTION
Fixes #107. Fixes #108.

## Why these two together

They are coupled. #107's central complaint is that the 4096-byte error-body bound is unpinned across four providers, and #108 is the catalogue of guards whose removal leaves the suite green. The bound is one of them. Fixing the hygiene without pinning it would just reset the clock.

## What "fixed" means here

Every #108 item is of the form "this guard exists, and removing it leaves the entire suite green". So a passing test does not close one. **A test that fails when its guard is removed does.**

**10 of 11 filed items were verified by actually removing the guard, watching the test fail, and restoring it.** The eleventh, the digest-before-items request ordering, has no single-line mutation against the current code, so it was verified with a simulated reordering instead; the report explains why.

## #107: the two decisions

**The 200 path now drains, consistently across the providers that already drained on 404.** Both options were defensible. `json.NewDecoder(...).Decode` consumes a whole JSON value on a well-formed single-object response, so reuse largely survived already, but a reader could not tell whether the asymmetry was a decision or an oversight. Now it is uniform and the reason is in the code.

`providers/doppler`'s 404 branch stays asymmetric deliberately, and says so, rather than being swept in as drive-by scope.

**The 4096-byte bound is now pinned in all four providers.** Removing it previously left every suite green. It is what stops a hostile or broken upstream putting an unbounded response into an error string.

**`providers/vercel-gc` no longer builds a diagnostic error on the 404 path and discards it.** That body was the one place `edge_config_not_found` versus something else would tell a user what actually went wrong.

## Two items were already fixed before the issue was filed

The `/items` error-path coverage and the unclassified-418 coverage in `providers/vercel-gc` were closed by a pre-merge fix wave. Confirmed with `git log -p` rather than assumed, and left alone.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Tests

## Checklist

- [x] `go test ./...` passes for every affected module (`make test`)
- [x] `go vet ./...` and `golangci-lint run` are clean (`make lint`)
- [x] New/changed behavior is covered by tests
- [x] Secret values are never logged or rendered unredacted

`make all` green across every module. Each provider was also built, vetted, raced, and linted individually from inside its own module directory.

## One caveat

The new two-key live integration test for `providers/cloudflare-kv`, which confirms absent keys are omitted from `result.values`, could not be run against a real Cloudflare account. It is verified to build and to skip cleanly without credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)