### PR TITLE
fix: restore the provider registrations lost in the merge cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ go get github.com/xavidop/mamori/providers/cloudflare-kv  # cloudflare-kv://
 go get github.com/xavidop/mamori/providers/heroku         # heroku:// (config vars, batched)
 go get github.com/xavidop/mamori/providers/https          # https:// (generic REST)
 go get github.com/xavidop/mamori/providers/hcp-vault-secrets # hcp-vs://
+go get github.com/xavidop/mamori/providers/infisical      # infisical://
 go get github.com/xavidop/mamori/providers/scaleway-sm    # scaleway-sm://
+go get github.com/xavidop/mamori/providers/supabase       # supabase:// (Supabase Vault)
+go get github.com/xavidop/mamori/providers/bitwarden      # bitwarden-sm://
 # ... gcp, azure, consul, doppler, nacos, onepassword, sops
 
 go get github.com/xavidop/mamori/providers/httpcore       # no scheme: the shared HTTP core
@@ -132,6 +135,7 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 | `providers/k8s` | `k8s-secret://` · `k8s-cm://` | **native** (watch API) | ✅ |
 | `providers/consul` | `consul://` | **native** (blocking queries) | ✅ |
 | `providers/doppler` | `doppler://` | poll | ✅ |
+| `providers/infisical` | `infisical://` | poll | ✅ |
 | `providers/hcp-vault-secrets` | `hcp-vs://` | poll | ✅ |
 | `providers/scaleway-sm` | `scaleway-sm://` | poll | ✅ |
 | `providers/bitwarden` | `bitwarden-sm://` | poll | ✅ |

--- a/cmd/mamori/internal/sourcetag/sourcetag.go
+++ b/cmd/mamori/internal/sourcetag/sourcetag.go
@@ -45,6 +45,9 @@ var defaultSecretSchemes = []string{
 	"op",           // 1Password
 	"sops",         // Mozilla SOPS
 	"doppler",      // Doppler
+	"infisical",    // Infisical
+	"hcp-vs",       // HCP Vault Secrets (distinct from self-hosted vault above)
+	"supabase",     // Supabase Vault (vault.decrypted_secrets, over PostgREST)
 	"k8s-secret",   // Kubernetes Secret (k8s-cm, a ConfigMap, is not secret)
 	"bitwarden-sm", // Bitwarden Secrets Manager
 

--- a/go.work
+++ b/go.work
@@ -23,6 +23,7 @@ use (
 	./providers/gcs
 	./providers/goff
 	./providers/growthbook
+	./providers/hcp-vault-secrets
 	./providers/heroku
 	./providers/httpcore
 	./providers/https
@@ -35,8 +36,8 @@ use (
 	./providers/nacos
 	./providers/onepassword
 	./providers/openfeature
-	./providers/posthog
 	./providers/postgres
+	./providers/posthog
 	./providers/redis
 	./providers/s3
 	./providers/scaleway-sm

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -66,6 +66,7 @@ const groups = [
       { slug: "providers/gcp", title: "GCP", indent: true },
       { slug: "providers/azure", title: "Azure", indent: true },
       { slug: "providers/doppler", title: "Doppler", indent: true },
+      { slug: "providers/infisical", title: "Infisical", indent: true },
       { slug: "providers/hcp-vault-secrets", title: "HCP Vault Secrets", indent: true },
       { slug: "providers/scaleway-sm", title: "Scaleway Secret Manager", indent: true },
       { slug: "providers/bitwarden", title: "Bitwarden Secrets Manager", indent: true },

--- a/site/src/pages/docs/cli/vet.md
+++ b/site/src/pages/docs/cli/vet.md
@@ -54,8 +54,12 @@ The secret-bearing schemes are the ones that resolve to secret material:
 | `op`           | 1Password                   | yes                           |
 | `sops`         | Mozilla SOPS                | yes                           |
 | `doppler`      | Doppler                     | yes                           |
+| `infisical`    | Infisical                   | yes                           |
+| `hcp-vs`       | HCP Vault Secrets           | yes                           |
+| `supabase`     | Supabase Vault              | yes                           |
 | `k8s-secret`   | Kubernetes Secret           | yes                           |
 | `bitwarden-sm` | Bitwarden Secrets Manager   | yes                           |
+| `heroku`       | Heroku config vars          | treated as yes, see below     |
 | `aws-ps`       | AWS SSM Parameter Store     | only `SecureString` params    |
 | `exec`         | Command output              | mamori marks all of it secret |
 | `mamori`       | A mamori config server      | whatever the server marks     |

--- a/site/src/pages/docs/providers/index.md
+++ b/site/src/pages/docs/providers/index.md
@@ -15,7 +15,7 @@ Every provider that ships in this repo passes the conformance kit (see **Write a
 
 The **Errors** column shows which providers classify a failure beyond `not_found`, mapping backend-specific errors onto `mamori.ErrorKind` values like `permission_denied`, `unauthenticated`, `unavailable`, `rate_limited`, and `invalid`. The classification sweep across the whole catalog is now complete, and every provider falls into exactly one of three honest states:
 
-- **✅** - classifies real backend errors beyond `not_found`: thirty-eight rows across thirty-three modules. A row lists every scheme its module classifies, so `aws-sm://` and `aws-ps://` share one and `k8s-secret://` and `k8s-cm://` share one, while the core module's `env:`, `dotenv://`, `file://` and `exec:` each get a row of their own.
+- **✅** - classifies real backend errors beyond `not_found`: forty-four rows across thirty-nine modules. A row lists every scheme its module classifies, so `aws-sm://` and `aws-ps://` share one and `k8s-secret://` and `k8s-cm://` share one, while the core module's `env:`, `dotenv://`, `file://` and `exec:` each get a row of their own.
 - **no (chain preserved)** - `firebase-rtdb`, `growthbook`, and `flagsmith` have no backend-specific error vocabulary to map, so a non-not-found failure still reports `unknown`, but `Resolve` wraps the underlying error with `%w` rather than flattening it, so `errors.Is`/`errors.As` still reach it. This is not classification; it is proof that the chain survives even where there is nothing more specific to name.
 - **n/a (no error surface)** - `unleash`, `configcat`, `split`, and `viper` wrap a client surface with no per-key error at all: the flag SDKs return only `bool`/`string`, and Viper's own read API has no error return (`Get` returns `any`, `IsSet` returns `bool`). `Resolve` can only ever produce `not_found` or a client-construction error. Each is explicitly exempt from the conformance kit's `ErrorClassification` case via `providertest.Config.NoResolveErrors`, a deliberate, greppable opt-out rather than a silent gap.
 
@@ -35,6 +35,7 @@ Don't read either non-✅ state as broken: `not_found` is detected everywhere re
 | `azure-kv://` | Azure | yes | poll | ✅ |
 | `azure-appconfig://` | Azure AppConfig | no | poll | ✅ |
 | `doppler://` | Doppler | yes | poll | ✅ |
+| `infisical://` | Infisical | yes | poll | ✅ |
 | `hcp-vs://` | HCP Vault Secrets | yes | poll | ✅ |
 | `scaleway-sm://` | Scaleway Secret Manager | yes | poll | ✅ |
 | `bitwarden-sm://` | Bitwarden Secrets Manager | yes | poll | ✅ |

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -46,8 +46,7 @@ const categories = [
   },
   {
     name: "Secret managers",
-    count: 9,
-    items: "AWS · Vault · GCP · Azure · Scaleway · Bitwarden · Doppler · 1Password · SOPS",
+    items: "AWS · Vault · HCP Vault Secrets · GCP · Azure · Scaleway · Bitwarden · Doppler · Infisical · 1Password · SOPS · Supabase",
     href: `${base}docs/providers/aws`,
   },
   {
@@ -62,7 +61,7 @@ const categories = [
   },
   {
     name: "KV, app config & Kubernetes",
-    items: "Consul · etcd · Nacos · AWS AppConfig · Azure AppConfig · Vercel Global Config · Cloudflare Workers KV · Generic HTTPS · Kubernetes Secret · ConfigMap",
+    items: "Consul · etcd · Nacos · AWS AppConfig · Azure AppConfig · Vercel Global Config · Cloudflare Workers KV · Heroku Config Vars · Generic HTTPS · Kubernetes Secret · ConfigMap",
     href: `${base}docs/providers/kubernetes`,
   },
   {

--- a/skills/mamori/references/providers.md
+++ b/skills/mamori/references/providers.md
@@ -29,6 +29,7 @@ Module path is `github.com/xavidop/mamori/providers/<name>`.
 | `gcp` | `gcp-sm://` | `gcp-sm://my-project/api-key` |
 | `azure` | `azure-kv://` `azure-appconfig://` | `azure-kv://vaultname/secret-name`, `azure-appconfig://mystore/db/port?label=prod` |
 | `doppler` | `doppler://` | `doppler://project/config#SECRET` |
+| `infisical` | `infisical://` | `infisical://DB_PASSWORD`, `infisical://DB_PASSWORD?env=staging&path=/backend`, `infisical://DB_CREDS#/creds/password`. The whole ref path is the secret NAME; project/environment/folder come from options or `?project=`/`?env=`/`?path=`, never from the path. Machine identity Universal Auth via `INFISICAL_CLIENT_ID`/`INFISICAL_CLIENT_SECRET`. |
 | `hcp-vault-secrets` | `hcp-vs://` | `hcp-vs://DB_PASSWORD`, `hcp-vs://DB_PASSWORD?app=web&org=<uuid>&project=<uuid>`, `hcp-vs://DB_CREDS#/creds/password`. HCP Vault Secrets, NOT self-hosted `vault://`. The whole ref path is the secret NAME; organization/project/app come from options or `?org=`/`?project=`/`?app=`, never from the path. Service principal via `HCP_CLIENT_ID`/`HCP_CLIENT_SECRET`. Static secrets only. |
 | `scaleway-sm` | `scaleway-sm://` | `scaleway-sm://prod/db-password`, `scaleway-sm://db-password?revision=7` |
 | `bitwarden` | `bitwarden-sm://` | Bitwarden **Secrets Manager** (the `bws` machine-account product), not the consumer password manager. A secret is addressed by its **UUID**, never its name, because the list endpoint returns names as ciphertext and omits values: `bitwarden-sm://6b3f9e0c-9f9a-4a5c-9a09-af9601317f2d`, `bitwarden-sm://6b3f9e0c-9f9a-4a5c-9a09-af9601317f2d#password`. Reads `BWS_ACCESS_TOKEN`. Decrypts client side with the Go standard library alone. |
@@ -67,7 +68,10 @@ Module path is `github.com/xavidop/mamori/providers/<name>`.
 Store these in `secret.String` / `secret.Bytes`, never a plain `string`:
 
 - Always secret: `aws-sm`, `gcp-sm`, `azure-kv`, `vault`, `op`, `sops`,
-  `doppler`, `scaleway-sm`, `k8s-secret`, `bitwarden-sm`.
+  `doppler`, `infisical`, `hcp-vs`, `scaleway-sm`, `supabase`, `k8s-secret`,
+  `bitwarden-sm`, `heroku` (not a secret manager, but Heroku add-ons write
+  `DATABASE_URL` and `REDIS_URL` into the same unclassified config var
+  namespace as `LOG_LEVEL`).
 - Sometimes secret, and flagged anyway: `aws-ps` (SecureString params), `exec`
   (mamori marks all command output secret), `mamori` (relays whatever the
   server marks).


### PR DESCRIPTION
Repairs damage I caused merging the eight provider PRs.

## What went wrong

Merging them in sequence meant repeatedly merging `main` back into the not-yet-merged branches. I resolved those conflicts by **keeping the branch's side**, which is wrong for cumulative lists: where two branches each append to one line, keeping either one discards the other. Every merge dropped what the previous merge had added. Where git auto-merged without raising a conflict, entries vanished with no signal at all.

You spotted it on the landing page. It was wider than that.

## Functional losses

**`go.work` had lost `./providers/hcp-vault-secrets`**, so the module sat outside the workspace entirely.

**`defaultSecretSchemes` had lost `infisical`, `hcp-vs` and `supabase`.** All three resolve `Value{Sensitive: true}`, so **`mamori vet` was not flagging a hardcoded credential from any of them** in a plain `string`. Verified against each provider's `resolve.go` rather than its README. `nacos` and `posthog` are correctly still absent; neither marks values sensitive.

## Advertising losses

| Surface | Lost |
| --- | --- |
| Root README `go get` block | infisical, supabase, bitwarden |
| Root README coverage table | infisical |
| Site coverage table | infisical |
| `docs/cli/vet.md` | four scheme rows, while its prose still referenced one of them |
| Agent skill | infisical, plus three from its always-secret list |
| Docs sidebar | infisical, leaving a shipped page unreachable from navigation |
| Landing page | Infisical, HCP Vault Secrets, Supabase, Heroku, plus a stale hand-written `count: 9` contradicting the derived value |

## Counts

Recomputed from the tables rather than adjusted by hand: the provider index now reads **forty-four rows across thirty-nine modules**, and the landing renders **fifty-one sources**, derived by `catCount`.

## Verification

- `go build ./providers/hcp-vault-secrets/...` and `go vet` on it, proving the workspace entry works
- `make test` pass, no FAIL lines; `make lint` `0 issues.` per module
- `cd cmd/mamori && go test ./...` ok, including `internal/sourcetag` and `internal/vetcheck`
- `npm run build` 107 pages, `npm run linkcheck` no broken links
- `All 52 Go modules are covered by dependabot.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)