### PR TITLE
docs(site): write provider pages for users, and derive the landing counts

### DIFF
--- a/site/src/pages/docs/providers/https.md
+++ b/site/src/pages/docs/providers/https.md
@@ -5,7 +5,7 @@ title: Generic HTTPS
 
 # Generic HTTPS
 
-Load configuration and secrets from an HTTP endpoint you declare - your own REST API, not a named vendor. Built on `providers/httpcore`, it is the only provider in this repo that names no vendor at all: reach for it when your configuration or secrets live behind a REST API your own team owns, rather than one mamori already speaks to.
+Load configuration and secrets from an HTTP endpoint you declare: your own REST API, rather than a named vendor. Reach for it when your config lives behind a service your team owns.
 
 | | |
 | --- | --- |
@@ -38,13 +38,11 @@ if err != nil {
 cfg, err := mamori.Load[Config](ctx, mamori.WithProvider(p))
 ```
 
-**This is an ordinary import, never a blank one, and this provider has no `init()`.** Every other provider registers itself from `init`, so `import _` is enough, because each has a vendor default: `New()` is valid with no arguments and reads credentials from the environment at resolve time. This one has no vendor and therefore no default - `Name`, `BaseURL`, `Auth`, `Query` and `Header` are all operator-supplied, `New` requires at least one `Endpoint`, and `New` returns an error, none of which an `init` function has anything to pass or anywhere to report. Registering an endpointless provider globally would be worse than not registering one: it would advertise `https://` in `RegisteredSchemes()` and to `mamori doctor` while failing every ref.
-
-Hand the constructed provider to `mamori.WithProvider`, which takes precedence over the global registry for its scheme, or to `mamori.Register` once you have built it.
+Unlike other providers, this one takes an ordinary import rather than a blank one, and you pass the result to `mamori.WithProvider` or `mamori.Register`. There is no vendor default to fall back on, so at least one endpoint is always required.
 
 ## Using the ref
 
-An `https://` ref points at a path on one registered `Endpoint`, optionally selecting a field from a JSON value stored there.
+An `https://` ref points at a path on one registered endpoint, optionally selecting a field from a JSON value stored there.
 
 ```text
 https://<endpoint>/<path>
@@ -53,16 +51,16 @@ https://<endpoint>/<path>[#field-or-pointer]
 
 | Part | Required | What it means |
 | --- | --- | --- |
-| `<endpoint>` | yes | Not a hostname - the `Name` of an `Endpoint` registered with `New`. A ref naming an unregistered endpoint fails with `mamori.ErrInvalid`, caught by `mamori doctor` before deployment. |
-| `<path>` | yes | Everything after the endpoint name; joined onto that endpoint's `BaseURL`. |
-| `#field` / `#/json/pointer` | no | Select a field from a JSON-valued response via `mamori.SelectKey` - a literal top-level key, or an RFC 6901 JSON Pointer for a nested field. |
+| `<endpoint>` | yes | The `Name` of an endpoint you registered, **not a hostname**. An unregistered name fails with `mamori.ErrInvalid`. |
+| `<path>` | yes | Everything after the endpoint name, joined onto that endpoint's `BaseURL`. |
+| `#field` / `#/json/pointer` | no | Select a field from a JSON response: a top-level key, or an RFC 6901 JSON Pointer for a nested one. |
 
 **Examples**
 
 - `https://billing/cfg` reads path `cfg` on the endpoint named `billing`.
-- `https://billing/cfg/main` reads path `cfg/main` on `billing` - only the first ref-path segment names the endpoint.
-- `https://billing/cfg#level` reads top-level field `level` of the JSON document at `cfg`.
-- `https://billing/cfg#/db/pass` reads a nested field of `cfg`, selected by JSON Pointer.
+- `https://billing/cfg/main` reads path `cfg/main`; only the first segment names the endpoint.
+- `https://billing/cfg#level` reads top-level field `level` of the JSON at `cfg`.
+- `https://billing/cfg#/db/pass` reads a nested field, selected by JSON Pointer.
 - `https://billing/${TENANT}/cfg` interpolates `TENANT` from `WithRefVars` at load time.
 
 ```go
@@ -72,77 +70,47 @@ type Config struct {
 }
 ```
 
-## Ref paths are percent-escaped
+## Declaring endpoints
 
-A ref path is a percent-escaped path: `%2F` addresses a single path segment whose own name contains a slash, and a literal percent sign must be written `%25`, never a bare `%`, or `Resolve` rejects the ref before any request reaches the backend.
-
-```
-https://billing/discount-50%-off        # rejected: bare "%" is not a valid escape
-https://billing/discount-50%25-off      # reaches the backend as discount-50%-off
-```
-
-## Why endpoints are named, not raw URLs
-
-A ref cannot carry target query parameters: mamori's grammar puts the fragment before the query (`path#key?opts`), the reverse of a standard URL's `path?query#fragment`, so a ref written the standard way, `https://api.example.com/cfg?env=prod#/db/pass`, does not fail loudly - `ParseRef` splits off everything from the first `?` onward as `Opts` before it ever looks for a `#`, so `Key` comes out empty and `Opts` comes out as `env` = `"prod#/db/pass"`. Fixed query parameters live on the `Endpoint`'s `Query` field instead.
-
-A ref cannot carry credentials either, because a struct tag is source code; authentication lives on the `Endpoint`'s `Auth` field. And a provider that fetched an arbitrary URL named by a struct tag would make every `source` tag a potential SSRF vector. Restricting refs to declared endpoints matches the posture the rest of mamori takes: the config server serves a fixed, operator-declared binding table and never a client-supplied ref.
-
-## Ref paths cannot escape their endpoint
-
-A ref path containing a `.` or `..` segment is rejected with `mamori.ErrInvalid`, before it is joined onto the endpoint's `BaseURL` and before any request goes out. This is not theoretical: `${VAR}` interpolation from `WithRefVars` means a ref like `https://billing/${TENANT}/cfg` carries whatever the application put in `TENANT` at runtime. Without this check, a `TENANT` of `../..` would reach another tenant's configuration without ever leaving the declared host, so the endpoint restriction above would never fire.
-
-**The check lives in `httpcore`, not here**, so that every provider built on it inherits the same guarantee and none can forget it. That is a claim about where the check lives, not that `https://`'s ref behaviour is unchanged in every respect: elsewhere on this page, a percent-encoded traversal (`%2e%2e`) now fails where it used to resolve, and a literal `%` now must be written `%25`.
-
-The check splits on **both** `/` and `\`, not `/` alone: splitting only on `/` would leave `a\..\..\secrets` as one segment matching neither `.` nor `..`, and the request would go out with its backslashes percent-encoded as `%5C` - which IIS and ASP.NET decode and honor as a directory separator, the classic backslash traversal bypass. A backslash inside an ordinary key still works; only a traversal is refused. Three-dot segments are not matched: RFC 3986 defines dot-segment removal over exactly `.` and `..`, so `...` is an ordinary name.
-
-It runs on the **decoded** path, so `%2e%2e` is refused exactly like `..`. `httpcore` preserves a caller's percent escapes to the wire, because a key whose own name contains a slash cannot be addressed otherwise, and an encoded traversal would be preserved with them.
-
-It rejects rather than cleans, deliberately: cleaning a path would silently change which value a ref names, and `mamori doctor` resolving every ref before deployment means a rejected ref surfaces there, not in production.
-
-```go
-ref, _ := mamori.ParseRef("https://billing/../secrets")
-_, err := p.Resolve(context.Background(), ref)
-fmt.Println(errors.Is(err, mamori.ErrInvalid))
-// Output: true
-```
-
-## Endpoint options
+The endpoint name in a ref is one you choose. Credentials and any fixed query string or headers live here rather than in the ref, because a struct tag is source code and cannot safely carry a token.
 
 | Field | Default | Effect |
 | --- | --- | --- |
-| `Name` | required | The ref authority, e.g. `billing`. Must be non-empty and must not contain `/`. |
-| `BaseURL` | required | The root every ref path is joined onto. Scheme must be `http` or `https`; `http://` is rejected unless `AllowInsecure` is set. |
-| `Auth` | `nil` (unauthenticated) | An `httpcore.Authenticator` - `Bearer`, `HeaderAuth`, `BasicAuth`, `QueryAuth`, or `OAuth2ClientCredentials`. |
-| `Query` | `nil` | Merged into every request to this endpoint. |
-| `Header` | `nil` | Merged into every request to this endpoint. |
-| `Client` | `nil` (httpcore's default) | The `*http.Client` performing round trips. |
-| `MaxBody` | `0` (`httpcore.DefaultMaxBody`, 1 MiB) | Caps the response size read from this endpoint. |
-| `Sensitive` | `false` | Marks every `Value` from this endpoint as secret. |
-| `AllowInsecure` | `false` | Permits an `http://` `BaseURL` - cleartext `http` and nothing else, never a way to skip the scheme check itself. |
+| `Name` | required | The name refs use, e.g. `billing`. No `/`, `?` or `#`. |
+| `BaseURL` | required | The root every ref path is joined onto. Must be `https://`, or `http://` with `AllowInsecure`. |
+| `Auth` | none | An `httpcore.Authenticator`: `Bearer`, `HeaderAuth`, `BasicAuth`, `QueryAuth`, or `OAuth2ClientCredentials`. |
+| `Query` | none | Query parameters added to every request to this endpoint. |
+| `Header` | none | Headers added to every request to this endpoint. |
+| `Client` | default | The `*http.Client` used for requests. |
+| `MaxBody` | 1 MiB | Caps the response size read from this endpoint. |
+| `Sensitive` | `false` | Marks every value from this endpoint as a secret, so it is redacted in logs. |
+| `AllowInsecure` | `false` | Permits a cleartext `http://` `BaseURL`. Nothing else. |
 
 ```go
-import (
-	"github.com/xavidop/mamori/providers/httpcore"
-	httpsprov "github.com/xavidop/mamori/providers/https"
-)
-
 p, err := httpsprov.New(httpsprov.Endpoint{
-	Name:    "billing",
-	BaseURL: "https://billing.internal.example.com/v1",
-	Auth:    httpcore.Bearer(os.Getenv("BILLING_API_TOKEN")),
+	Name:      "billing",
+	BaseURL:   "https://billing.internal.example.com/v1",
+	Auth:      httpcore.Bearer(os.Getenv("BILLING_API_TOKEN")),
+	Sensitive: true,
 })
-if err != nil {
-	return err
-}
-
-cfg, err := mamori.Load[Config](ctx, mamori.WithProvider(p))
 ```
 
-`New` validates every endpoint at construction: it fails on a missing/duplicate/slashed `Name`, a missing or unparsable `BaseURL`, or a `BaseURL` scheme outside the closed `http`/`https` set - checked as a closed set rather than merely testing for `http://`, so an `ftp://` typo fails at startup instead of on every resolve with `net/http`'s "unsupported protocol scheme".
+Endpoints are validated when you construct the provider, so a typo in a name or a `BaseURL` fails at startup rather than on every resolve.
+
+## Path rules
+
+Two rules apply to the `<path>` part of a ref.
+
+**Write a literal `%` as `%25`.** A ref path is percent-escaped, so `%2F` addresses a single path segment whose own name contains a slash.
+
+```text
+https://billing/discount-50%-off      rejected
+https://billing/discount-50%25-off    reaches the backend as discount-50%-off
+```
+
+**A path cannot climb out of its endpoint.** A `.` or `..` segment is rejected with `mamori.ErrInvalid` before any request is sent. This matters when a path is interpolated: in `https://billing/${TENANT}/cfg`, a `TENANT` of `../..` would otherwise reach a different tenant's configuration. Both the plain and percent-encoded forms are refused, and `mamori doctor` surfaces a bad ref before you deploy.
 
 ## Error classification
-
-`Resolve` classifies every non-2xx, non-304 response through `httpcore.ClassifyStatus`, unmodified:
 
 | HTTP status | mamori kind |
 | --- | --- |
@@ -153,13 +121,13 @@ cfg, err := mamori.Load[Config](ctx, mamori.WithProvider(p))
 | 408, 429 | `rate_limited` |
 | anything else | `unavailable` |
 
-422 is named rather than left to the default because the default kind is transient: mamori would back off and retry a request that was well formed and semantically wrong, which retrying can never fix.
+A `404` is reported as `not_found`, so a field's `default:` or `optional` handling applies as usual.
 
-The response body never reaches an error. `ClassifyStatus` takes only a caller-supplied `detail` string, `httpcore.Config.ErrorDetail` is the hook that supplies one, and this provider leaves it nil, because the body it just fetched can itself be the config value or secret a ref is resolving.
+Response bodies never appear in an error message, since the body being fetched may itself be the secret.
 
 ## Watch
 
-mamori polls this provider - a generic, operator-declared endpoint exposes no push channel to subscribe to. Each `Endpoint` is wired to its own `httpcore.Revalidator`, keyed by the ref's raw string, so every poll after the first sends `If-None-Match` / `If-Modified-Since` and an unchanged value costs a `304` with an empty body rather than the full payload again. `Value.Version` comes from `httpcore.Version`, derived from whichever validator the response actually carried. This provider does not implement `WatchableProvider`; compose [`middleware.Cache`](/docs/middleware/) in front of it to coalesce reads beyond what conditional GET already saves.
+mamori polls this provider; a generic endpoint has no push channel to subscribe to. Polls after the first send `If-None-Match` and `If-Modified-Since`, so an unchanged value costs a `304` with an empty body rather than the whole payload again. Compose [`middleware.Cache`](/docs/middleware/) in front of it to coalesce reads further.
 
 ## Configuration
 
@@ -182,6 +150,4 @@ if err != nil {
 opt := mamori.WithProvider(p)
 ```
 
-There is no zero-config default: at least one `Endpoint` is required, each naming a `BaseURL` whose scheme is `http` or `https` (`http://` only with `AllowInsecure`). `Query` and `Header` cover a fixed target query string or header, since a ref itself cannot carry either.
-
-Verified with an in-process fake `http.RoundTripper` (endpoint validation, ref resolution and selection, conditional GET, dot-segment rejection, error classification), so the conformance kit runs without a live backend. A `//go:build integration` test exercises a real HTTP endpoint when `MAMORI_HTTPS_BASE_URL` and `MAMORI_HTTPS_PATH` are set.
+Tested against an in-process HTTP fake, so the conformance suite runs without a live backend. A `//go:build integration` test exercises a real endpoint when `MAMORI_HTTPS_BASE_URL` and `MAMORI_HTTPS_PATH` are set.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -33,45 +33,45 @@ const features = [
 
 // Providers are summarized on the landing by category; the full gallery lives in
 // the docs. Each card links to a representative provider page.
+//
+// A category's count is DERIVED from its own items list rather than written out
+// beside it. Kept by hand the two drift: "Secret managers" long displayed 9 over
+// a list of 8, and every provider added to a category is one more chance to
+// update one and not the other.
 const categories = [
   {
     name: "Local sources",
-    count: 5,
     items: "env · dotenv · file · exec · Viper",
     href: `${base}docs/providers/env`,
   },
   {
     name: "Secret managers",
-    count: 9,
     items: "AWS · Vault · GCP · Azure · Scaleway · Doppler · 1Password · SOPS",
     href: `${base}docs/providers/aws`,
   },
   {
     name: "Feature flags",
-    count: 9,
     items: "LaunchDarkly · Unleash · Flagsmith · ConfigCat · Split · GrowthBook · Flipt · GO Feature Flag · OpenFeature",
     href: `${base}docs/providers/launchdarkly`,
   },
   {
     name: "Databases",
-    count: 7,
     items: "Postgres · MySQL · SQLite · MongoDB · Redis · DynamoDB · Cosmos",
     href: `${base}docs/providers/postgres`,
   },
   {
     name: "KV, app config & Kubernetes",
-    count: 9,
     items: "Consul · etcd · AWS AppConfig · Azure AppConfig · Vercel Global Config · Cloudflare Workers KV · Generic HTTPS · Kubernetes Secret · ConfigMap",
     href: `${base}docs/providers/kubernetes`,
   },
   {
     name: "Object storage & Firebase",
-    count: 6,
     items: "S3 · GCS · Azure Blob · Firestore · Firebase RTDB · Remote Config",
     href: `${base}docs/providers/s3`,
   },
 ];
-const totalProviders = categories.reduce((n, c) => n + c.count, 0);
+const catCount = (c: { items: string }) => c.items.split(" \u00b7 ").length;
+const totalProviders = categories.reduce((n, c) => n + catCount(c), 0);
 
 // The operational layer beyond loading: serve, inspect, observe, and hand to an
 // agent. Each card links to its docs.
@@ -234,7 +234,7 @@ cfg := w.<span class="f">Get</span>() <span class="c">// lock-free; always the l
             <a class="card cat" href={c.href}>
               <div class="cat__top">
                 <h3 class="cat__name">{c.name}</h3>
-                <span class="cat__count">{c.count}</span>
+                <span class="cat__count">{catCount(c)}</span>
               </div>
               <p class="cat__items">{c.items}</p>
             </a>


### PR DESCRIPTION
Docs-only. No Go code changes.

## The problem

The `https` provider page had grown into a design discussion. It explained `ParseRef`'s splitting order, IIS backslash traversal bypasses, and RFC 3986 dot-segment semantics, and at one point argued with a code reviewer in prose:

> "That is a claim about where the check lives, not that `https://`'s ref behaviour is unchanged in every respect..."

Someone who just wants to read config from their own REST API had to wade through all of that.

## What changed

**`site/src/pages/docs/providers/https.md`, 187 lines to 153.** Rewritten to the shape every other provider page already uses: install, the ref, the options, the gotchas, errors, watch, configuration. Compare `cloudflare-kv.md` (108 lines) and `aws.md` (91).

The two rules a user can actually trip over are kept, but stated as rules with an example instead of as the reasoning that produced them:

- write a literal `%` as `%25`
- a path cannot climb out of its endpoint, which matters when the path is interpolated from `WithRefVars`

Everything else, the `ParseRef` internals, the SSRF posture, the backslash bypass, the RFC citation, is gone. The module README keeps the depth; that is the right home for it.

**`site/src/pages/index.astro`: a real bug, and the mechanism that caused it.**

The landing page counted providers per category by hand, and had drifted. "Secret managers" displayed **9** above a list of **8** names, which a visitor can simply count, and the headline total therefore read **45** when the lists summed to **44**.

The count is now derived from each category's own `items` string. That fixes the number, and removes the class of bug: adding a provider to a category can no longer leave the count behind.

It also removes a collision. All seven open provider PRs hand-edit these same count fields, so they would have conflicted on merge and could each have been independently wrong. With the count derived, a merge only has to reconcile the item list, and the number follows.

## Verification

- `npm run build`: 100 pages, Complete
- `npm run linkcheck`: no broken internal links
- Landing now renders `44 sources across 6 categories`, and Secret managers shows `8` over its 8 names

🤖 Generated with [Claude Code](https://claude.com/claude-code)