### PR TITLE
ci: restore the dependabot entries lost in the merge cascade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,6 +186,18 @@ updates:
     schedule: { interval: weekly }
     labels: [dependencies, go, provider:hcp-vault-secrets]
   - package-ecosystem: gomod
+    directory: "/providers/heroku"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, provider:heroku]
+  - package-ecosystem: gomod
+    directory: "/providers/infisical"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, provider:infisical]
+  - package-ecosystem: gomod
+    directory: "/providers/supabase"
+    schedule: { interval: weekly }
+    labels: [dependencies, go, provider:supabase]
+  - package-ecosystem: gomod
     directory: "/providers/https"
     schedule: { interval: weekly }
     labels: [dependencies, go, provider:https]


### PR DESCRIPTION
Fixes the failing `Dependabot covers every module` check on `main`.

`providers/heroku`, `providers/infisical` and `providers/supabase` each added their own entry on their own branch. Merging the eight provider PRs in sequence meant repeatedly merging `main` back into the not-yet-merged branches, and git **auto-merged `dependabot.yml` without ever raising a conflict**, so three entries were dropped silently rather than being resolved.

That is my mistake: my conflict resolution only inspected files git reported as conflicted, and this file never was.

Verified locally by running the exact CI script against the real module list:

```
All 52 Go modules are covered by dependabot.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly maintenance checks for provider integrations.
  * Improved organization of maintenance updates with provider-specific labeling.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->