### PR TITLE
refactor(providers): migrate six providers onto httpcore, and stop leaking paths

### DIFF
--- a/docs/superpowers/specs/2026-08-03-provider-and-core-expansion-design.md
+++ b/docs/superpowers/specs/2026-08-03-provider-and-core-expansion-design.md
@@ -4,6 +4,12 @@
 HTTP resolve core, then migrate the sixteen existing `net/http` providers onto that
 core. Sixteen independent pull requests.
 
+**Correction, after PR1 shipped:** the migration set is eight providers, not sixteen,
+which merges PR13 and PR14 into one batch and withdraws PR16. The reasoning is under
+[PR1](#why-this-exists) and [Deliverables 13 through
+16](#deliverables-13-through-16-migrating-the-existing-http-providers); the original
+numbering is kept throughout so the two sections can be read against each other.
+
 **Status:** design approved, pending spec review.
 
 ## Scope: this is a program, not a feature
@@ -44,6 +50,9 @@ anything else.
 | 14 | `xavier/migrate-poll-2` | migrate flipt, growthbook, onepassword, scaleway-sm, unleash, vault, vercel-gc, cloudflare-kv | PR2-8 |
 | 15 | `xavier/httpcore-sse` | `httpcore` SSE, migrate firebase-rtdb and mamori | PR2-8 |
 | 16 | `xavier/migrate-consul` | migrate consul onto `LongPoll` | PR2-8, needs `LongPoll` from PR5 |
+
+Rows 13, 14 and 16 are superseded: see the correction under Deliverables 13 through
+16. The rows are left as written so the corrected batches can be read against them.
 
 A stack was considered and rejected. Only PR1 is a genuine dependency, so an
 eight-deep chain would buy nothing and would restack seven branches every time a
@@ -87,6 +96,20 @@ bug. Five providers additionally hand-roll conditional-GET polling: `s3` on ETag
 
 Seven of the eight providers requested here are REST APIs. Building them the current
 way writes that layer seven more times.
+
+**Correction, after PR1 shipped.** "Sixteen" was measured by import, not by use: it
+counted every provider whose non-test sources import `net/http`. Eight of the sixteen
+(`azblob`, `azure`, `cosmos`, `flipt`, `growthbook`, `unleash`, `vault`, `consul`)
+import it only incidentally - for the `http.Status*` constants they compare a vendor
+SDK's error code against, for an `*http.Client` they hand to a vendor SDK, or for an
+`http.Header` value - and do their actual fetching through that SDK. They have no raw
+HTTP for `httpcore` to replace. The providers that genuinely hand-roll request
+building are eight, not sixteen: `cloudflare-kv`, `doppler`, `firebase-rc`,
+`onepassword`, `scaleway-sm`, and `vercel-gc`, which are the six migrated on
+`xavier/httpcore-migration`, plus `firebase-rtdb` and `mamori`, whose read paths are
+SSE streams and which stay with PR15. The duplication and the #107 hygiene bug were
+real in all eight; only the count was wrong. See the correction under Deliverables 13
+through 16 for what that does to the migration batches.
 
 ### `providers/httpcore`
 
@@ -294,15 +317,20 @@ supplied, since `#key` selects into a JSON payload.
 ### Deferred out of PR1, but in the program
 
 Retro-fitting the existing sixteen `net/http` providers is PR13 through PR16, not
-PR1. PR1 must stay a reviewable module.
+PR1. PR1 must stay a reviewable module. (Eight providers, not sixteen: see the
+correction above.)
 
 Server-sent events are PR15. `httpcore` grows an SSE unit there and `firebase-rtdb`
 and `mamori` migrate onto it in the same PR, so the abstraction lands with both of
 its consumers rather than ahead of them.
 
-Long polling is PR5. Nacos needs it, `consul` already hand-rolls it, so `httpcore`
-gains `LongPoll` when the new provider forces the question and `consul` harvests it
-in PR16.
+Long polling is PR5. Nacos needs it, so `httpcore` gains `LongPoll` when the new
+provider forces the question.
+
+**Correction:** this originally added "and `consul` harvests it in PR16". It cannot.
+`consul`'s blocking query is `api.QueryOptions.WaitIndex` inside the HashiCorp SDK,
+not a hand-rolled HTTP long poll, so there is nothing for `httpcore.LongPoll` to take
+over. `LongPoll` is justified by Nacos alone.
 
 ## Deliverables 2 through 8: the REST providers
 
@@ -316,7 +344,7 @@ and the reason each one is not merely an `https://` recipe.
 | 2 | `providers/infisical` | `infisical://` | Project, environment, and secret path form a structured ref; error envelope needs mapping |
 | 3 | `providers/hcp-vault-secrets` | `hcp-vs://` | OAuth2 client-credentials exchange with token caching; distinct product and API from `vault://` |
 | 4 | `providers/bitwarden` | `bws://` | Client-side cryptography; the value is decrypted locally, not served in the clear |
-| 5 | `providers/nacos` | `nacos://` | Long-poll listener protocol gives it a native watch, so it implements `WatchableProvider`. **Also adds `httpcore.LongPoll`**, which PR16 harvests for `consul` |
+| 5 | `providers/nacos` | `nacos://` | Long-poll listener protocol gives it a native watch, so it implements `WatchableProvider`. **Also adds `httpcore.LongPoll`** (originally justified as something PR16 would also harvest for `consul`; see the correction above, `consul` cannot use it) |
 | 6 | `providers/supabase` | `supabase://` | Reads `vault.decrypted_secrets` through PostgREST; needs its own row and column shaping |
 | 7 | `providers/heroku` | `heroku://` | Requires the Heroku API `Accept` version header and returns all config vars in one document, so it is a `BatchProvider` |
 | 8 | `providers/posthog` | `posthog://` | Flag evaluation is a POST with a distinct id, not a GET; result is a facet on an evaluated payload |
@@ -369,12 +397,23 @@ Sixteen providers use `net/http` with no shared helper today. Migrating them ont
 `httpcore` is the reason `httpcore` is worth building: it is what turns issue #107
 from a recurring class of bug into a single place to fix.
 
+**Correction, after PR1 shipped.** That sixteen was measured by import rather than by
+use, and the real number is eight; see the correction under PR1 for which eight and
+why. The batches below shrink accordingly. PR13 and PR14 collapse into a single
+poll-only batch of six - `cloudflare-kv`, `doppler`, `firebase-rc`, `onepassword`,
+`scaleway-sm`, `vercel-gc` - which is what `xavier/httpcore-migration` carries. PR15
+is unaffected: `firebase-rtdb` and `mamori` do hand-roll their requests, and both are
+SSE consumers, so they still wait on the SSE unit. PR16 is withdrawn, because
+`consul` has no hand-rolled long poll to migrate. The eight providers dropped from
+the set are not being skipped, they were never in it: an `http.StatusNotFound`
+constant compared against a vendor SDK's error is not HTTP that `httpcore` can own.
+
 **Sequencing.** These land after PR2 through PR8, not before. Eight new consumers
 (`https` plus seven adapters) exercise the API first, so that if they reveal a gap it
-is fixed once, in `httpcore`, rather than after sixteen modules have already committed
-to the wrong shape.
+is fixed once, in `httpcore`, rather than after every migrated module has already
+committed to the wrong shape.
 
-**What makes this verifiable.** Every one of the sixteen already passes
+**What makes this verifiable.** Every one of them already passes
 `providertest.Run` and carries its own unit tests. A migration that preserves
 behaviour keeps them green, and a migration that does not fails loudly. No new test
 strategy is needed; the safety net exists. Each PR must show its modules' conformance
@@ -382,21 +421,26 @@ runs passing before and after, and must not change any provider's public API,
 `Scheme()`, ref grammar, or error mapping. This is a refactor, and any behaviour
 change found along the way belongs in a separate PR.
 
+The table as originally written, with the correction applied to each row:
+
 | PR | Modules | Shape |
 | --- | --- | --- |
-| 13 | azblob, azure, cosmos, doppler, firebase-rc | Poll-only. First migration batch, kept small so the pattern is established under real review before it is applied at scale |
-| 14 | flipt, growthbook, onepassword, scaleway-sm, unleash, vault, vercel-gc, cloudflare-kv | Poll-only. Applies the pattern PR13 established |
-| 15 | firebase-rtdb, mamori | Adds `httpcore` SSE and migrates both streaming consumers in the same PR |
-| 16 | consul | Migrates onto `httpcore.LongPoll`, which PR5 built for Nacos |
+| 13 | ~~azblob, azure, cosmos,~~ doppler, firebase-rc | Poll-only. Merged into the single batch below; the three struck modules fetch through a vendor SDK |
+| 14 | ~~flipt, growthbook,~~ onepassword, scaleway-sm, ~~unleash, vault,~~ vercel-gc, cloudflare-kv | Poll-only. Merged into the single batch below; the four struck modules fetch through a vendor SDK |
+| 13+14 | cloudflare-kv, doppler, firebase-rc, onepassword, scaleway-sm, vercel-gc | Poll-only, one batch of six rather than two. `xavier/httpcore-migration` |
+| 15 | firebase-rtdb, mamori | Adds `httpcore` SSE and migrates both streaming consumers in the same PR. Unchanged |
+| 16 | ~~consul~~ | Withdrawn. Its blocking query is `api.QueryOptions.WaitIndex` inside the HashiCorp SDK, so there is no hand-rolled long poll to migrate |
 
-**PR15 is the one to watch.** `providers/mamori` is 3,485 lines, the largest of the
-sixteen, and it is the client half of the config server's wire protocol. Its SSE
+**PR15 is the one to watch.** `providers/mamori` is 3,485 lines, the largest of them,
+and it is the client half of the config server's wire protocol. Its SSE
 handling is load-bearing for `server/`, so PR15 carries more risk than PR13 and PR14
 combined. Splitting it further is an acceptable outcome if its own spec finds the
 SSE unit does not fit both consumers cleanly.
 
 **`vault` migrates its resolve path only.** Its lease-aware refresh reads `NotAfter`
-from the lease and is not an HTTP concern, so it stays where it is.
+from the lease and is not an HTTP concern, so it stays where it is. **Correction:**
+`vault` migrates nothing. Its resolve path goes through the HashiCorp SDK, and its
+`net/http` import is `http.Status*` constants used to classify the SDK's error.
 
 ## Risks
 
@@ -408,10 +452,10 @@ so the first person with credentials can confirm the shape in one command.
 **`httpcore` is load-bearing before it has users.** Its API is fixed by PR1 but only
 exercised by one provider until PR2. Mitigation: PR1 ships `https` on top of it as a
 real consumer rather than a demonstration; `httpcore` is a separate module on its own
-tag, so a v0 API change does not force a core release; and the sixteen migrations are
+tag, so a v0 API change does not force a core release; and the migrations are
 sequenced after eight consumers have exercised it.
 
-**The migrations touch working code.** PR13 through PR16 change sixteen providers
+**The migrations touch working code.** The migration PRs change providers
 that work today, for an internal benefit rather than a user-visible one. Mitigation:
 every one of them already passes the conformance kit, so the refactor is verifiable
 rather than hopeful, and the batches are ordered so the smallest establishes the

--- a/providers/cloudflare-kv/README.md
+++ b/providers/cloudflare-kv/README.md
@@ -146,10 +146,14 @@ identically on both paths:
 | --- | --- |
 | 401 | `unauthenticated` |
 | 403 | `permission_denied` |
-| 429 | `rate_limited` |
-| 400 | `invalid` |
-| 5xx | `unavailable` |
-| anything else | `unknown` |
+| 408, 429 | `rate_limited` |
+| 400, 422 | `invalid` |
+| 5xx, and any other status not named above | `unavailable` |
+
+The mapping is `httpcore.ClassifyStatus`, shared with every other
+`httpcore`-backed provider, rather than a table private to this module. An
+unrecognized status reports `unavailable` (transient, so mamori backs off and
+retries) rather than `unknown`.
 
 **The 404 caveat.** An absent key and an absent namespace are indistinguishable
 in Cloudflare's response: both return a plain 404 with no error code this
@@ -168,10 +172,17 @@ request URL, and `http.Client.Do` wraps every transport-level failure - a
 refused connection, a timeout, a cancelled context - in a `*url.Error` whose
 `Error()` renders that full URL. Without stripping it, an ordinary network
 hiccup, not even a bug in this provider, would put the account id and
-namespace id into a returned error's text. This provider's
-`sanitizeTransportError` discards the rendered URL and keeps only the
-underlying reason, while still wrapping it with `%w` so `errors.Is(_,
-context.Canceled)` and similar checks keep working.
+namespace id into a returned error's text. This provider therefore hands
+`httpcore` a `Config.RedactPath` hook that substitutes `<account>` and
+`<namespace>` for the two ids, in both their raw and percent-encoded forms,
+before `httpcore` composes the message. `httpcore` applies that hook at every
+site that renders a URL into an error, including the `*url.Error` it rebuilds
+around a transport failure, so the ids cannot be read back out through the
+chain either. Substituting the path before the message exists, rather than
+rewriting the finished message afterwards as this provider used to, is what
+keeps the error chain whole: nothing is rewritten, so `errors.Is(_,
+context.Canceled)` and `errors.As(_, &urlErr)` keep working, and the rest of
+the path still names which endpoint was called.
 
 ## Authentication & configuration
 
@@ -249,9 +260,10 @@ either.
 | `ResolveBatch` grouped by namespace; a key deduplicated across refs that select different `#field`s fans out to every ref | **Verified** (`TestResolveBatchGroupsByNamespace`, `TestResolveBatchDedupedKeyFansOutToAllRefs`) |
 | An absent key omitted from a batch response leaves its siblings intact, per the `BatchProvider` contract; an invalid selection still fails the batch | **Verified** (unit tests) |
 | A 404 namespace on the bulk path omits that namespace's keys instead of failing the batch, and a sibling namespace's ref still resolves | **Verified** (`TestResolveBatchNotFoundNamespaceOmitsKeys`, `TestResolveBatchSurvivesSiblingNamespaceNotFound`) |
-| Error classification (401/403/429/400/5xx), exercised from both the single-key path and the bulk path | **Verified** (unit tests + `providertest` `ErrorClassification` case) |
+| Error classification (401/403/400/422/408/429, and an unnamed status such as 418 as `unavailable`), exercised from both the single-key path and the bulk path | **Verified** (unit tests + `providertest` `ErrorClassification` case) |
 | A namespace containing `/` (ref-controlled via `?namespace=`) travels percent-encoded in the request path, on both the single-key and the bulk path | **Verified** (`TestResolveNamespaceWithSlashIsEscaped`, `TestResolveBatchNamespaceWithSlashIsEscaped`) |
-| Credentials never reach an error: the token, account id, and namespace id never appear in an error string, on any of the four `sanitizeTransportError` call sites (`NewRequestWithContext` and `httpClient.Do`, in each of `get` and `bulkGet`) | **Verified** (`TestSettingsErrorsNeverCarryCredentials`, `TestResolveSendsBearerTokenNeverInURL`, `TestResolveTransportErrorNeverLeaksCredentials`, `TestResolveBatchTransportErrorNeverLeaksCredentials`, `TestResolveMalformedBaseURLNeverLeaksCredentials`, `TestResolveBatchMalformedBaseURLNeverLeaksCredentials`) |
+| Credentials never reach an error: the token, account id, and namespace id never appear in an error string, on the transport-failure path of both `get` and `bulkGet`, where `httpcore` renders the request URL twice (into its own message and into the `*url.Error` it rebuilds around the cause) | **Verified** (`TestSettingsErrorsNeverCarryCredentials`, `TestResolveSendsBearerTokenNeverInURL`, `TestResolveTransportErrorNeverLeaksCredentials`, `TestResolveBatchTransportErrorNeverLeaksCredentials`, plus `TestRedactPathSubstitutesBothIDs` and `TestRedactPathLeavesAPathCarryingNoIDAlone` on the hook itself) |
+| A malformed `WithBaseURL` is rejected at client construction as `mamori.ErrInvalid`, on both the single-key and the bulk path, rather than reaching mamori as an unclassified error it would back off and retry | **Verified** (`TestResolveMalformedBaseURLIsInvalid`, `TestResolveBatchMalformedBaseURLIsInvalid`) |
 | No cache: every `Resolve` reaches the fake transport, never a held value | **Verified** (`TestResolveNeverCaches`) |
 | Context cancellation | **Verified** (unit tests) |
 | `BatchProvider` is implemented; `WatchableProvider` is deliberately not | **Verified** (`TestProviderImplementsBatchProvider`, `TestProviderIsNotWatchable`) |

--- a/providers/cloudflare-kv/conformance_test.go
+++ b/providers/cloudflare-kv/conformance_test.go
@@ -2,35 +2,26 @@ package cloudflarekv
 
 import (
 	"context"
-	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 	"github.com/xavidop/mamori/providertest"
 )
 
 // statusForFailure maps the mamori sentinel providertest.RunErrorClassification
-// injects to the HTTP status that would produce it through classifyStatus.
-// This provider's client surfaces a failure as a status code on the request,
-// not as a mamori error, so the conformance Fail hook has to invert that
-// mapping to actually exercise every classification case; injecting one fixed
-// status regardless of err would only ever exercise the case that status
-// happens to map to (see classifyStatus's doc comment for the mapping this
-// mirrors).
+// injects to the HTTP status that produces it. This provider's client surfaces
+// a failure as a status code on the request, not as a mamori error, so the
+// conformance Fail hook has to invert the classification to actually exercise
+// every case; injecting one fixed status regardless of err would only ever
+// exercise the case that status happens to map to.
+//
+// The inverse is httpcore.StatusForKind rather than a switch copied into this
+// file: a hand-rolled inverse that drifts from the forward table does not fail
+// loudly, it just makes this case exercise one classification five times while
+// still reporting green.
 func statusForFailure(err error) int {
-	switch {
-	case errors.Is(err, mamori.ErrPermissionDenied):
-		return http.StatusForbidden
-	case errors.Is(err, mamori.ErrUnauthenticated):
-		return http.StatusUnauthorized
-	case errors.Is(err, mamori.ErrRateLimited):
-		return http.StatusTooManyRequests
-	case errors.Is(err, mamori.ErrInvalid):
-		return http.StatusBadRequest
-	default: // mamori.ErrUnavailable and anything unrecognized
-		return http.StatusServiceUnavailable
-	}
+	return httpcore.StatusForKind(mamori.ErrorKind(err))
 }
 
 // TestConformance runs the shared providertest kit against this provider,
@@ -44,8 +35,8 @@ func statusForFailure(err error) int {
 // cases must skip on their own because the type assertion to
 // mamori.WatchableProvider fails, not because this test told them to.
 // NoResolveErrors is likewise left unset: Resolve classifies HTTP status
-// through classifyStatus and Fail/Clear give the kit a real seam to inject
-// through, so this provider owes the ErrorClassification case.
+// through httpcore and Fail/Clear give the kit a real seam to inject through,
+// so this provider owes the ErrorClassification case.
 func TestConformance(t *testing.T) {
 	f := newFake()
 
@@ -66,10 +57,10 @@ func TestConformance(t *testing.T) {
 			// Workers KV's REST API surfaces a failure as a status code on the
 			// whole request, not per key, so the whole namespace is failed and
 			// cleared rather than one key within it. statusForFailure maps the
-			// injected sentinel to the status that produces it through
-			// classifyStatus, so each of the five ErrorClassification cases
-			// actually round-trips through the real status-to-error mapping
-			// instead of only ever exercising one of them.
+			// injected sentinel back to the status that produces it, so each
+			// of the five ErrorClassification cases actually round-trips
+			// through the real status-to-error mapping instead of only ever
+			// exercising one of them.
 			f.failStatus(testNamespace, statusForFailure(err))
 			return nil
 		},

--- a/providers/cloudflare-kv/errors_test.go
+++ b/providers/cloudflare-kv/errors_test.go
@@ -1,73 +1,146 @@
 package cloudflarekv
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-// TestClassifyStatusUnmappedIsUnknown asserts that a status classifyStatus has
-// no case for (teapot, chosen because no real Workers KV response uses it)
-// reports mamori.KindUnknown, matching the "anything else maps to unknown"
-// contract the site page publishes, and returns statusErr unchanged rather
-// than re-wrapping it.
-func TestClassifyStatusUnmappedIsUnknown(t *testing.T) {
-	base := errors.New(`mamori/cloudflare-kv: unexpected status 418 reading key "k": teapot`)
-	got := classifyStatus(http.StatusTeapot, base)
-
-	if got != base {
-		t.Fatalf("classifyStatus(418, base) = %v, want base returned unchanged", got)
-	}
-	if kind := mamori.ErrorKind(got); kind != mamori.KindUnknown {
-		t.Fatalf("ErrorKind = %q, want %q", kind, mamori.KindUnknown)
-	}
-}
-
-func TestClassifyStatusNilIsNil(t *testing.T) {
-	if err := classifyStatus(http.StatusForbidden, nil); err != nil {
-		t.Fatalf("classifyStatus(403, nil) = %v, want nil", err)
-	}
-}
-
-// TestClassifyStatusPreservesChain asserts that the diagnostic text in
-// statusErr - the status code and key get built into it in get - stays
-// reachable through errors.Is after classification wraps it with a sentinel,
-// so nothing throws away the original context.
-func TestClassifyStatusPreservesChain(t *testing.T) {
-	base := errors.New(`mamori/cloudflare-kv: unexpected status 403 reading key "k": forbidden`)
-	wrapped := classifyStatus(http.StatusForbidden, base)
-
-	if !errors.Is(wrapped, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", wrapped)
-	}
-	if !errors.Is(wrapped, base) {
-		t.Fatalf("underlying status error no longer reachable: %v", wrapped)
-	}
-}
-
-// TestClassifyStatusMapsOrdinaryHTTPSemantics pins classifyStatus's mapping
-// for every status this provider is documented to recognize.
-func TestClassifyStatusMapsOrdinaryHTTPSemantics(t *testing.T) {
-	tests := []struct {
+// TestResolveClassifiesStatus pins the status-to-kind mapping this provider
+// inherits from httpcore.ClassifyStatus, exercised end to end through Resolve
+// against a real response. There is no longer a hand-rolled classifyStatus to
+// table-test directly: the mapping lives in one place for every httpcore-backed
+// provider.
+//
+// Three rows differ from the mapping this provider carried before it moved onto
+// httpcore, and each is deliberate:
+//
+//   - 422 was previously unclassified (KindUnknown), so mamori treated it as an
+//     unknown failure and kept retrying a request that was well formed and
+//     semantically wrong. It is now KindInvalid.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside 429.
+//   - 418, and every other status neither this provider nor httpcore names, was
+//     previously KindUnknown and is now KindUnavailable: httpcore has one
+//     default for an unrecognized status rather than per-provider silence.
+//
+// 404 is absent on purpose: get and bulkGet each take it back for a message of
+// their own, which TestResolveAbsentKeyIsNotFound covers.
+func TestResolveClassifiesStatus(t *testing.T) {
+	cases := []struct {
 		code int
-		want error
+		want mamori.Kind
 	}{
-		{http.StatusUnauthorized, mamori.ErrUnauthenticated},
-		{http.StatusForbidden, mamori.ErrPermissionDenied},
-		{http.StatusTooManyRequests, mamori.ErrRateLimited},
-		{http.StatusBadRequest, mamori.ErrInvalid},
-		{http.StatusInternalServerError, mamori.ErrUnavailable},
-		{http.StatusBadGateway, mamori.ErrUnavailable},
+		{http.StatusUnauthorized, mamori.KindUnauthenticated},
+		{http.StatusForbidden, mamori.KindPermissionDenied},
+		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
+		{http.StatusBadRequest, mamori.KindInvalid},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusInternalServerError, mamori.KindUnavailable},
+		{http.StatusBadGateway, mamori.KindUnavailable},
+		{http.StatusTeapot, mamori.KindUnavailable},
 	}
-	for _, tc := range tests {
+	for _, tc := range cases {
 		t.Run(http.StatusText(tc.code), func(t *testing.T) {
-			base := errors.New("injected")
-			got := classifyStatus(tc.code, base)
-			if !errors.Is(got, tc.want) {
-				t.Fatalf("classifyStatus(%d, base) = %v, want an error satisfying %v", tc.code, got, tc.want)
+			f := newFake()
+			f.set(testNamespace, "k", []byte("v"))
+			f.failStatus(testNamespace, tc.code)
+			p := f.provider()
+
+			_, err := p.Resolve(context.Background(), ref(t, "cloudflare-kv://k"))
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.code)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.code, got, tc.want, err)
 			}
 		})
+	}
+}
+
+// TestResolveBatchClassifiesUnmappedStatus is TestResolveClassifiesStatus's
+// counterpart for the bulk path, which reaches the same classification through
+// its own call site.
+func TestResolveBatchClassifiesUnmappedStatus(t *testing.T) {
+	f := newFake()
+	f.set(testNamespace, "k", []byte("v"))
+	f.failStatus(testNamespace, http.StatusTeapot)
+	p := f.provider()
+
+	_, err := p.ResolveBatch(context.Background(), []mamori.Ref{ref(t, "cloudflare-kv://k")})
+	if err == nil {
+		t.Fatal("ResolveBatch returned a nil error for a 418 response")
+	}
+	if got := mamori.ErrorKind(err); got != mamori.KindUnavailable {
+		t.Fatalf("ErrorKind = %q, want %q", got, mamori.KindUnavailable)
+	}
+}
+
+// TestResolveErrorMessagePreservesContext guards what the migration onto
+// httpcore had to keep: the key, the HTTP status, and the verbatim (bounded)
+// upstream body all still reach the message, and the classification is still
+// reachable with errors.Is rather than flattened into text.
+func TestResolveErrorMessagePreservesContext(t *testing.T) {
+	f := newFake()
+	f.set(testNamespace, "log-level", []byte("v"))
+	f.failStatus(testNamespace, http.StatusForbidden)
+	p := f.provider()
+
+	_, err := p.Resolve(context.Background(), ref(t, "cloudflare-kv://log-level"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
+	}
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
+	}
+	for _, want := range []string{"log-level", "403", "injected failure"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error message lost %q: %v", want, err)
+		}
+	}
+}
+
+// TestRedactPathSubstitutesBothIDs pins the hook this package hands
+// httpcore.Config.RedactPath: both ids are gone from the path httpcore will
+// render, both placeholders are there in their place, and the rest of the path
+// is untouched so an error still says which endpoint was called.
+//
+// It replaces the two tests that covered redactIDs, the local workaround this
+// hook retired. Half of what those tests guarded is now unfalsifiable rather
+// than untested: redactIDs rewrote a finished error message and so could lose
+// the cause, while a path substituted before the message exists cannot, since
+// no error is rewritten at all. The two transport-failure leak tests in
+// resolve_test.go drive the same guarantee end to end, through Resolve and
+// through ResolveBatch.
+func TestRedactPathSubstitutesBothIDs(t *testing.T) {
+	s := settings{token: secretToken, account: secretAccount, namespace: secretNamespace}
+	path := namespacePath(s) + "/values/log-level"
+
+	got := redactPath(s)(path)
+
+	if strings.Contains(got, secretAccount) || strings.Contains(got, secretNamespace) {
+		t.Fatalf("redactPath left an id in %q", got)
+	}
+	if !strings.Contains(got, accountPlaceholder) || !strings.Contains(got, namespacePlaceholder) {
+		t.Fatalf("redactPath did not substitute both placeholders: %q", got)
+	}
+	if !strings.HasSuffix(got, "/values/log-level") {
+		t.Fatalf("redactPath rewrote more than the ids: %q", got)
+	}
+}
+
+// TestRedactPathLeavesAPathCarryingNoIDAlone keeps the hook from mangling a
+// path that names nothing identifying, which is every path httpcore renders for
+// a client built with settings these ids did not come from.
+func TestRedactPathLeavesAPathCarryingNoIDAlone(t *testing.T) {
+	s := settings{token: secretToken, account: secretAccount, namespace: secretNamespace}
+	const path = "/accounts/other/storage/kv/namespaces/other/values/k"
+
+	if got := redactPath(s)(path); got != path {
+		t.Fatalf("redactPath rewrote a path carrying no id: %q", got)
 	}
 }

--- a/providers/cloudflare-kv/go.mod
+++ b/providers/cloudflare-kv/go.mod
@@ -2,7 +2,10 @@ module github.com/xavidop/mamori/providers/cloudflare-kv
 
 go 1.26.0
 
-require github.com/xavidop/mamori v0.1.0
+require (
+	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -21,3 +23,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/cloudflare-kv/go.sum
+++ b/providers/cloudflare-kv/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/cloudflare-kv/resolve.go
+++ b/providers/cloudflare-kv/resolve.go
@@ -1,17 +1,17 @@
 package cloudflarekv
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 )
 
 // bulkMaxKeys is the maximum number of keys Cloudflare's bulk/get endpoint
@@ -21,16 +21,27 @@ import (
 // error at all.
 const bulkMaxKeys = 100
 
-// errBodyLimit bounds how much of a non-200 response body get and bulkGet
-// read, so a hostile or broken upstream cannot put an unbounded response
-// into an error string. Both functions' 404 branches drain within this same
-// bound (see get's doc comment on why an absent key needs that drain), and
-// both 200 paths now drain within it too - get already does by reading the
-// whole body via io.ReadAll, and bulkGet's Decode-based path drains
-// explicitly right after decoding - so every branch that can be entered
-// shares one connection-reuse discipline rather than the 200 and 404 paths
-// silently differing.
+// errBodyLimit bounds how much of a failing response body reaches an error
+// string, so a hostile or broken upstream cannot put an unbounded response
+// into one. httpcore hands errorDetail at most Config.MaxBody bytes and always
+// drains the rest on every branch, so the connection-reuse discipline this
+// file used to hand-roll per branch now comes from one place; this constant is
+// only about how much of that body is worth quoting.
 const errBodyLimit = 4096
+
+// maxBodyBytes is the response ceiling for a successful read. It is set
+// explicitly rather than left at httpcore's 1 MiB default because a Workers KV
+// value may be up to 25 MiB, and this provider read the value body unbounded
+// before it moved onto httpcore: a smaller ceiling would turn a legal, if
+// large, value into a resolve failure.
+const maxBodyBytes = 25 << 20
+
+// Placeholders substituted for the account and namespace ids in an error
+// message. See redactPath.
+const (
+	accountPlaceholder   = "<account>"
+	namespacePlaceholder = "<namespace>"
+)
 
 // Resolve fetches the value for ref from Workers KV.
 //
@@ -190,66 +201,46 @@ func (p *Provider) ResolveBatch(ctx context.Context, refs []mamori.Ref) (map[str
 // absent from the returned map; the caller (ResolveBatch) treats that as an
 // omission, not an error.
 func (p *Provider) bulkGet(ctx context.Context, s settings, keys []string) (map[string][]byte, error) {
-	u := p.baseURL + "/accounts/" + url.PathEscape(s.account) +
-		"/storage/kv/namespaces/" + url.PathEscape(s.namespace) + "/bulk/get"
-
 	reqBody, err := json.Marshal(bulkGetRequestBody{Keys: keys, Type: "text"})
 	if err != nil {
 		return nil, fmt.Errorf("mamori/cloudflare-kv: encoding bulk request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(reqBody))
+	client, err := p.clientFor(s)
 	if err != nil {
-		return nil, sanitizeTransportError(err)
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+s.token)
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := client.Do(ctx, httpcore.Request{
+		Method: http.MethodPost,
+		Path:   namespacePath(s) + "/bulk/get",
+		Header: http.Header{"Content-Type": {"application/json"}},
+		Body:   reqBody,
+	})
 	if err != nil {
-		return nil, sanitizeTransportError(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
-		// Unlike get, an absent key never reaches this branch: the bulk
-		// endpoint has no per-key 404 - a missing key is simply omitted from
-		// a successful response's Values map (see bulkGetResponseBody's doc
-		// comment). A 404 here can therefore only mean the namespace itself
-		// does not exist, so it is classified as mamori.ErrNotFound before
-		// classifyStatus ever sees it, exactly as get's namespace-not-found
-		// case is. ResolveBatch's call site treats this the same way it
-		// treats an absent key: this chunk's keys are skipped so their refs
-		// fall back to their defaults, rather than one bad namespace failing
-		// every sibling ref in the batch.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
-		return nil, fmt.Errorf("mamori/cloudflare-kv: namespace not found for bulk get of %d key(s): %w", len(keys), mamori.ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded amount of the error body for diagnostics. Never log
-		// it. Embedding the body verbatim, bounded by errBodyLimit, is a
-		// deliberate house convention shared with providers/doppler,
-		// providers/vercel-gc, and providers/scaleway-sm, not something
-		// invented here: the verbatim text is what actually tells an operator
-		// what the upstream rejected the request for, and the bound is what
-		// stops a hostile or broken upstream turning that diagnostic into an
-		// unbounded string.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
-		statusErr := fmt.Errorf("mamori/cloudflare-kv: unexpected status %d from bulk get of %d key(s): %s",
-			resp.StatusCode, len(keys), strings.TrimSpace(string(msg)))
-		return nil, classifyStatus(resp.StatusCode, statusErr)
+		if errors.Is(err, mamori.ErrNotFound) {
+			// Unlike get, an absent key never reaches this branch: the bulk
+			// endpoint has no per-key 404 - a missing key is simply omitted
+			// from a successful response's Values map (see
+			// bulkGetResponseBody's doc comment). A 404 here can therefore
+			// only mean the namespace itself does not exist, and it gets its
+			// own message for that, exactly as get's namespace-not-found case
+			// does. ResolveBatch's call site treats this the same way it
+			// treats an absent key: this chunk's keys are skipped so their
+			// refs fall back to their defaults, rather than one bad namespace
+			// failing every sibling ref in the batch.
+			return nil, fmt.Errorf("mamori/cloudflare-kv: namespace not found for bulk get of %d key(s): %w", len(keys), mamori.ErrNotFound)
+		}
+		// One %w: the cause already carries the sentinel httpcore classified
+		// it with, and adding a second would replace that kind rather than
+		// duplicate it.
+		return nil, fmt.Errorf("mamori/cloudflare-kv: bulk get of %d key(s): %w", len(keys), err)
 	}
 
 	var body bulkGetResponseBody
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
 		return nil, fmt.Errorf("mamori/cloudflare-kv: decoding bulk response: %w: %w", mamori.ErrInvalid, err)
 	}
-	// Decode consumes a well-formed single JSON value, so this is normally a
-	// no-op; draining explicitly, rather than relying on that, is what makes
-	// this path's connection-reuse behavior a decision instead of an
-	// accident of Decode's internals, matching the 404 branch above and
-	// get's own 200 path (see errBodyLimit's doc comment).
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 	if !body.Success {
 		// A 200 status carrying "success":false is Cloudflare's own reported
 		// failure, distinct from an HTTP-level status code, and is a malformed
@@ -283,78 +274,128 @@ func (p *Provider) bulkGet(ctx context.Context, s settings, keys []string) (map[
 // (config%2Fprod%2Flog-level) rather than as three, which is why keyOf takes
 // the entire ref path as one key and never splits it on '/'.
 func (p *Provider) get(ctx context.Context, s settings, key string) ([]byte, error) {
-	u := p.baseURL + "/accounts/" + url.PathEscape(s.account) +
-		"/storage/kv/namespaces/" + url.PathEscape(s.namespace) +
-		"/values/" + url.PathEscape(key)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	client, err := p.clientFor(s)
 	if err != nil {
-		return nil, sanitizeTransportError(err)
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+s.token)
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := client.Do(ctx, httpcore.Request{
+		Path: namespacePath(s) + "/values/" + url.PathEscape(key),
+	})
 	if err != nil {
-		return nil, sanitizeTransportError(err)
+		if errors.Is(err, mamori.ErrNotFound) {
+			// Either the key or the namespace is absent; the response does not
+			// reliably distinguish them, which is the caveat this provider's
+			// package doc names rather than hides.
+			return nil, fmt.Errorf("mamori/cloudflare-kv: key %q not found: %w", key, mamori.ErrNotFound)
+		}
+		// One %w: the cause already carries the sentinel httpcore classified
+		// it with, and adding a second would replace that kind rather than
+		// duplicate it.
+		return nil, fmt.Errorf("mamori/cloudflare-kv: reading key %q: %w", key, err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
-		// Either the key or the namespace is absent; see classifyStatus's doc
-		// comment for why the response does not reliably distinguish them.
-		// Drain and discard a bounded amount of the body before returning:
-		// this provider caches nothing, so an absent key is read again on
-		// every poll tick, and leaving the body unread here would prevent
-		// the connection being reused, paying a fresh TCP and TLS handshake
-		// on every one of those ticks.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
-		return nil, fmt.Errorf("mamori/cloudflare-kv: key %q not found: %w", key, mamori.ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded amount of the error body for diagnostics. Never log
-		// it (same errBodyLimit bound and rationale as bulkGet's status
-		// branch, above).
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
-		statusErr := fmt.Errorf("mamori/cloudflare-kv: unexpected status %d reading key %q: %s",
-			resp.StatusCode, key, strings.TrimSpace(string(msg)))
-		return nil, classifyStatus(resp.StatusCode, statusErr)
-	}
-	// The 200 path needs no matching drain step: it already reads the whole
-	// body via io.ReadAll below, so the connection is already fully consumed
-	// by the time this function returns (see errBodyLimit's doc comment).
-	return io.ReadAll(resp.Body)
+	return resp.Body, nil
 }
 
-// sanitizeTransportError strips a *url.Error down to its underlying reason,
-// discarding the request URL it would otherwise render into Error().
+// namespacePath is the escaped path prefix addressing one namespace, shared by
+// the single-key and bulk endpoints.
 //
-// The request URL built in get embeds the account id and the namespace id,
-// and http.Client.Do wraps every transport-level failure - a refused
-// connection, a timeout, a cancelled context - in a *url.Error whose Error()
-// renders the full request URL. Without this, an ordinary network hiccup,
-// not even a bug in this provider, would put the account id into a returned
-// error's text. This is the same class of leak providers/vercel-gc fixed in
-// parseConnectionString (see its doc comment), reached here through the
-// client's transport instead of url.Parse.
+// Both ids are url.PathEscape'd. The namespace is ref-controlled through
+// ?namespace=, so without the escape a namespace containing "/" would produce
+// a request path addressing an entirely different endpoint. httpcore joins
+// Request.Path in its escaped form precisely so that works, and rejects a "."
+// or ".." segment (literal or percent-encoded) before anything is sent, so a
+// traversal payload cannot escape the base URL's prefix either.
+func namespacePath(s settings) string {
+	return "/accounts/" + url.PathEscape(s.account) +
+		"/storage/kv/namespaces/" + url.PathEscape(s.namespace)
+}
+
+// clientFor builds the httpcore client for one read.
 //
-// Wrapping urlErr.Err with %w, rather than discarding it, keeps
-// errors.Is(_, context.Canceled) (and similar checks) working: *url.Error
-// already unwraps to the same underlying error via its own Unwrap method, so
-// this changes only the rendered message, never the errors.Is chain.
-//
-// The final `return err` is deliberate, not a missed case: by construction
-// only a *url.Error carries a rendered request URL, so any other error type
-// already has nothing to strip, and wrapping it here would add noise without
-// removing anything sensitive.
-func sanitizeTransportError(err error) error {
-	if err == nil {
-		return nil
+// It is built per call rather than cached because the token, the account id
+// and the namespace are resolved per ref, reading the environment lazily (see
+// settingsFor): caching would pin whichever set happened to be resolved first,
+// and the namespace in particular is allowed to differ from one ref to the
+// next. Construction performs no network call and reuses the provider's
+// *http.Client, so the connection pool is shared across every read.
+func (p *Provider) clientFor(s settings) (*httpcore.Client, error) {
+	c, err := httpcore.New(httpcore.Config{
+		BaseURL:     p.baseURL,
+		HTTPClient:  p.httpClient,
+		Auth:        httpcore.Bearer(s.token),
+		MaxBody:     maxBodyBytes,
+		ErrorDetail: errorDetail,
+		RedactPath:  redactPath(s),
+	})
+	if err != nil {
+		// No redaction here: this error echoes the operator's configured
+		// BaseURL, which carries neither id, and a BaseURL that failed to parse
+		// has no path for a path hook to work on.
+		return nil, fmt.Errorf("mamori/cloudflare-kv: building the API client: %w", err)
 	}
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return fmt.Errorf("mamori/cloudflare-kv: request failed: %w", urlErr.Err)
+	return c, nil
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it quotes a bounded
+// prefix of a failing response's body into the error message.
+//
+// Embedding the body verbatim, bounded by errBodyLimit, is a deliberate house
+// convention shared with providers/doppler, providers/vercel-gc and
+// providers/scaleway-sm: the verbatim text is what actually tells an operator
+// what the upstream rejected the request for, and the bound is what stops a
+// hostile or broken upstream turning that diagnostic into an unbounded string.
+// httpcore calls this only for a status it has already decided is a failure,
+// never for the 200 whose body IS the stored value.
+func errorDetail(_ int, body []byte) string {
+	if len(body) > errBodyLimit {
+		body = body[:errBodyLimit]
 	}
-	return err
+	return strings.TrimSpace(string(body))
+}
+
+// redactPath returns httpcore's Config.RedactPath hook for s: it substitutes
+// placeholders for the account id and the namespace id in the request path
+// httpcore renders into every error it returns.
+//
+// httpcore strips the query string and any userinfo from that URL but renders
+// the path, which is right for a provider whose path carries only a key name
+// and wrong for this one: a Workers KV URL carries the account id and the
+// namespace id as ordinary path segments. This package guarantees neither
+// reaches an error's text (see TestResolveTransportErrorNeverLeaksCredentials),
+// and without this hook an ordinary refused connection would put both into a
+// log line. The API token needs no such treatment: it travels in the
+// Authorization header, which is never rendered.
+//
+// Substituting before httpcore composes the message, rather than rewriting the
+// finished message afterwards as this package used to, is what keeps the error
+// chain untouched: errors.Is still reaches httpcore's sentinel and still
+// reaches the transport's own cause through the *url.Error httpcore preserves,
+// because nothing is rewritten at all. httpcore applies the hook to that
+// rebuilt *url.Error too, so the ids cannot be read back out through the chain.
+//
+// Both the raw and the url.PathEscape'd form of each id are replaced, since the
+// path carries the escaped one, and the longest string is replaced first so that
+// an id which is a prefix of the other cannot leave a fragment of it behind.
+func redactPath(s settings) func(string) string {
+	subs := []struct{ from, to string }{
+		{s.account, accountPlaceholder},
+		{url.PathEscape(s.account), accountPlaceholder},
+		{s.namespace, namespacePlaceholder},
+		{url.PathEscape(s.namespace), namespacePlaceholder},
+	}
+	slices.SortFunc(subs, func(a, b struct{ from, to string }) int {
+		return len(b.from) - len(a.from)
+	})
+
+	return func(path string) string {
+		for _, sub := range subs {
+			if sub.from != "" {
+				path = strings.ReplaceAll(path, sub.from, sub.to)
+			}
+		}
+		return path
+	}
 }
 
 // valueFor turns the raw response body into a mamori.Value, applying the
@@ -382,41 +423,16 @@ func valueFor(b []byte, ref mamori.Ref, namespace string) (mamori.Value, error) 
 	}, nil
 }
 
-// classifyStatus maps a Workers KV REST API status onto a mamori
-// classification sentinel, wrapping statusErr so both the sentinel and the
-// diagnostic context survive in the errors.Is chain. 404 is handled by its own
-// branch in both get and bulkGet and never reaches this function.
+// Status classification comes from httpcore.ClassifyStatus, inside
+// httpcore.Client.Do, rather than from a mapping copied into this package. 404
+// is the one status get and bulkGet each take back, to give it a message of
+// their own.
 //
-// The mapping follows ordinary HTTP semantics: 401 for a missing or invalid
-// API token, 403 for a token that authenticates but lacks permission to read
-// this namespace, 429 for rate limiting, and 400 for a malformed request. One
-// caveat is worth being honest about, because it is the kind of thing a
-// misconfiguration hides behind rather than announces: a 404 from this API
-// means either an absent key or an absent namespace, and Cloudflare's response
-// does not reliably distinguish the two, so a namespace id that is simply
-// wrong presents as every key in it silently falling back to its default,
-// exactly like a genuinely absent key would. Cloudflare has not published a
-// stable enough error-code vocabulary in the response body to key this
-// mapping on anything but the status, so codes not listed here report
-// unknown rather than being guessed at.
-func classifyStatus(code int, statusErr error) error {
-	if statusErr == nil {
-		return nil
-	}
-	var sentinel error
-	switch {
-	case code == http.StatusUnauthorized:
-		sentinel = mamori.ErrUnauthenticated
-	case code == http.StatusForbidden:
-		sentinel = mamori.ErrPermissionDenied
-	case code == http.StatusTooManyRequests:
-		sentinel = mamori.ErrRateLimited
-	case code == http.StatusBadRequest:
-		sentinel = mamori.ErrInvalid
-	case code >= 500:
-		sentinel = mamori.ErrUnavailable
-	default:
-		return statusErr
-	}
-	return fmt.Errorf("%w: %w", sentinel, statusErr)
-}
+// One caveat of that 404 is worth being honest about, because it is the kind
+// of thing a misconfiguration hides behind rather than announces: a 404 from
+// this API means either an absent key or an absent namespace, and Cloudflare's
+// response does not reliably distinguish the two, so a namespace id that is
+// simply wrong presents as every key in it silently falling back to its
+// default, exactly like a genuinely absent key would. Cloudflare has not
+// published a stable enough error-code vocabulary in the response body to key
+// anything on but the status.

--- a/providers/cloudflare-kv/resolve_test.go
+++ b/providers/cloudflare-kv/resolve_test.go
@@ -380,16 +380,16 @@ func assertNoCredentialLeak(t *testing.T, err error) {
 // connection string; this provider has no connection string, but its request
 // URL embeds the account id and namespace id, and http.Client.Do wraps every
 // transport-level failure in a *url.Error whose Error() renders the full
-// request URL. Without sanitizing that, an ordinary network hiccup - not
+// request URL. Without redacting that, an ordinary network hiccup - not
 // even a bug in this provider - would put the account id and namespace id
 // into a returned error's text.
 //
-// This is one of four sanitizeTransportError call sites (the
-// NewRequestWithContext branch and the httpClient.Do branch, in each of get
-// and bulkGet); the other three are pinned by
-// TestResolveBatchTransportErrorNeverLeaksCredentials,
-// TestResolveMalformedBaseURLNeverLeaksCredentials, and
-// TestResolveBatchMalformedBaseURLNeverLeaksCredentials below.
+// A transport failure is the branch that renders the URL twice: once into
+// httpcore's own message, and once more into the *url.Error it rebuilds
+// around the cause. Both go through the redactPath hook this package hands
+// httpcore.Config, so this test fails if either site loses it, and
+// TestResolveBatchTransportErrorNeverLeaksCredentials drives the same pair
+// from the bulk path.
 func TestResolveTransportErrorNeverLeaksCredentials(t *testing.T) {
 	p := New(
 		WithAPIToken(secretToken),
@@ -425,18 +425,26 @@ func TestResolveBatchTransportErrorNeverLeaksCredentials(t *testing.T) {
 	assertNoCredentialLeak(t, err)
 }
 
-// TestResolveMalformedBaseURLNeverLeaksCredentials pins the
-// NewRequestWithContext branch in get, the one sanitizeTransportError call
-// site nothing previously exercised: a malformed WithBaseURL makes
-// url.Parse fail inside http.NewRequestWithContext itself, before any
-// network call, and that failure is also a *url.Error whose Error() renders
-// the full (unreachable) request URL - unsanitized, it would read
-// `parse "http://example.com/%zz/accounts/<account>/storage/kv/namespaces/<namespace>/values/k": ...`.
-func TestResolveMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
+// TestResolveMalformedBaseURLIsInvalid pins what a malformed WithBaseURL
+// actually does on the single-key path: httpcore.New rejects it at
+// construction, inside clientFor, and Resolve surfaces that as
+// mamori.ErrInvalid rather than as an unclassified error mamori would treat
+// as KindUnknown and keep retrying. A BaseURL that cannot be parsed is a
+// configuration mistake, and no amount of backing off will fix it.
+//
+// This test used to be TestResolveMalformedBaseURLNeverLeaksCredentials and
+// used to assert that no account or namespace id reached the error. That
+// assertion could not fail, before this migration or after it: the rejection
+// names the operator's configured BaseURL and nothing else, because no
+// request path is ever built. The name promised a leak check the body did not
+// perform. The genuine leak guarantee is driven end to end, on a path that
+// really does render both ids, by TestResolveTransportErrorNeverLeaksCredentials
+// and TestResolveBatchTransportErrorNeverLeaksCredentials above.
+func TestResolveMalformedBaseURLIsInvalid(t *testing.T) {
 	p := New(
-		WithAPIToken(secretToken),
-		WithAccountID(secretAccount),
-		WithNamespaceID(secretNamespace),
+		WithAPIToken(testToken),
+		WithAccountID(testAccount),
+		WithNamespaceID(testNamespace),
 		WithBaseURL("http://example.com/%zz"),
 	)
 
@@ -444,17 +452,19 @@ func TestResolveMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
 	if err == nil {
 		t.Fatal("want an error from a malformed base URL")
 	}
-	assertNoCredentialLeak(t, err)
+	if !errors.Is(err, mamori.ErrInvalid) {
+		t.Fatalf("got %v (kind %q), want an error satisfying mamori.ErrInvalid", err, mamori.ErrorKind(err))
+	}
 }
 
-// TestResolveBatchMalformedBaseURLNeverLeaksCredentials is
-// TestResolveMalformedBaseURLNeverLeaksCredentials's counterpart for
-// bulkGet's NewRequestWithContext branch.
-func TestResolveBatchMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
+// TestResolveBatchMalformedBaseURLIsInvalid is
+// TestResolveMalformedBaseURLIsInvalid's counterpart for the bulk path, which
+// reaches clientFor through bulkGet rather than get.
+func TestResolveBatchMalformedBaseURLIsInvalid(t *testing.T) {
 	p := New(
-		WithAPIToken(secretToken),
-		WithAccountID(secretAccount),
-		WithNamespaceID(secretNamespace),
+		WithAPIToken(testToken),
+		WithAccountID(testAccount),
+		WithNamespaceID(testNamespace),
 		WithBaseURL("http://example.com/%zz"),
 	)
 
@@ -462,7 +472,9 @@ func TestResolveBatchMalformedBaseURLNeverLeaksCredentials(t *testing.T) {
 	if err == nil {
 		t.Fatal("want an error from a malformed base URL")
 	}
-	assertNoCredentialLeak(t, err)
+	if !errors.Is(err, mamori.ErrInvalid) {
+		t.Fatalf("got %v (kind %q), want an error satisfying mamori.ErrInvalid", err, mamori.ErrorKind(err))
+	}
 }
 
 // TestGetErrorBodyIsBounded pins errBodyLimit on get's single-key path: the

--- a/providers/doppler/doppler.go
+++ b/providers/doppler/doppler.go
@@ -2,8 +2,11 @@
 // (https://www.doppler.com), the SecretOps platform.
 //
 // Doppler has no official Go SDK, so this provider talks to the Doppler REST
-// API (https://api.doppler.com) directly with net/http. A single secret is
-// fetched per resolve using the "config/secret" endpoint.
+// API (https://api.doppler.com) directly, over
+// github.com/xavidop/mamori/providers/httpcore and the standard library only,
+// inheriting request building, status classification, body bounding and URL
+// redaction from one shared place. A single secret is fetched per resolve
+// using the "config/secret" endpoint.
 //
 // # Scheme
 //
@@ -34,7 +37,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -42,6 +44,7 @@ import (
 	"time"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 )
 
 // defaultBaseURL is the Doppler REST API root.
@@ -50,16 +53,15 @@ const defaultBaseURL = "https://api.doppler.com"
 // scheme is the URL scheme this provider handles.
 const scheme = "doppler"
 
-// errBodyLimit bounds how much of a non-200 response body Resolve reads for
-// diagnostics, so a hostile or broken upstream cannot put an unbounded
-// response into an error string. The 404 branch below reads nothing at all
-// rather than reading up to this bound and discarding it: the not-found
-// message is already the whole story, so there is no diagnostic worth
-// paying a read for. The 200 path explicitly drains any bytes its own
-// decode did not consume, within this same bound, so that path and the
-// error path share one connection-reuse discipline instead of two silently
-// different ones; see the decode call below for why that drain is
-// deliberate rather than a hedge against Decode misbehaving.
+// secretPath is the single-secret read endpoint, joined onto the base URL.
+const secretPath = "/v3/configs/config/secret"
+
+// errBodyLimit bounds how much of a failing response body reaches an error
+// string, so a hostile or broken upstream cannot put an unbounded response
+// into one. httpcore hands errorDetail at most Config.MaxBody bytes and always
+// drains the rest, so the connection-reuse discipline this provider used to
+// hand-roll on every branch now comes from one place; this constant is only
+// about how much of that body is worth quoting.
 const errBodyLimit = 4096
 
 // Provider resolves doppler:// refs against the Doppler REST API. It is safe for
@@ -133,6 +135,11 @@ type secretResponse struct {
 
 // Resolve fetches a single secret named by ref.Key from the project/config
 // encoded in ref.Path. A 404 (or missing secret) is reported as ErrNotFound.
+//
+// A ref path containing a "." or ".." segment cannot escape the base URL:
+// httpcore.Client.Do rejects one for every provider built on it. Nothing here
+// interpolates ref.Path into a path anyway (the project and config travel as
+// query parameters), but the guarantee is inherited rather than re-stated.
 func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, error) {
 	project, config, err := parsePath(ref.Path)
 	if err != nil {
@@ -148,47 +155,38 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 		return mamori.Value{}, errors.New("mamori/doppler: no token; set DOPPLER_TOKEN or use doppler.WithToken")
 	}
 
-	endpoint := p.baseURL + "/v3/configs/config/secret"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	client, err := p.clientFor(token)
 	if err != nil {
 		return mamori.Value{}, err
 	}
-	q := url.Values{}
-	q.Set("project", project)
-	q.Set("config", config)
-	q.Set("name", name)
-	req.URL.RawQuery = q.Encode()
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := client.Do(ctx, httpcore.Request{
+		Path: secretPath,
+		Query: url.Values{
+			"project": {project},
+			"config":  {config},
+			"name":    {name},
+		},
+		Header: http.Header{"Accept": {"application/json"}},
+	})
 	if err != nil {
-		return mamori.Value{}, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		// handled below
-	case http.StatusNotFound:
-		return mamori.Value{}, fmt.Errorf("mamori/doppler: secret %q not found in %s/%s: %w", name, project, config, mamori.ErrNotFound)
-	default:
-		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
-		statusErr := fmt.Errorf("mamori/doppler: unexpected status %d fetching secret %q: %s", resp.StatusCode, name, strings.TrimSpace(string(msg)))
-		return mamori.Value{}, classifyDopplerStatus(resp.StatusCode, statusErr)
+		// A 404 is the only status with a message of its own: it names the
+		// project and config the secret was looked for in, which the status
+		// alone does not say. One %w, because the sentinel is already the
+		// classification.
+		if errors.Is(err, mamori.ErrNotFound) {
+			return mamori.Value{}, fmt.Errorf("mamori/doppler: secret %q not found in %s/%s: %w", name, project, config, mamori.ErrNotFound)
+		}
+		// One %w: the cause already carries the sentinel httpcore classified it
+		// with, and adding a second would replace that kind rather than
+		// duplicate it.
+		return mamori.Value{}, fmt.Errorf("mamori/doppler: fetching secret %q: %w", name, err)
 	}
 
 	var sr secretResponse
-	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+	if err := json.Unmarshal(resp.Body, &sr); err != nil {
 		return mamori.Value{}, fmt.Errorf("mamori/doppler: decoding secret %q: %w", name, err)
 	}
-	// Decode consumes a well-formed single JSON value, so this is normally a
-	// no-op; draining explicitly, rather than relying on that, is what makes
-	// the 200 path's connection-reuse behavior a decision instead of an
-	// accident of Decode's internals, matching the bound this provider's
-	// error path already applies (see errBodyLimit).
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 
 	// Prefer the computed value (references resolved); fall back to raw.
 	val := sr.Value.Computed
@@ -209,6 +207,49 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 	}, nil
 }
 
+// clientFor builds the httpcore client for one resolve.
+//
+// It is built per call rather than cached because the token is read lazily
+// from the environment on every resolve (see resolveToken): caching the client
+// would pin whichever token happened to be set on the first one. Construction
+// performs no network call and reuses the provider's *http.Client, so the
+// connection pool is shared across resolves regardless.
+func (p *Provider) clientFor(token string) (*httpcore.Client, error) {
+	c, err := httpcore.New(httpcore.Config{
+		BaseURL:     p.baseURL,
+		HTTPClient:  p.httpClient,
+		Auth:        httpcore.Bearer(token),
+		ErrorDetail: errorDetail,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mamori/doppler: building the API client: %w", err)
+	}
+	return c, nil
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it quotes a bounded
+// prefix of a failing response's body into the error message.
+//
+// Embedding the body verbatim, bounded, is a deliberate house convention
+// shared with providers/cloudflare-kv, providers/vercel-gc and
+// providers/scaleway-sm: the verbatim text is what actually tells an operator
+// what the upstream rejected the request for, and the bound is what stops a
+// hostile or broken upstream turning that diagnostic into an unbounded string.
+// It is safe here because httpcore calls this only for a status it has already
+// decided is a failure, never for the 200 whose body IS the secret.
+//
+// A 404 yields no detail: Resolve replaces that status with its own message
+// naming the project and config, so anything returned here would be discarded.
+func errorDetail(status int, body []byte) string {
+	if status == http.StatusNotFound {
+		return ""
+	}
+	if len(body) > errBodyLimit {
+		body = body[:errBodyLimit]
+	}
+	return strings.TrimSpace(string(body))
+}
+
 // resolveToken returns the configured token, or DOPPLER_TOKEN read lazily.
 func (p *Provider) resolveToken() string {
 	if p.token != "" {
@@ -226,42 +267,4 @@ func parsePath(path string) (project, config string, err error) {
 		return "", "", fmt.Errorf("mamori/doppler: path %q must be <project>/<config>", path)
 	}
 	return segs[0], segs[1], nil
-}
-
-// classifyDopplerStatus maps a Doppler REST API HTTP status onto a mamori
-// classification sentinel, wrapping statusErr (the error Resolve already
-// built from the response, carrying the status code and body for
-// diagnostics) so both the sentinel and that context survive in the
-// errors.Is chain. 404 is handled by its own branch in Resolve above and
-// never reaches this function.
-//
-// 429 is the confirmed case: Doppler's API reference documents rate limiting
-// explicitly, including the response headers that accompany a 429. 401 (a
-// missing or malformed token) is well established from Doppler's
-// token-based auth model and its own community support threads, though the
-// API reference's status-code section only describes the 2xx/4xx/5xx
-// categories in general terms rather than spelling out 401 by name. 403,
-// 400, and 5xx are mapped on ordinary HTTP semantics - defensible mappings,
-// not individually confirmed by Doppler's documentation. Codes not listed
-// above report unknown rather than being guessed at.
-func classifyDopplerStatus(code int, statusErr error) error {
-	if statusErr == nil {
-		return nil
-	}
-	var sentinel error
-	switch {
-	case code == http.StatusForbidden:
-		sentinel = mamori.ErrPermissionDenied
-	case code == http.StatusUnauthorized:
-		sentinel = mamori.ErrUnauthenticated
-	case code == http.StatusTooManyRequests:
-		sentinel = mamori.ErrRateLimited
-	case code >= 500:
-		sentinel = mamori.ErrUnavailable
-	case code == http.StatusBadRequest:
-		sentinel = mamori.ErrInvalid
-	default:
-		return statusErr
-	}
-	return fmt.Errorf("%w: %w", sentinel, statusErr)
 }

--- a/providers/doppler/doppler_test.go
+++ b/providers/doppler/doppler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 	"github.com/xavidop/mamori/providertest"
 )
 
@@ -36,6 +37,7 @@ type fakeDoppler struct {
 	mu       sync.Mutex
 	store    map[string]string // key: project/config/name -> value
 	fails    map[string]error  // key: project/config/name -> injected transport error
+	codes    map[string]int    // key: project/config/name -> injected HTTP status
 	lastAuth string            // last Authorization header seen
 }
 
@@ -44,7 +46,7 @@ func storeKey(project, config, name string) string {
 }
 
 func newFake() *fakeDoppler {
-	return &fakeDoppler{store: map[string]string{}, fails: map[string]error{}}
+	return &fakeDoppler{store: map[string]string{}, fails: map[string]error{}, codes: map[string]int{}}
 }
 
 func (f *fakeDoppler) set(project, config, name, val string) {
@@ -70,6 +72,31 @@ func (f *fakeDoppler) clear(project, config, name string) {
 	delete(f.fails, storeKey(project, config, name))
 }
 
+// failCode makes every request for project/config/name answer with the HTTP
+// status code, until clearCode is called. It is the seam the providertest
+// ErrorClassification case uses.
+//
+// It has to be a real status rather than a transport error. Resolve now sends
+// its request through httpcore.Client.Do, which classifies ANY transport
+// failure as mamori.ErrUnavailable, and mamori.ErrorKind tests
+// ErrUnavailable before ErrRateLimited and ErrInvalid: a sentinel injected at
+// the transport would come back out as "unavailable" for two of the five
+// cases. Going through a real status is also the stronger test, because it
+// forces the classification to be earned through the same status mapping a
+// live Doppler 403 or 429 would take.
+func (f *fakeDoppler) failCode(project, config, name string, code int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.codes[storeKey(project, config, name)] = code
+}
+
+// clearCode cancels a previously injected failCode.
+func (f *fakeDoppler) clearCode(project, config, name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.codes, storeKey(project, config, name))
+}
+
 func (f *fakeDoppler) handle(w http.ResponseWriter, r *http.Request) {
 	f.mu.Lock()
 	f.lastAuth = r.Header.Get("Authorization")
@@ -87,9 +114,18 @@ func (f *fakeDoppler) handle(w http.ResponseWriter, r *http.Request) {
 
 	f.mu.Lock()
 	val, ok := f.store[storeKey(project, config, name)]
+	code, failing := f.codes[storeKey(project, config, name)]
 	f.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
+	if failing {
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":  false,
+			"messages": []string{"injected failure"},
+		})
+		return
+	}
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -141,14 +177,13 @@ func (f *fakeDoppler) inProcessProvider() *Provider {
 // error keyed by the requested project/config/name and, when present,
 // returns it directly instead of invoking the handler.
 //
-// This is the seam the providertest ErrorClassification case and
-// TestResolveInjectedSentinelSurvives exercise: http.Client.Do wraps a
-// RoundTripper error in *url.Error, which is Unwrap-compatible, and
-// doppler.go's Resolve returns that error verbatim on a transport failure
-// (it never touches an HTTP response at all), so an injected mamori sentinel
-// survives errors.Is unchanged. This is a separate path from
-// classifyDopplerStatus, which only classifies a real HTTP status on a real
-// response; both must work independently.
+// This is the seam TestResolveInjectedSentinelSurvives exercises:
+// http.Client.Do wraps a RoundTripper error in *url.Error, which is
+// Unwrap-compatible, and httpcore rebuilds that wrapper with a redacted URL
+// rather than discarding it, so an injected mamori sentinel is still reachable
+// with errors.Is on the way out. This is a separate path from status
+// classification, which only runs on a real HTTP response; both must work
+// independently.
 func (f *fakeDoppler) failClient() *http.Client {
 	return &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -358,12 +393,17 @@ func TestConformance(t *testing.T) {
 			f.set(testProject, testConfig, key, val)
 			return nil
 		},
+		// httpcore.StatusForKind is the exported inverse of the status mapping
+		// Resolve now classifies through, so each of the five cases
+		// round-trips the real mapping rather than exercising one of them five
+		// times. See fakeDoppler.failCode for why this is a status and not a
+		// transport error.
 		Fail: func(_ context.Context, key string, err error) error {
-			f.fail(testProject, testConfig, key, err)
+			f.failCode(testProject, testConfig, key, httpcore.StatusForKind(mamori.ErrorKind(err)))
 			return nil
 		},
 		Clear: func(_ context.Context, key string) error {
-			f.clear(testProject, testConfig, key)
+			f.clearCode(testProject, testConfig, key)
 			return nil
 		},
 		SkipWatch: true, // Doppler has no native change notification.
@@ -385,6 +425,7 @@ func TestResolveInjectedSentinelSurvives(t *testing.T) {
 
 	p := New(WithBaseURL("http://doppler.test"), WithToken(testToken), WithHTTPClient(f.failClient()))
 	_, err := p.Resolve(context.Background(), mustRef(t, "doppler://"+testProject+"/"+testConfig+"#K"))
+	f.clear(testProject, testConfig, "K")
 	if err == nil {
 		t.Fatal("Resolve returned a nil error while the transport was failing")
 	}
@@ -396,14 +437,11 @@ func TestResolveInjectedSentinelSurvives(t *testing.T) {
 	}
 }
 
-// TestResolveClassifiesRealStatus exercises classifyDopplerStatus through
+// TestResolveClassifiesRealStatus exercises status classification through
 // Resolve itself, using a real HTTP 403 response from a handler (not an
-// injected transport error). Neither the conformance ErrorClassification
-// case nor TestResolveInjectedSentinelSurvives can catch a regression in
-// Resolve's default-branch wiring: both inject a mamori sentinel directly at
-// the RoundTripper, bypassing the HTTP-status path entirely, so they would
-// keep passing even if the classifyDopplerStatus call were deleted from
-// Resolve. This test fails if that wiring is removed.
+// injected transport error), so a regression in the wiring between Resolve and
+// httpcore's classification surfaces here even though
+// TestResolveInjectedSentinelSurvives bypasses the HTTP-status path entirely.
 func TestResolveClassifiesRealStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/providers/doppler/errors_test.go
+++ b/providers/doppler/errors_test.go
@@ -1,14 +1,47 @@
 package doppler
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-func TestClassifyDopplerStatus(t *testing.T) {
+// statusServerProvider returns a provider pointed at a server that answers
+// every request with status and body.
+func statusServerProvider(t *testing.T, status int, body string) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(WithBaseURL(srv.URL), WithToken(testToken), WithHTTPClient(srv.Client()))
+}
+
+// TestResolveClassifiesStatus pins the status-to-kind mapping this provider
+// inherits from httpcore.ClassifyStatus, exercised end to end through Resolve
+// against a real response. There is no longer a hand-rolled
+// classifyDopplerStatus to table-test directly: the mapping lives in one place
+// for every httpcore-backed provider, and what this provider still owes is
+// that a real response reaches it.
+//
+// Three rows differ from the mapping this provider carried before it moved
+// onto httpcore, and each is deliberate:
+//
+//   - 422 was previously unclassified, so mamori treated it as an unknown
+//     failure and kept retrying a request that was well formed and
+//     semantically wrong. It is now KindInvalid.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside
+//     429.
+//   - 409, and every other status neither this provider nor httpcore names,
+//     was previously KindUnknown and is now KindUnavailable: httpcore has one
+//     default for an unrecognized status rather than per-provider silence.
+func TestResolveClassifiesStatus(t *testing.T) {
 	cases := []struct {
 		status int
 		want   mamori.Kind
@@ -16,49 +49,62 @@ func TestClassifyDopplerStatus(t *testing.T) {
 		{http.StatusForbidden, mamori.KindPermissionDenied},
 		{http.StatusUnauthorized, mamori.KindUnauthenticated},
 		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
 		{http.StatusInternalServerError, mamori.KindUnavailable},
 		{http.StatusBadGateway, mamori.KindUnavailable},
 		{http.StatusServiceUnavailable, mamori.KindUnavailable},
 		{http.StatusBadRequest, mamori.KindInvalid},
-		{http.StatusConflict, mamori.KindUnknown},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusConflict, mamori.KindUnavailable},
 	}
 	for _, tc := range cases {
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
-			base := errors.New("boom")
-			got := mamori.ErrorKind(classifyDopplerStatus(tc.status, base))
-			if got != tc.want {
-				t.Fatalf("status %d: ErrorKind = %q, want %q", tc.status, got, tc.want)
+			p := statusServerProvider(t, tc.status, `{"messages":["nope"]}`)
+			_, err := p.Resolve(context.Background(), mustRef(t, "doppler://"+testProject+"/"+testConfig+"#K"))
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.status)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.status, got, tc.want, err)
 			}
 		})
 	}
 }
 
-func TestClassifyDopplerStatusPreservesStatusError(t *testing.T) {
-	base := errors.New(`mamori/doppler: unexpected status 403 fetching secret "K": forbidden`)
-	wrapped := classifyDopplerStatus(http.StatusForbidden, base)
-
-	if !errors.Is(wrapped, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", wrapped)
+// TestResolveErrorMessagePreservesContext guards what the migration onto
+// httpcore had to keep: the secret name, the HTTP status, and the verbatim
+// (bounded) upstream body all still reach the message, and the classification
+// is still reachable with errors.Is rather than flattened into text.
+func TestResolveErrorMessagePreservesContext(t *testing.T) {
+	p := statusServerProvider(t, http.StatusForbidden, `{"messages":["token lacks read access"]}`)
+	_, err := p.Resolve(context.Background(), mustRef(t, "doppler://"+testProject+"/"+testConfig+"#STRIPE_API_KEY"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
 	}
-	if !errors.Is(wrapped, base) {
-		t.Fatalf("underlying status error no longer reachable: %v", wrapped)
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"STRIPE_API_KEY", "403", "token lacks read access"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message lost %q: %v", want, err)
+		}
 	}
 }
 
-func TestClassifyDopplerStatusNilIsNil(t *testing.T) {
-	if err := classifyDopplerStatus(http.StatusForbidden, nil); err != nil {
-		t.Fatalf("classifyDopplerStatus(403, nil) = %v, want nil", err)
+// TestResolveNotFoundNamesProjectAndConfig pins the one status that keeps a
+// message of its own rather than httpcore's: a 404 says which project and
+// config the secret was looked for in, which the status alone does not.
+func TestResolveNotFoundNamesProjectAndConfig(t *testing.T) {
+	p := statusServerProvider(t, http.StatusNotFound, `{"messages":["Could not find requested secret"]}`)
+	_, err := p.Resolve(context.Background(), mustRef(t, "doppler://"+testProject+"/"+testConfig+"#MISSING"))
+	if !errors.Is(err, mamori.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
-}
-
-// TestClassifyDopplerStatusUnknownReturnsStatusErrorVerbatim asserts that an
-// unmapped status returns the original statusErr unchanged (not re-wrapped),
-// so its diagnostic text and type are untouched for a code mamori has no
-// classification for.
-func TestClassifyDopplerStatusUnknownReturnsStatusErrorVerbatim(t *testing.T) {
-	base := errors.New(`mamori/doppler: unexpected status 409 fetching secret "K": conflict`)
-	got := classifyDopplerStatus(http.StatusConflict, base)
-	if got != base {
-		t.Fatalf("classifyDopplerStatus(409, base) = %v, want base returned unchanged", got)
+	msg := err.Error()
+	for _, want := range []string{"MISSING", testProject, testConfig} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("not-found message lost %q: %v", want, err)
+		}
 	}
 }

--- a/providers/doppler/go.mod
+++ b/providers/doppler/go.mod
@@ -2,7 +2,10 @@ module github.com/xavidop/mamori/providers/doppler
 
 go 1.26.0
 
-require github.com/xavidop/mamori v0.1.0
+require (
+	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -21,3 +23,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/doppler/go.sum
+++ b/providers/doppler/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/firebase-rc/errors_test.go
+++ b/providers/firebase-rc/errors_test.go
@@ -1,14 +1,49 @@
 package firebaserc
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-func TestClassifyFirebaseRC(t *testing.T) {
+// statusProvider returns a provider whose Remote Config endpoint answers every
+// request with status and body.
+func statusProvider(t *testing.T, status int, body string) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	p := New(WithProjectID("demo"), WithHTTPClient(srv.Client()), WithBaseURL(srv.URL))
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// TestFetchTemplateClassifiesStatus pins the status-to-kind mapping this
+// provider inherits from httpcore.ClassifyStatus, exercised end to end through
+// Resolve against real responses. There is no longer a hand-rolled
+// classifyFirebaseRC to table-test directly: the mapping lives in one place for
+// every httpcore-backed provider.
+//
+// Three rows differ from the mapping this provider carried before it moved onto
+// httpcore:
+//
+//   - 422 was previously unclassified (KindUnknown). It is now KindInvalid, so
+//     mamori stops retrying a request that can never succeed.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside 429.
+//   - 409, and every other status neither this provider nor httpcore names, was
+//     previously KindUnknown and is now KindUnavailable.
+//
+// 404 is in the table with its ORIGINAL kind, KindUnknown, and that is not an
+// oversight: see notFoundIsNotAMissingParameter for why a 404 on the template
+// endpoint must not reach mamori as ErrNotFound.
+func TestFetchTemplateClassifiesStatus(t *testing.T) {
 	cases := []struct {
 		status int
 		want   mamori.Kind
@@ -16,54 +51,85 @@ func TestClassifyFirebaseRC(t *testing.T) {
 		{http.StatusForbidden, mamori.KindPermissionDenied},
 		{http.StatusUnauthorized, mamori.KindUnauthenticated},
 		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
 		{http.StatusInternalServerError, mamori.KindUnavailable},
 		{http.StatusBadGateway, mamori.KindUnavailable},
 		{http.StatusServiceUnavailable, mamori.KindUnavailable},
 		{http.StatusBadRequest, mamori.KindInvalid},
-		{http.StatusConflict, mamori.KindUnknown},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusConflict, mamori.KindUnavailable},
 		{http.StatusNotFound, mamori.KindUnknown},
 	}
 	for _, tc := range cases {
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
-			err := errors.New("Remote Config API returned " + http.StatusText(tc.status))
-			if got := mamori.ErrorKind(classifyFirebaseRC(tc.status, err)); got != tc.want {
-				t.Fatalf("status %d: ErrorKind = %q, want %q", tc.status, got, tc.want)
+			p := statusProvider(t, tc.status, `{"error":{"status":"NOPE"}}`)
+			_, err := p.Resolve(context.Background(), parse(t, "firebase-rc://welcome"))
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.status)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.status, got, tc.want, err)
 			}
 		})
 	}
 }
 
-// TestClassifyFirebaseRCPreservesUnderlyingError asserts classification
-// double-wraps: the returned error must still satisfy errors.Is against the
-// original API error, not just the sentinel, so diagnostics are not lost.
-func TestClassifyFirebaseRCPreservesUnderlyingError(t *testing.T) {
-	orig := errors.New("Remote Config API returned 403 Forbidden")
-	wrapped := classifyFirebaseRC(http.StatusForbidden, orig)
-
-	if !errors.Is(wrapped, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", wrapped)
+// TestTemplate404IsNotNotFound is the guard for the one status this provider
+// takes back from httpcore's table. A 404 on the template endpoint means the
+// project does not exist or the Remote Config API is not enabled on it, which
+// affects every ref at once; mamori.ErrNotFound is the one kind that makes a
+// field apply its default instead of failing, so a 404 leaking through as
+// not-found would turn a wrong project id into silence.
+func TestTemplate404IsNotNotFound(t *testing.T) {
+	p := statusProvider(t, http.StatusNotFound, `{"error":{"status":"NOT_FOUND","message":"Requested entity was not found."}}`)
+	_, err := p.Resolve(context.Background(), parse(t, "firebase-rc://welcome"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 404 template response")
 	}
-	if !errors.Is(wrapped, orig) {
-		t.Fatalf("underlying error lost: %v", wrapped)
+	if errors.Is(err, mamori.ErrNotFound) {
+		t.Fatalf("a 404 on the template endpoint must not reach mamori as ErrNotFound: %v", err)
+	}
+	// The diagnostic must survive the sentinel being dropped.
+	for _, want := range []string{"404", "Requested entity was not found"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("404 message lost %q: %v", want, err)
+		}
 	}
 }
 
-func TestClassifyFirebaseRCNilIsNil(t *testing.T) {
-	if err := classifyFirebaseRC(http.StatusForbidden, nil); err != nil {
-		t.Fatalf("classifyFirebaseRC(status, nil) = %v, want nil", err)
+// TestFetchTemplateErrorQuotesAPIDiagnostic guards what the migration onto
+// httpcore had to keep: the API's own error body still reaches the message, so
+// an operator sees why a request was refused rather than only its status.
+func TestFetchTemplateErrorQuotesAPIDiagnostic(t *testing.T) {
+	p := statusProvider(t, http.StatusForbidden, `{"error":{"status":"PERMISSION_DENIED"}}`)
+	_, err := p.Resolve(context.Background(), parse(t, "firebase-rc://welcome"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
+	}
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
+	}
+	for _, want := range []string{"403", "PERMISSION_DENIED"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error message lost %q: %v", want, err)
+		}
 	}
 }
 
-// TestClassifyFirebaseRCUnmappedStatusIsUnknown asserts a status with no
-// mapping (e.g. 409 Conflict) reports KindUnknown rather than being guessed
-// at, and that the original error passes through unwrapped in that case.
-func TestClassifyFirebaseRCUnmappedStatusIsUnknown(t *testing.T) {
-	orig := errors.New("Remote Config API returned 409 Conflict")
-	got := classifyFirebaseRC(http.StatusConflict, orig)
-	if got != orig {
-		t.Fatalf("unmapped status: got %v, want the original error unchanged", got)
+// TestErrorDetailIsBounded pins snippet's bound: a hostile or broken upstream
+// must not be able to put an unbounded response body into an error string.
+func TestErrorDetailIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	p := statusProvider(t, http.StatusInternalServerError, strings.Repeat("A", 20000)+marker)
+
+	_, err := p.Resolve(context.Background(), parse(t, "firebase-rc://welcome"))
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
 	}
-	if kind := mamori.ErrorKind(got); kind != mamori.KindUnknown {
-		t.Fatalf("unmapped status kind = %q, want unknown", kind)
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 1000 {
+		t.Fatalf("error message is %d bytes long; the quoted body must be bounded well below the oversized response", len(err.Error()))
 	}
 }

--- a/providers/firebase-rc/firebaserc.go
+++ b/providers/firebase-rc/firebaserc.go
@@ -12,8 +12,9 @@
 //	FeatureFlag    string `source:"firebase-rc://feature_flags#new_ui"`
 //
 // The provider reads the current *server* Remote Config template (the one used
-// by Admin SDK / server workloads) via the Firebase Remote Config REST API and
-// returns the named parameter's default (server-side) value. Parameters that do
+// by Admin SDK / server workloads) via the Firebase Remote Config REST API,
+// over github.com/xavidop/mamori/providers/httpcore, and returns the named
+// parameter's default (server-side) value. Parameters that do
 // not exist, or that are configured to use the in-app default (no server value),
 // resolve to an error satisfying errors.Is(err, mamori.ErrNotFound).
 //
@@ -31,12 +32,14 @@ package firebaserc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -204,10 +207,22 @@ func (p *Provider) buildFetcher(ctx context.Context) (templateFetcher, error) {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
+	// MaxBody is set explicitly rather than left at httpcore's 1 MiB default:
+	// a server Remote Config template is a whole project's parameter set, not
+	// a single value, and this provider has always allowed 16 MiB for one.
+	client, err := httpcore.New(httpcore.Config{
+		BaseURL:     baseURL,
+		HTTPClient:  httpClient,
+		MaxBody:     maxBodyBytes,
+		ErrorDetail: errorDetail,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("firebase-rc: building the Remote Config client: %w", err)
+	}
 	return &httpFetcher{
 		projectID:  projectID,
 		httpClient: httpClient,
-		baseURL:    baseURL,
+		client:     client,
 	}, nil
 }
 
@@ -277,66 +292,71 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 }
 
 // httpFetcher fetches the server Remote Config template over the REST API.
+//
+// httpClient is retained alongside the httpcore client purely so Close can
+// release its idle connections; every request goes through client.
 type httpFetcher struct {
 	projectID  string
 	httpClient *http.Client
-	baseURL    string
+	client     *httpcore.Client
 }
 
 var _ templateFetcher = (*httpFetcher)(nil)
 
-func (f *httpFetcher) fetchTemplate(ctx context.Context) (*template, error) {
-	url := fmt.Sprintf("%s/projects/%s/remoteConfig", f.baseURL, f.projectID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("firebase-rc: building request: %w", err)
-	}
-	resp, err := f.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("firebase-rc: fetching template: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("firebase-rc: reading template response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		apiErr := fmt.Errorf("firebase-rc: Remote Config API returned %s: %s", resp.Status, snippet(body))
-		return nil, classifyFirebaseRC(resp.StatusCode, apiErr)
-	}
-	return decodeTemplate(body)
-}
-
-// classifyFirebaseRC maps a Remote Config REST API HTTP status onto a mamori
-// classification sentinel. Unlike the Azure and GCP SDKs, the REST API has no
-// structured error type to pattern-match with errors.As; the status code is
-// already in hand at the fetch call site (fetchTemplate), so it is classified
-// directly there rather than recovered from the error afterward.
+// fetchTemplate reads the current server template.
 //
-// A status this provider has no mapping for (e.g. 409 Conflict) is returned
-// unclassified rather than guessed at.
-func classifyFirebaseRC(statusCode int, err error) error {
-	if err == nil {
-		return nil
+// The status is classified by httpcore.Client.Do, with one status taken back:
+// see notFoundIsNotAMissingParameter below.
+func (f *httpFetcher) fetchTemplate(ctx context.Context) (*template, error) {
+	resp, err := f.client.Do(ctx, httpcore.Request{
+		Path: "/projects/" + url.PathEscape(f.projectID) + "/remoteConfig",
+	})
+	if err != nil {
+		return nil, notFoundIsNotAMissingParameter(err)
 	}
-	var sentinel error
-	switch {
-	case statusCode == http.StatusForbidden:
-		sentinel = mamori.ErrPermissionDenied
-	case statusCode == http.StatusUnauthorized:
-		sentinel = mamori.ErrUnauthenticated
-	case statusCode == http.StatusTooManyRequests:
-		sentinel = mamori.ErrRateLimited
-	case statusCode >= http.StatusInternalServerError:
-		sentinel = mamori.ErrUnavailable
-	case statusCode == http.StatusBadRequest:
-		sentinel = mamori.ErrInvalid
-	default:
-		return err
-	}
-	return fmt.Errorf("%w: %w", sentinel, err)
+	return decodeTemplate(resp.Body)
 }
+
+// notFoundIsNotAMissingParameter keeps an HTTP 404 from this API out of
+// mamori's not-found kind.
+//
+// httpcore.ClassifyStatus maps 404 to mamori.ErrNotFound, which is correct for
+// a provider whose request addresses one value: the value is absent. This
+// request addresses a whole project's template, so a 404 means the project does
+// not exist or the Remote Config API is not enabled on it - a misconfiguration
+// affecting every ref at once. ErrNotFound is the one kind that makes mamori
+// apply a field's default instead of failing, so letting it through would turn
+// a wrong project id into every firebase-rc field silently taking its default,
+// announcing nothing. A missing PARAMETER is reported as ErrNotFound by Resolve
+// itself, from the decoded template, and that is the only thing that should be.
+//
+// The cause is rendered into the message rather than wrapped, the one place in
+// this package that does so, and deliberately: errors.Is offers no way to veto
+// a sentinel that is already in the chain, so keeping the chain whole here
+// would keep mamori.ErrNotFound reachable with it. Everything the message
+// carried - the status, the API's own diagnostic snippet - survives as text,
+// and the kind goes back to being unclassified, exactly as it was before this
+// provider moved onto httpcore.
+func notFoundIsNotAMissingParameter(err error) error {
+	if errors.Is(err, mamori.ErrNotFound) {
+		return fmt.Errorf("firebase-rc: fetching Remote Config template: %s", err)
+	}
+	// One %w: the cause already carries the sentinel httpcore classified it
+	// with, and adding a second would replace that kind rather than duplicate
+	// it.
+	return fmt.Errorf("firebase-rc: fetching Remote Config template: %w", err)
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it lifts a short prefix of
+// a failing response's body into the error message, so an operator sees the
+// API's own diagnostic ("PERMISSION_DENIED", "Requested entity was not found")
+// rather than only a status. httpcore calls it only for a status it has
+// already decided is a failure, never for the 200 whose body is the template.
+//
+// A Remote Config template is not secret material (parameters are served to
+// clients), and the error envelope is a status plus a reason, so quoting a
+// bounded prefix of it discloses nothing a resolved value would.
+func errorDetail(_ int, body []byte) string { return snippet(body) }
 
 // restTemplate is the decoded subset of the Remote Config REST response.
 type restTemplate struct {

--- a/providers/firebase-rc/firebaserc_test.go
+++ b/providers/firebase-rc/firebaserc_test.go
@@ -154,7 +154,7 @@ func TestResolveNotFound(t *testing.T) {
 // TestResolvePendingErrorSurvives verifies that an error injected through the
 // fakeBackend pending-error seam (used by providertest's ErrorClassification
 // case) reaches Resolve's caller unchanged: fakeBackend.fetchTemplate returns
-// it directly (it never touches classifyFirebaseRC, which only runs inside
+// it directly (it never touches status classification, which only runs inside
 // httpFetcher.fetchTemplate), and Resolve must not mangle or lose the
 // sentinel on the way out.
 func TestResolvePendingErrorSurvives(t *testing.T) {
@@ -354,16 +354,14 @@ func TestHTTPFetcherErrorStatus(t *testing.T) {
 	}
 }
 
-// TestResolveClassifiesHTTPStatus exercises classifyFirebaseRC through Resolve
-// -> httpFetcher.fetchTemplate itself, not just as a direct function call.
-// Neither the conformance ErrorClassification case nor
-// TestResolvePendingErrorSurvives can catch a regression here: both go
-// through fakeBackend, whose fetchTemplate returns an injected error directly
-// and never calls classifyFirebaseRC, so they would still pass even if the
-// classifyFirebaseRC call were deleted from httpFetcher.fetchTemplate. This
-// test drives a real 403 response through an httptest.Server, the same shape
-// a live Remote Config API failure would take, so it fails if the wiring is
-// removed.
+// TestResolveClassifiesHTTPStatus exercises status classification through
+// Resolve -> httpFetcher.fetchTemplate. Neither the conformance
+// ErrorClassification case nor TestResolvePendingErrorSurvives can catch a
+// regression here: both go through fakeBackend, whose fetchTemplate returns an
+// injected error directly and never performs a request, so they would still
+// pass even if the classification were dropped. This test drives a real 403
+// response through an httptest.Server, the same shape a live Remote Config API
+// failure would take, so it fails if the wiring is removed.
 func TestResolveClassifiesHTTPStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"error":{"status":"PERMISSION_DENIED"}}`, http.StatusForbidden)

--- a/providers/firebase-rc/go.mod
+++ b/providers/firebase-rc/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
 	golang.org/x/oauth2 v0.36.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -25,3 +25,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/firebase-rc/go.sum
+++ b/providers/firebase-rc/go.sum
@@ -1,6 +1,5 @@
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/httpcore/do.go
+++ b/providers/httpcore/do.go
@@ -87,7 +87,7 @@ func (c *Client) Do(ctx context.Context, r Request) (*Response, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("httpcore: %s %s: %w: %w",
-			req.Method, redactURL(req.URL), mamori.ErrUnavailable, redactTransportError(err, req.URL))
+			req.Method, c.redactURL(req.URL), mamori.ErrUnavailable, c.redactTransportError(err, req.URL))
 	}
 	// Drain and close on every path so the connection is reused rather than
 	// abandoned. This is the hygiene issue #107 found missing across providers.
@@ -110,7 +110,7 @@ func (c *Client) Do(ctx context.Context, r Request) (*Response, error) {
 		if c.errorDetail != nil {
 			err = classify(resp.StatusCode, c.errorDetail(resp.StatusCode, readErrorBody(resp.Body, c.maxBody)))
 		}
-		return nil, fmt.Errorf("httpcore: %s %s: %w", req.Method, redactURL(req.URL), err)
+		return nil, fmt.Errorf("httpcore: %s %s: %w", req.Method, c.redactURL(req.URL), err)
 	}
 	if out.NotModified {
 		return out, nil
@@ -118,7 +118,7 @@ func (c *Client) Do(ctx context.Context, r Request) (*Response, error) {
 
 	body, err := readBounded(resp.Body, c.maxBody)
 	if err != nil {
-		return nil, fmt.Errorf("httpcore: %s %s: %w", req.Method, redactURL(req.URL), err)
+		return nil, fmt.Errorf("httpcore: %s %s: %w", req.Method, c.redactURL(req.URL), err)
 	}
 	out.Body = body
 	return out, nil
@@ -152,7 +152,7 @@ func (c *Client) build(ctx context.Context, r Request) (*http.Request, error) {
 	}
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
-		return nil, fmt.Errorf("httpcore: building %s %s: %w: %w", method, redactURL(&u), mamori.ErrInvalid, err)
+		return nil, fmt.Errorf("httpcore: building %s %s: %w: %w", method, c.redactURL(&u), mamori.ErrInvalid, err)
 	}
 
 	for k, vs := range r.Header {
@@ -343,14 +343,39 @@ func readErrorBody(r io.Reader, max int64) []byte {
 	return b
 }
 
-// redactURL renders a URL for an error message with its query and userinfo
+// redactURL renders a URL for one of this Client's error messages, applying the
+// Client's [Config.RedactPath] to the path.
+func (c *Client) redactURL(u *url.URL) string {
+	return redactURLWith(u, c.redactPath)
+}
+
+// redactURLWith renders a URL for an error message with its query and userinfo
 // stripped, because QueryAuth puts a credential in the query and a URL can
-// carry userinfo.
-func redactURL(u *url.URL) string {
+// carry userinfo, and with its path passed through redactPath.
+//
+// A nil redactPath renders the path verbatim, exactly as this did before the
+// hook existed. It takes the hook as an argument rather than reading it off a
+// Client because checkTokenURLScheme renders a URL before
+// OAuth2ClientCredentials has built one, and that site needs the hook too:
+// [OAuth2Config.RedactPath] hands it over directly.
+//
+// The hook's result is concatenated rather than assigned back to the copy's
+// Path, because url.URL.String escapes Path on the way out: a placeholder like
+// "<account>" assigned there would render as "%3Caccount%3E". Clearing the path
+// and appending leaves exactly what the provider wrote. The fragment is cleared
+// with it, since keeping it would render it BEFORE the appended path; no URL
+// Client.build produces has one, and a fragment never reaches the wire anyway.
+func redactURLWith(u *url.URL, redactPath func(string) string) string {
 	c := *u
 	c.RawQuery = ""
 	c.User = nil
-	return c.String()
+	if redactPath == nil {
+		return c.String()
+	}
+	redacted := redactPath(u.EscapedPath())
+	c.Path, c.RawPath = "", ""
+	c.Fragment, c.RawFragment = "", ""
+	return c.String() + redacted
 }
 
 // redactTransportError strips the credential that net/http leaks into the error
@@ -366,10 +391,15 @@ func redactURL(u *url.URL) string {
 // The wrapper is rebuilt rather than discarded so the chain stays whole:
 // errors.As still reaches *url.Error, and errors.Is still reaches the underlying
 // net.OpError, timeout, or TLS verification error.
-func redactTransportError(err error, u *url.URL) error {
+//
+// The URL it is rebuilt with goes through [Config.RedactPath] like every other
+// rendered URL. Skipping it here would leave the hook trivially defeatable: the
+// path a provider asked to have hidden would still be one errors.As away, and it
+// would render into the very same message through the wrapped cause.
+func (c *Client) redactTransportError(err error, u *url.URL) error {
 	var ue *url.Error
 	if !errors.As(err, &ue) {
 		return err
 	}
-	return &url.Error{Op: ue.Op, URL: redactURL(u), Err: ue.Err}
+	return &url.Error{Op: ue.Op, URL: c.redactURL(u), Err: ue.Err}
 }

--- a/providers/httpcore/do_test.go
+++ b/providers/httpcore/do_test.go
@@ -653,6 +653,195 @@ func TestDoTransportErrorRedactsURLWithoutBreakingChain(t *testing.T) {
 	}
 }
 
+// pathIDMarker stands in for an identifier a provider carries as a path
+// segment: an account id, a namespace id, an organisation. Like the two markers
+// above it must not appear in any mamori sentinel's own text, so an assertion
+// trips on a real leak rather than on the sentinel.
+const pathIDMarker = "s3cr3t-path-id-4b8e"
+
+// pathIDPlaceholder is what hidePathID substitutes for pathIDMarker. It is
+// asserted on as well as the marker's absence, so a hook that silently dropped
+// the whole path, or was never called at all, cannot pass.
+const pathIDPlaceholder = "<id>"
+
+// hidePathID is the Config.RedactPath hook the tests below install: the shape a
+// path-identified provider writes, substituting a placeholder for an identifier
+// rather than discarding the path.
+func hidePathID(path string) string {
+	return strings.ReplaceAll(path, pathIDMarker, pathIDPlaceholder)
+}
+
+// TestDoRedactPathHidesPathFromClassifiedStatusError covers the wrap site that
+// renders a URL once ClassifyStatus has rejected the response: the commonest
+// error any provider returns, and the one an operator is most likely to paste
+// somewhere.
+func TestDoRedactPathHidesPathFromClassifiedStatusError(t *testing.T) {
+	c, err := New(Config{
+		BaseURL:    "https://api.test",
+		RedactPath: hidePathID,
+		HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+			resp, _ := newResponse(http.StatusForbidden, nil, nil)
+			return resp, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), Request{Path: "accounts/" + pathIDMarker + "/values/k"})
+	if err == nil {
+		t.Fatal("Do with 403 returned nil error")
+	}
+	if strings.Contains(err.Error(), pathIDMarker) {
+		t.Fatalf("path identifier leaked into the classified-status error %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), pathIDPlaceholder) {
+		t.Fatalf("RedactPath was not applied to the classified-status error %q", err.Error())
+	}
+}
+
+// TestDoRedactPathHidesPathFromTransportError covers the transport-failure wrap
+// site, and with it the subtle half of this hook: Do rebuilds net/http's
+// *url.Error with a redacted URL, and that rebuilt URL must go through
+// RedactPath too. Skipping it there would leave the path one errors.As away,
+// and would render it into the very same message through the wrapped cause, so
+// the assertions are made against both the message and the *url.Error itself.
+//
+// The chain assertions are the other half: the rebuild exists to keep
+// errors.As reaching *url.Error and errors.Is reaching the transport's own
+// cause, and a hook must not be an excuse to start discarding either.
+func TestDoRedactPathHidesPathFromTransportError(t *testing.T) {
+	sentinel := errors.New("dial tcp: connection refused")
+	c, err := New(Config{
+		BaseURL:    "https://api.test",
+		RedactPath: hidePathID,
+		HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+			return nil, sentinel
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), Request{Path: "accounts/" + pathIDMarker + "/values/k"})
+	if err == nil {
+		t.Fatal("Do with a transport error returned nil error")
+	}
+	if strings.Contains(err.Error(), pathIDMarker) {
+		t.Fatalf("path identifier leaked into the transport error %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), pathIDPlaceholder) {
+		t.Fatalf("RedactPath was not applied to the transport error %q", err.Error())
+	}
+
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Fatalf("errors.As(err, *url.Error) = false for %v", err)
+	}
+	if strings.Contains(urlErr.URL, pathIDMarker) {
+		t.Fatalf("urlErr.URL = %q: RedactPath was skipped on the *url.Error rebuild", urlErr.URL)
+	}
+	if !strings.Contains(urlErr.URL, pathIDPlaceholder) {
+		t.Fatalf("urlErr.URL = %q, want the RedactPath placeholder", urlErr.URL)
+	}
+	if !errors.Is(err, mamori.ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("cause lost from %v", err)
+	}
+}
+
+// TestDoRedactPathHidesPathFromRequestBuildError covers the third wrap site,
+// the one reached before anything is sent: http.NewRequestWithContext rejects
+// the request and httpcore renders the URL it would have called. An invalid
+// method is what drives it here, because it fails on a URL that is otherwise
+// perfectly well formed.
+func TestDoRedactPathHidesPathFromRequestBuildError(t *testing.T) {
+	c, err := New(Config{
+		BaseURL:    "https://api.test",
+		RedactPath: hidePathID,
+		HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+			t.Error("a request that could not be built reached the transport")
+			return newResponseOK()
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), Request{
+		Method: "BAD METHOD",
+		Path:   "accounts/" + pathIDMarker + "/values/k",
+	})
+	if err == nil {
+		t.Fatal("Do with an invalid method returned nil error")
+	}
+	if strings.Contains(err.Error(), pathIDMarker) {
+		t.Fatalf("path identifier leaked into the request-build error %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), pathIDPlaceholder) {
+		t.Fatalf("RedactPath was not applied to the request-build error %q", err.Error())
+	}
+}
+
+// TestDoRedactPathHidesPathFromOversizedBodyError covers the fourth and last
+// wrap site, the one a body over MaxBody reaches. It renders the URL through a
+// different fmt.Errorf than the classified-status path directly above it, so
+// nothing but its own test proves the hook reaches it.
+func TestDoRedactPathHidesPathFromOversizedBodyError(t *testing.T) {
+	c, err := New(Config{
+		BaseURL:    "https://api.test",
+		MaxBody:    8,
+		RedactPath: hidePathID,
+		HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+			resp, _ := newResponse(http.StatusOK, []byte(strings.Repeat("x", 64)), nil)
+			return resp, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), Request{Path: "accounts/" + pathIDMarker + "/values/k"})
+	if err == nil {
+		t.Fatal("Do with an oversized body returned nil error")
+	}
+	if strings.Contains(err.Error(), pathIDMarker) {
+		t.Fatalf("path identifier leaked into the oversized-body error %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), pathIDPlaceholder) {
+		t.Fatalf("RedactPath was not applied to the oversized-body error %q", err.Error())
+	}
+}
+
+// TestDoNilRedactPathRendersPathVerbatim pins the default. Every provider whose
+// path names nothing but a key wants the path in its errors, and that is the
+// overwhelming majority of them: a hook that quietly changed how an
+// unconfigured Client renders a URL would make every one of their messages
+// worse to pay for a guarantee they did not ask for.
+func TestDoNilRedactPathRendersPathVerbatim(t *testing.T) {
+	c, err := New(Config{
+		BaseURL: "https://api.test",
+		HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+			resp, _ := newResponse(http.StatusForbidden, nil, nil)
+			return resp, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), Request{Path: "accounts/" + pathIDMarker + "/values/k"})
+	if err == nil {
+		t.Fatal("Do with 403 returned nil error")
+	}
+	want := "https://api.test/accounts/" + pathIDMarker + "/values/k"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not render the URL as %q: a nil RedactPath must change nothing", err.Error(), want)
+	}
+}
+
 // TestDoPreservesAuthenticatorClassification pins that Do does not overwrite a
 // kind an Authenticator already chose.
 //

--- a/providers/httpcore/httpcore.go
+++ b/providers/httpcore/httpcore.go
@@ -79,6 +79,40 @@ type Config struct {
 	// providers/cloudflare-kv, providers/vercel-gc, and providers/scaleway-sm,
 	// and a migration onto httpcore must be able to preserve it.
 	ErrorDetail func(status int, body []byte) string
+	// RedactPath renders a request path for an error message. It receives the
+	// ESCAPED path, exactly as it appears in the URL, and returns whatever
+	// should stand in its place.
+	//
+	// Nil renders the path verbatim, which is what a provider whose path
+	// carries nothing but a key name wants.
+	//
+	// It exists because a body is not the only thing that leaks. ErrorDetail
+	// guards the response body, and the URL rendered into every error already
+	// has its query string and any userinfo stripped, on the reasoning that a
+	// credential travels there. The path was left alone because for most
+	// backends it names a key. For a backend that addresses its tenant through
+	// the path it does not: an account id in a path is as identifying as a
+	// token in a query, and it reaches an operator's logs, a mamori status
+	// page, and whatever gets pasted into an issue, on nothing worse than a
+	// refused connection. providers/cloudflare-kv carries an account id and a
+	// namespace id as path segments, providers/hcp-vault-secrets an
+	// organisation, project, app and secret name, providers/heroku an app
+	// name, providers/infisical a secret name.
+	//
+	// It is a hook rather than something httpcore decides because only the
+	// provider knows which of its own segments identify anything. Substituting
+	// here, rather than rewriting httpcore's finished message afterwards as
+	// providers/cloudflare-kv had to before this existed, is also what keeps
+	// the error chain honest: nothing is rewritten, so errors.Is and errors.As
+	// still reach everything they reached before.
+	//
+	// It applies at every site that renders a URL into an error, including the
+	// *url.Error that [Client.Do] rebuilds around a transport failure, so the
+	// chain cannot be used to read around it. It does not apply to New's own
+	// rejection of a BaseURL: that message echoes the operator's configured
+	// string verbatim so a typo is recognizable, and a BaseURL that failed to
+	// parse has no path to hand a path hook.
+	RedactPath func(path string) string
 }
 
 // Client performs bounded, classified HTTP round trips against one backend. It
@@ -92,6 +126,7 @@ type Client struct {
 	maxBody     int64
 	userAgent   string
 	errorDetail func(status int, body []byte) string
+	redactPath  func(path string) string
 }
 
 // New validates cfg and returns a Client. It fails when BaseURL is empty or
@@ -125,5 +160,6 @@ func New(cfg Config) (*Client, error) {
 		maxBody:     maxBody,
 		userAgent:   cfg.UserAgent,
 		errorDetail: cfg.ErrorDetail,
+		redactPath:  cfg.RedactPath,
 	}, nil
 }

--- a/providers/httpcore/oauth2.go
+++ b/providers/httpcore/oauth2.go
@@ -47,6 +47,16 @@ type OAuth2Config struct {
 	// That is a higher-value leak than a cleartext BaseURL, which is why the
 	// opt-in is required here too.
 	AllowInsecure bool
+	// RedactPath is [Config.RedactPath] for the token endpoint, applied both to
+	// the TokenURL this rejects at construction and to every error the exchange
+	// itself returns.
+	//
+	// A token endpoint identifies its tenant through the path often enough to
+	// need this: Microsoft Entra's is
+	// https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token, and the
+	// tenant id there is exactly as identifying as the account id a resource
+	// path carries.
+	RedactPath func(path string) string
 }
 
 // oauth2Auth caches one access token and refreshes it before expiry.
@@ -125,11 +135,11 @@ func OAuth2ClientCredentials(cfg OAuth2Config) (Authenticator, error) {
 		return nil, fmt.Errorf("httpcore: OAuth2 ClientSecret is required: %w", mamori.ErrInvalid)
 	}
 
-	if err := checkTokenURLScheme(cfg.TokenURL, cfg.AllowInsecure); err != nil {
+	if err := checkTokenURLScheme(cfg.TokenURL, cfg.AllowInsecure, cfg.RedactPath); err != nil {
 		return nil, err
 	}
 
-	client, err := New(Config{BaseURL: cfg.TokenURL, HTTPClient: cfg.HTTPClient})
+	client, err := New(Config{BaseURL: cfg.TokenURL, HTTPClient: cfg.HTTPClient, RedactPath: cfg.RedactPath})
 	if err != nil {
 		return nil, fmt.Errorf("httpcore: OAuth2 TokenURL: %w", err)
 	}
@@ -182,7 +192,7 @@ func OAuth2ClientCredentials(cfg OAuth2Config) (Authenticator, error) {
 // configuration value it fetches; a cleartext TokenURL exposes the client
 // secret, which the client-credentials grant POSTs in the form body, and that
 // secret is the key to every value the endpoint serves.
-func checkTokenURLScheme(tokenURL string, allowInsecure bool) error {
+func checkTokenURLScheme(tokenURL string, allowInsecure bool, redactPath func(string) string) error {
 	u, err := url.Parse(tokenURL)
 	if err != nil {
 		// The unparsed string is not echoed: a URL can carry userinfo, and this
@@ -195,7 +205,7 @@ func checkTokenURLScheme(tokenURL string, allowInsecure bool) error {
 	case "http":
 		if !allowInsecure {
 			return fmt.Errorf("httpcore: OAuth2 TokenURL %s is http://, which POSTs the client secret in cleartext; set AllowInsecure to accept that: %w",
-				redactURL(u), mamori.ErrInvalid)
+				redactURLWith(u, redactPath), mamori.ErrInvalid)
 		}
 		return nil
 	default:

--- a/providers/httpcore/oauth2_test.go
+++ b/providers/httpcore/oauth2_test.go
@@ -392,3 +392,61 @@ func TestOAuth2ConcurrentApply(t *testing.T) {
 		t.Fatalf("exchanges = %d, want 1 under concurrency", exchanges)
 	}
 }
+
+// TestOAuth2RedactPathHidesTokenURLPath pins that OAuth2Config.RedactPath
+// reaches both places a token endpoint's URL is rendered into an error: the
+// scheme rejection at construction, and every error the exchange itself
+// returns through the Client this builds for the token endpoint.
+//
+// A token endpoint identifies its tenant through the path often enough to need
+// this. Microsoft Entra's is
+// https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token, and a tenant id
+// there is exactly as identifying as an account id in a resource path.
+func TestOAuth2RedactPathHidesTokenURLPath(t *testing.T) {
+	tokenURL := "http://idp.test/" + pathIDMarker + "/oauth2/token"
+
+	t.Run("scheme rejection", func(t *testing.T) {
+		_, err := OAuth2ClientCredentials(OAuth2Config{
+			TokenURL:     tokenURL,
+			ClientID:     "cid",
+			ClientSecret: clientSecretMarker,
+			RedactPath:   hidePathID,
+		})
+		if err == nil {
+			t.Fatal("OAuth2ClientCredentials with an http:// TokenURL returned nil error")
+		}
+		if strings.Contains(err.Error(), pathIDMarker) {
+			t.Fatalf("path identifier leaked into the scheme rejection %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), pathIDPlaceholder) {
+			t.Fatalf("RedactPath was not applied to the scheme rejection %q", err.Error())
+		}
+	})
+
+	t.Run("exchange", func(t *testing.T) {
+		auth, err := OAuth2ClientCredentials(OAuth2Config{
+			TokenURL:      tokenURL,
+			ClientID:      "cid",
+			ClientSecret:  clientSecretMarker,
+			AllowInsecure: true,
+			RedactPath:    hidePathID,
+			HTTPClient: fakeClient(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("dial tcp: connection refused")
+			}),
+		})
+		if err != nil {
+			t.Fatalf("OAuth2ClientCredentials: %v", err)
+		}
+
+		err = auth.Apply(context.Background(), newTestRequest(t))
+		if err == nil {
+			t.Fatal("Apply with a failing token endpoint returned nil error")
+		}
+		if strings.Contains(err.Error(), pathIDMarker) {
+			t.Fatalf("path identifier leaked into the exchange error %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), pathIDPlaceholder) {
+			t.Fatalf("RedactPath was not applied to the exchange error %q", err.Error())
+		}
+	})
+}

--- a/providers/onepassword/errors_test.go
+++ b/providers/onepassword/errors_test.go
@@ -1,75 +1,127 @@
 package onepassword
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-func TestClassifyOnePassword(t *testing.T) {
+// statusProvider returns a provider pointed at a server that answers every
+// request with status and body.
+func statusProvider(t *testing.T, status int, body string) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(WithHost(srv.URL), WithToken(testToken), WithHTTPClient(srv.Client()))
+}
+
+// TestResolveClassifiesStatus pins the status-to-kind mapping this provider
+// inherits from httpcore.ClassifyStatus, exercised end to end through Resolve
+// against real responses. There is no longer a hand-rolled classifyOnePassword
+// to table-test directly: the mapping lives in one place for every
+// httpcore-backed provider.
+//
+// Three rows differ from the mapping this provider carried before it moved onto
+// httpcore, and each is deliberate:
+//
+//   - 422 was previously unclassified (KindUnknown). It is now KindInvalid, so
+//     mamori stops retrying a request that was well formed and semantically
+//     wrong and can never succeed.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside
+//     429.
+//   - 409, and every other status neither this provider nor httpcore names,
+//     was previously KindUnknown and is now KindUnavailable: httpcore has one
+//     default for an unrecognized status rather than per-provider silence.
+//
+// 404 is absent from the table on purpose: resolveVaultID and resolveItem each
+// translate it into their own not-found message, which TestNotFound covers.
+func TestResolveClassifiesStatus(t *testing.T) {
 	cases := []struct {
-		name   string
 		status int
 		want   mamori.Kind
 	}{
-		{"Forbidden", http.StatusForbidden, mamori.KindPermissionDenied},
-		{"Unauthorized", http.StatusUnauthorized, mamori.KindUnauthenticated},
-		{"TooManyRequests", http.StatusTooManyRequests, mamori.KindRateLimited},
-		{"InternalServerError", http.StatusInternalServerError, mamori.KindUnavailable},
-		{"BadGateway", http.StatusBadGateway, mamori.KindUnavailable},
-		{"ServiceUnavailable", http.StatusServiceUnavailable, mamori.KindUnavailable},
-		{"BadRequest", http.StatusBadRequest, mamori.KindInvalid},
+		{http.StatusForbidden, mamori.KindPermissionDenied},
+		{http.StatusUnauthorized, mamori.KindUnauthenticated},
+		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
+		{http.StatusInternalServerError, mamori.KindUnavailable},
+		{http.StatusBadGateway, mamori.KindUnavailable},
+		{http.StatusServiceUnavailable, mamori.KindUnavailable},
+		{http.StatusBadRequest, mamori.KindInvalid},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusConflict, mamori.KindUnavailable},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := mamori.ErrorKind(classifyOnePassword(tc.status))
-			if got != tc.want {
-				t.Fatalf("ErrorKind(classifyOnePassword(%d)) = %q, want %q", tc.status, got, tc.want)
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			p := statusProvider(t, tc.status, `{"message":"nope"}`)
+			ref, err := mamori.ParseRef("op://" + confVaultName + "/" + confItemTitle + "/password")
+			if err != nil {
+				t.Fatalf("ParseRef: %v", err)
+			}
+			_, err = p.Resolve(context.Background(), ref)
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.status)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.status, got, tc.want, err)
 			}
 		})
 	}
 }
 
-// TestClassifyOnePasswordUnmappedIsNil checks classifyOnePassword's own
-// return value for statuses it does not recognize, including 404 (handled by
-// callers directly, not by this function) and a couple of arbitrary
-// unrecognized codes. It intentionally does not go through mamori.ErrorKind:
-// ErrorKind(nil) is the empty Kind, not KindUnknown, so asserting KindUnknown
-// here would be asserting the wrong thing. The real "an unmapped status
-// stays unknown" guarantee is end-to-end, through statusError, which falls
-// back to the plain (non-nil) message error when classifyOnePassword returns
-// nil; see TestStatusErrorUnmappedStatusIsUnclassified.
-func TestClassifyOnePasswordUnmappedIsNil(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusNotFound, http.StatusTeapot, http.StatusConflict} {
-		if err := classifyOnePassword(status); err != nil {
-			t.Fatalf("classifyOnePassword(%d) = %v, want nil", status, err)
+// TestResolveErrorMessagePreservesContext guards what the migration onto
+// httpcore had to keep: the operation name, the HTTP status, and the verbatim
+// (bounded) Connect diagnostic body all still reach the message, and the
+// classification is still reachable with errors.Is rather than flattened into
+// text.
+func TestResolveErrorMessagePreservesContext(t *testing.T) {
+	p := statusProvider(t, http.StatusForbidden, `{"message":"access denied"}`)
+	ref, err := mamori.ParseRef("op://" + confVaultName + "/" + confItemTitle + "/password")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	_, err = p.Resolve(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
+	}
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"vault lookup", "403", "access denied"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message lost %q: %v", want, err)
 		}
 	}
 }
 
-// TestStatusErrorPreservesMessage guards the %w: %w wrapping in statusError:
-// the classification sentinel must be reachable with errors.Is, and the
-// original op/status/body message must still be reachable in Error(), not
-// discarded in favor of the sentinel alone.
-func TestStatusErrorPreservesMessage(t *testing.T) {
-	err := statusError("vault lookup", http.StatusForbidden, []byte(`{"message":"access denied"}`))
-	if !errors.Is(err, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", err)
-	}
-	if !strings.Contains(err.Error(), "vault lookup") {
-		t.Fatalf("op name lost from message: %v", err)
-	}
-	if !strings.Contains(err.Error(), "403") {
-		t.Fatalf("status code lost from message: %v", err)
-	}
-}
+// TestResolveErrorBodyIsBounded pins errDetailLimit: the diagnostic body quoted
+// into an error must never let a hostile or broken Connect server put an
+// unbounded response into an error string.
+func TestResolveErrorBodyIsBounded(t *testing.T) {
+	const marker = "TAIL_MARKER_MUST_NOT_SURVIVE"
+	p := statusProvider(t, http.StatusInternalServerError, strings.Repeat("A", 20000)+marker)
 
-func TestStatusErrorUnmappedStatusIsUnclassified(t *testing.T) {
-	err := statusError("item lookup", http.StatusConflict, nil)
-	if got := mamori.ErrorKind(err); got != mamori.KindUnknown {
-		t.Fatalf("ErrorKind(statusError(409)) = %q, want %q", got, mamori.KindUnknown)
+	ref, err := mamori.ParseRef("op://" + confVaultName + "/" + confItemTitle + "/password")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	_, err = p.Resolve(context.Background(), ref)
+	if err == nil {
+		t.Fatal("want an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Fatalf("error body was not bounded: the trailing marker reached the error text: %v", err)
+	}
+	if len(err.Error()) > 1000 {
+		t.Fatalf("error message is %d bytes long; the quoted body must be bounded well below the oversized response", len(err.Error()))
 	}
 }

--- a/providers/onepassword/go.mod
+++ b/providers/onepassword/go.mod
@@ -2,7 +2,10 @@ module github.com/xavidop/mamori/providers/onepassword
 
 go 1.26.0
 
-require github.com/xavidop/mamori v0.1.0
+require (
+	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -21,3 +23,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/onepassword/go.sum
+++ b/providers/onepassword/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/onepassword/onepassword.go
+++ b/providers/onepassword/onepassword.go
@@ -9,18 +9,21 @@
 //
 //	DBPassword secret.String `source:"op://Production/postgres/password"`
 //
-// The provider talks to a 1Password Connect server over its REST API using only
-// the Go standard library. The Connect host comes from OP_CONNECT_HOST and the
-// access token from OP_CONNECT_TOKEN (sent as an "Authorization: Bearer" header).
-// Values are always marked Sensitive. 1Password Connect has no native change
-// notification, so this provider is not watchable; mamori polls it.
+// The provider talks to a 1Password Connect server over its REST API using
+// github.com/xavidop/mamori/providers/httpcore and the Go standard library
+// only, inheriting request building, status classification, body bounding and
+// URL redaction from one shared place. The Connect host comes from
+// OP_CONNECT_HOST and the access token from OP_CONNECT_TOKEN (sent as an
+// "Authorization: Bearer" header). Values are always marked Sensitive.
+// 1Password Connect has no native change notification, so this provider is not
+// watchable; mamori polls it.
 package onepassword
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -29,6 +32,7 @@ import (
 	"time"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 )
 
 // Scheme is the URL scheme handled by this provider.
@@ -39,6 +43,12 @@ const (
 	envHost  = "OP_CONNECT_HOST"
 	envToken = "OP_CONNECT_TOKEN"
 )
+
+// errDetailLimit bounds how much of a failing response's body is quoted into
+// an error message. Connect error bodies are diagnostic JSON, not secret
+// values, but the bound is what stops a hostile or broken server turning that
+// diagnostic into an unbounded string.
+const errDetailLimit = 200
 
 func init() { mamori.Register(New()) }
 
@@ -104,9 +114,50 @@ func (p *Provider) effectiveToken() string {
 	return os.Getenv(envToken)
 }
 
+// clientFor builds the httpcore client for one resolve.
+//
+// It is built per call rather than cached because the host and token are read
+// lazily from the environment on every resolve (see effectiveHost and
+// effectiveToken): caching would pin whichever pair happened to be set on the
+// first one. Construction performs no network call and reuses the provider's
+// *http.Client, so the connection pool is shared across resolves regardless.
+func (p *Provider) clientFor(host, token string) (*httpcore.Client, error) {
+	c, err := httpcore.New(httpcore.Config{
+		BaseURL:     strings.TrimRight(host, "/"),
+		HTTPClient:  p.hc,
+		Auth:        httpcore.Bearer(token),
+		ErrorDetail: errorDetail,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("onepassword: building request: %w", err)
+	}
+	return c, nil
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it quotes a bounded
+// prefix of a failing response's body into the error message.
+//
+// Connect's error responses carry a free-text diagnostic message and no
+// machine-readable error code, and they are answers to a lookup rather than to
+// a request that contained a secret, so quoting them is safe. httpcore calls
+// this only for a status it has already decided is a failure, never for the
+// 200 whose body carries the item's field values.
+func errorDetail(_ int, body []byte) string {
+	msg := strings.TrimSpace(string(body))
+	if len(msg) > errDetailLimit {
+		msg = msg[:errDetailLimit]
+	}
+	return msg
+}
+
 // Resolve fetches the field named in ref from 1Password Connect. It returns an
 // error satisfying errors.Is(err, mamori.ErrNotFound) when the vault, item, or
 // field does not exist.
+//
+// A ref path containing a "." or ".." segment is rejected with
+// mamori.ErrInvalid. That check is not here: httpcore.Client.Do enforces it for
+// every provider built on it, in both the literal and the percent-encoded form,
+// so no provider can forget it.
 func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, error) {
 	host := p.effectiveHost()
 	if host == "" {
@@ -122,12 +173,17 @@ func (p *Provider) Resolve(ctx context.Context, ref mamori.Ref) (mamori.Value, e
 		return mamori.Value{}, err
 	}
 
-	vaultID, err := p.resolveVaultID(ctx, host, token, vaultRef)
+	client, err := p.clientFor(host, token)
 	if err != nil {
 		return mamori.Value{}, err
 	}
 
-	item, err := p.resolveItem(ctx, host, token, vaultID, itemRef)
+	vaultID, err := p.resolveVaultID(ctx, client, vaultRef)
+	if err != nil {
+		return mamori.Value{}, err
+	}
+
+	item, err := p.resolveItem(ctx, client, vaultID, itemRef)
 	if err != nil {
 		return mamori.Value{}, err
 	}
@@ -191,16 +247,20 @@ type item struct {
 	Fields  []itemField `json:"fields"`
 }
 
-// resolveVaultID resolves a vault name to its id. If the name filter returns no
-// match it treats the segment as a possible vault id and fetches it directly.
-func (p *Provider) resolveVaultID(ctx context.Context, host, token, vaultRef string) (string, error) {
+// resolveVaultID resolves a vault name to its id. If the name filter does not
+// produce a match it treats the segment as a possible vault id and fetches it
+// directly.
+//
+// A failed filter request is deliberately swallowed rather than returned: the
+// filter is an optimization, and the direct fetch below is the authoritative
+// answer for a segment that is an id rather than a name. That is what this
+// provider has always done for a non-200 filter response; a transport failure
+// now takes the same path as a status failure, since httpcore reports both as
+// an error, and the direct fetch fails identically a moment later.
+func (p *Provider) resolveVaultID(ctx context.Context, c *httpcore.Client, vaultRef string) (string, error) {
 	q := url.Values{}
 	q.Set("filter", fmt.Sprintf(`name eq "%s"`, vaultRef))
-	status, body, err := p.get(ctx, host, token, "/v1/vaults", q)
-	if err != nil {
-		return "", err
-	}
-	if status == http.StatusOK {
+	if body, err := get(ctx, c, "/v1/vaults", q); err == nil {
 		var vaults []vaultSummary
 		if err := json.Unmarshal(body, &vaults); err != nil {
 			return "", fmt.Errorf("onepassword: decoding vaults: %w", err)
@@ -211,39 +271,32 @@ func (p *Provider) resolveVaultID(ctx context.Context, host, token, vaultRef str
 	}
 
 	// Fall back to treating vaultRef as a vault id.
-	status, body, err = p.get(ctx, host, token, "/v1/vaults/"+url.PathEscape(vaultRef), nil)
+	body, err := get(ctx, c, "/v1/vaults/"+url.PathEscape(vaultRef), nil)
 	if err != nil {
-		return "", err
-	}
-	switch status {
-	case http.StatusOK:
-		var v vaultSummary
-		if err := json.Unmarshal(body, &v); err != nil {
-			return "", fmt.Errorf("onepassword: decoding vault: %w", err)
+		if errors.Is(err, mamori.ErrNotFound) {
+			return "", fmt.Errorf("onepassword: vault %q not found: %w", vaultRef, mamori.ErrNotFound)
 		}
-		if v.ID != "" {
-			return v.ID, nil
-		}
-		return vaultRef, nil
-	case http.StatusNotFound:
-		return "", fmt.Errorf("onepassword: vault %q not found: %w", vaultRef, mamori.ErrNotFound)
-	default:
-		return "", statusError("vault lookup", status, body)
+		return "", fmt.Errorf("onepassword: vault lookup: %w", err)
 	}
+	var v vaultSummary
+	if err := json.Unmarshal(body, &v); err != nil {
+		return "", fmt.Errorf("onepassword: decoding vault: %w", err)
+	}
+	if v.ID != "" {
+		return v.ID, nil
+	}
+	return vaultRef, nil
 }
 
 // resolveItem finds an item by title within a vault and fetches it in full
-// (including its fields).
-func (p *Provider) resolveItem(ctx context.Context, host, token, vaultID, itemRef string) (item, error) {
+// (including its fields). A failed title-filter request falls back to treating
+// itemRef as an item id, for the reason resolveVaultID's doc comment gives.
+func (p *Provider) resolveItem(ctx context.Context, c *httpcore.Client, vaultID, itemRef string) (item, error) {
 	q := url.Values{}
 	q.Set("filter", fmt.Sprintf(`title eq "%s"`, itemRef))
-	status, body, err := p.get(ctx, host, token, "/v1/vaults/"+url.PathEscape(vaultID)+"/items", q)
-	if err != nil {
-		return item{}, err
-	}
 
 	var itemID string
-	if status == http.StatusOK {
+	if body, err := get(ctx, c, "/v1/vaults/"+url.PathEscape(vaultID)+"/items", q); err == nil {
 		var items []itemSummary
 		if err := json.Unmarshal(body, &items); err != nil {
 			return item{}, fmt.Errorf("onepassword: decoding items: %w", err)
@@ -257,91 +310,35 @@ func (p *Provider) resolveItem(ctx context.Context, host, token, vaultID, itemRe
 		itemID = itemRef
 	}
 
-	status, body, err = p.get(ctx, host, token, "/v1/vaults/"+url.PathEscape(vaultID)+"/items/"+url.PathEscape(itemID), nil)
+	body, err := get(ctx, c, "/v1/vaults/"+url.PathEscape(vaultID)+"/items/"+url.PathEscape(itemID), nil)
 	if err != nil {
-		return item{}, err
-	}
-	switch status {
-	case http.StatusOK:
-		var it item
-		if err := json.Unmarshal(body, &it); err != nil {
-			return item{}, fmt.Errorf("onepassword: decoding item: %w", err)
+		if errors.Is(err, mamori.ErrNotFound) {
+			return item{}, fmt.Errorf("onepassword: item %q not found: %w", itemRef, mamori.ErrNotFound)
 		}
-		return it, nil
-	case http.StatusNotFound:
-		return item{}, fmt.Errorf("onepassword: item %q not found: %w", itemRef, mamori.ErrNotFound)
-	default:
-		return item{}, statusError("item lookup", status, body)
+		return item{}, fmt.Errorf("onepassword: item lookup: %w", err)
 	}
+	var it item
+	if err := json.Unmarshal(body, &it); err != nil {
+		return item{}, fmt.Errorf("onepassword: decoding item: %w", err)
+	}
+	return it, nil
 }
 
-// get performs a GET against the Connect API and returns the status code and body.
-func (p *Provider) get(ctx context.Context, host, token, path string, query url.Values) (int, []byte, error) {
-	u := strings.TrimRight(host, "/") + path
-	if len(query) > 0 {
-		u += "?" + query.Encode()
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+// get performs one GET against the Connect API and returns the response body.
+// A non-2xx status comes back as an error already carrying the mamori sentinel
+// httpcore classified it with, so callers test it with errors.Is rather than
+// switching on a status code.
+func get(ctx context.Context, c *httpcore.Client, path string, query url.Values) ([]byte, error) {
+	resp, err := c.Do(ctx, httpcore.Request{
+		Path:   path,
+		Query:  query,
+		Header: http.Header{"Accept": {"application/json"}},
+	})
 	if err != nil {
-		return 0, nil, fmt.Errorf("onepassword: building request: %w", err)
+		// One %w: the cause already carries the sentinel that classifies it.
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := p.hc.Do(req)
-	if err != nil {
-		return 0, nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp.StatusCode, nil, fmt.Errorf("onepassword: reading response: %w", err)
-	}
-	return resp.StatusCode, body, nil
-}
-
-// statusError builds an error for an unexpected HTTP status without leaking any
-// secret payload (Connect error bodies are diagnostic JSON, not secret values).
-// The status is routed through classifyOnePassword so callers can recover a
-// mamori classification sentinel with errors.Is or mamori.ErrorKind; a status
-// classifyOnePassword does not recognize comes back unclassified.
-func statusError(op string, status int, body []byte) error {
-	msg := strings.TrimSpace(string(body))
-	if len(msg) > 200 {
-		msg = msg[:200]
-	}
-	err := fmt.Errorf("onepassword: %s: unexpected status %d: %s", op, status, msg)
-	if sentinel := classifyOnePassword(status); sentinel != nil {
-		return fmt.Errorf("%w: %w", sentinel, err)
-	}
-	return err
-}
-
-// classifyOnePassword maps a Connect HTTP status onto a mamori classification
-// sentinel. Connect's error responses carry only a numeric status and a
-// free-text message, no machine-readable error code, so classification is by
-// status code alone.
-//
-// 404 is deliberately not handled here: resolveVaultID and resolveItem each
-// check for it directly, before falling into the statusError path this
-// function feeds, because a missing vault, item, or field needs its own
-// specific message naming what was not found. Statuses with no clear mamori
-// meaning are left unclassified (nil) rather than guessed at.
-func classifyOnePassword(status int) error {
-	switch {
-	case status == http.StatusForbidden:
-		return mamori.ErrPermissionDenied
-	case status == http.StatusUnauthorized:
-		return mamori.ErrUnauthenticated
-	case status == http.StatusTooManyRequests:
-		return mamori.ErrRateLimited
-	case status >= http.StatusInternalServerError:
-		return mamori.ErrUnavailable
-	case status == http.StatusBadRequest:
-		return mamori.ErrInvalid
-	default:
-		return nil
-	}
+	return resp.Body, nil
 }
 
 // Ensure Provider satisfies the core interface. Note: no Watch method is

--- a/providers/onepassword/onepassword_test.go
+++ b/providers/onepassword/onepassword_test.go
@@ -104,11 +104,12 @@ func (f *fakeConnect) set(label, val string) {
 // err is translated into an HTTP status via failStatus rather than being
 // returned as a Go error directly. That matters for what the resulting test
 // proves: if fail instead made the RoundTripper return err as a transport
-// error, err would reach Resolve's caller by straight propagation, and the
-// test would pass even with classifyOnePassword deleted. Going through a real
-// HTTP status forces the classification to be earned through
-// statusError/classifyOnePassword, the same path a live Connect server's 403
-// or 429 would take.
+// error, httpcore would classify that transport failure as
+// mamori.ErrUnavailable, and mamori.ErrorKind tests ErrUnavailable before
+// ErrRateLimited and ErrInvalid, so two of the five cases would report the
+// wrong kind. Going through a real HTTP status forces the classification to be
+// earned through the same status mapping a live Connect server's 403 or 429
+// would take.
 func (f *fakeConnect) fail(err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -123,9 +124,8 @@ func (f *fakeConnect) clear() {
 }
 
 // failStatus maps a mamori classification sentinel onto the HTTP status
-// classifyOnePassword would decode it back from. It is the fake's mirror of
-// classifyOnePassword, used only to reify an injected sentinel as a
-// wire-level response.
+// httpcore.ClassifyStatus decodes it back from. It is used only to reify an
+// injected sentinel as a wire-level response.
 func failStatus(err error) int {
 	switch {
 	case errors.Is(err, mamori.ErrPermissionDenied):
@@ -429,14 +429,13 @@ func TestConformance(t *testing.T) {
 	})
 }
 
-// TestResolveClassifiesNonNotFoundError exercises classifyOnePassword through
-// Resolve itself, not just as a direct function call, using the same
-// pending-error seam as the conformance ErrorClassification case (see the
-// comment on fakeConnect.fail for why 1Password Connect needs that coarser
-// seam). Because fail translates the injected sentinel into a real HTTP
-// status rather than returning it as a Go error, this only passes if
-// statusError still routes through classifyOnePassword: deleting that call
-// makes the error come back unclassified (KindUnknown) and this test fails.
+// TestResolveClassifiesNonNotFoundError exercises status classification
+// through Resolve itself, using the same pending-error seam as the conformance
+// ErrorClassification case (see the comment on fakeConnect.fail for why
+// 1Password Connect needs that coarser seam). Because fail translates the
+// injected sentinel into a real HTTP status rather than returning it as a Go
+// error, this only passes if Resolve still surfaces httpcore's classification
+// rather than flattening it.
 func TestResolveClassifiesNonNotFoundError(t *testing.T) {
 	fake := newFakeConnect()
 	fake.set("password", "s3cr3t")

--- a/providers/scaleway-sm/README.md
+++ b/providers/scaleway-sm/README.md
@@ -175,10 +175,14 @@ status:
 | --- | --- |
 | 401 | `unauthenticated` |
 | 403 | `permission_denied` |
-| 429 | `rate_limited` |
-| 400 | `invalid` |
-| 5xx | `unavailable` |
-| anything else | `unknown` |
+| 408, 429 | `rate_limited` |
+| 400, 422 | `invalid` |
+| 5xx, and any other status not named above | `unavailable` |
+
+The mapping is `httpcore.ClassifyStatus`, shared with every other
+`httpcore`-backed provider, rather than a table private to this module. An
+unrecognized status reports `unavailable` (transient, so mamori backs off and
+retries) rather than `unknown`.
 
 **The 404 caveat.** Scaleway's by-path access route returns the same 404, with no
 distinguishing error code in the body, whether the secret name is unknown, the
@@ -192,7 +196,7 @@ operator disables the newest revision. Either way it degrades silently to the
 field's default or optional handling, exactly as if the secret had never existed
 at all. Scaleway has not published a stable enough error-code vocabulary in the
 response body to key this mapping on anything but the status, so codes not
-listed here report `unknown` rather than being guessed at.
+listed here report `unavailable` rather than being guessed at.
 
 ## Authentication & configuration
 
@@ -259,7 +263,7 @@ revision, see above) to detect a change between ticks.
 | The disabled-revision decision: `?revision` defaulting to `latest_enabled` skips a disabled revision and resolves the newest enabled one; a disabled revision fails to resolve regardless of whether it is addressed via `latest` or by its exact number | **Verified** (`TestResolveLatestEnabledSkipsDisabledRevision`, `TestResolveDisabledRevisionFails`) |
 | `#field` and `#/json/pointer` selection, including a nested pointer | **Verified** (unit tests) |
 | Not-found (unknown secret) | **Verified** (`TestResolveUnknownSecretIsNotFound`) |
-| Error classification (401/403/429/400/5xx), exercised through `Resolve` and by table tests against `classifyStatus` directly | **Verified** (unit tests + `providertest` `ErrorClassification` case) |
+| Error classification (401/403/400/422/408/429, and an unnamed status such as 418 as `unavailable`), exercised through `Resolve` | **Verified** (unit tests + `providertest` `ErrorClassification` case) |
 | Credentials never reach an error: the secret key and project id never appear in an error string, from a live transport failure or a malformed `WithBaseURL` | **Verified** (`TestResolveTransportErrorNeverLeaksCredentials`, `TestResolveMalformedBaseURLNeverLeaksCredentials`) |
 | No cache: repeated resolves of an unchanged secret cost one request each, and a failure injected between resolves is observed on the very next call | **Verified** (`TestResolveNeverCaches`) |
 | Context cancellation | **Verified** (`TestResolveHonorsContextCancellation`) |

--- a/providers/scaleway-sm/conformance_test.go
+++ b/providers/scaleway-sm/conformance_test.go
@@ -2,36 +2,27 @@ package scalewaysm
 
 import (
 	"context"
-	"errors"
-	"net/http"
 	"sync"
 	"testing"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 	"github.com/xavidop/mamori/providertest"
 )
 
 // statusForFailure maps the mamori sentinel providertest.RunErrorClassification
-// injects to the HTTP status that would produce it through classifyStatus.
-// This provider's client surfaces a failure as a status code on the request,
-// not as a mamori error, so the conformance Fail hook has to invert that
-// mapping to actually exercise every classification case; injecting one fixed
-// status regardless of err would only ever exercise the case that status
-// happens to map to (see classifyStatus's doc comment for the mapping this
-// mirrors).
+// injects to the HTTP status that produces it. This provider's client surfaces
+// a failure as a status code on the request, not as a mamori error, so the
+// conformance Fail hook has to invert the classification to actually exercise
+// every case; injecting one fixed status regardless of err would only ever
+// exercise the case that status happens to map to.
+//
+// The inverse is httpcore.StatusForKind rather than a switch copied into this
+// file: a hand-rolled inverse that drifts from the forward table does not fail
+// loudly, it just makes this case exercise one classification five times while
+// still reporting green.
 func statusForFailure(err error) int {
-	switch {
-	case errors.Is(err, mamori.ErrPermissionDenied):
-		return http.StatusForbidden
-	case errors.Is(err, mamori.ErrUnauthenticated):
-		return http.StatusUnauthorized
-	case errors.Is(err, mamori.ErrRateLimited):
-		return http.StatusTooManyRequests
-	case errors.Is(err, mamori.ErrInvalid):
-		return http.StatusBadRequest
-	default: // mamori.ErrUnavailable and anything unrecognized
-		return http.StatusServiceUnavailable
-	}
+	return httpcore.StatusForKind(mamori.ErrorKind(err))
 }
 
 // TestConformance runs the shared providertest kit against this provider,
@@ -45,8 +36,8 @@ func statusForFailure(err error) int {
 // cases must skip on their own because the type assertion to
 // mamori.WatchableProvider fails, not because this test told them to.
 // NoResolveErrors is likewise left unset: Resolve classifies HTTP status
-// through classifyStatus and Fail/Clear give the kit a real seam to inject
-// through, so this provider owes the ErrorClassification case.
+// through httpcore and Fail/Clear give the kit a real seam to inject through,
+// so this provider owes the ErrorClassification case.
 func TestConformance(t *testing.T) {
 	f := newFakeSM()
 
@@ -86,11 +77,10 @@ func TestConformance(t *testing.T) {
 			return nil
 		},
 		Fail: func(_ context.Context, key string, err error) error {
-			// Map the injected sentinel back to the HTTP status that produces it
-			// through the real classifyStatus, so all five ErrorClassification
-			// cases round-trip through the actual status-to-error mapping instead
-			// of only ever exercising whichever one a single hard-coded status
-			// happens to hit.
+			// Map the injected sentinel back to the HTTP status that produces it,
+			// so all five ErrorClassification cases round-trip through the
+			// actual status-to-error mapping instead of only ever exercising
+			// whichever one a single hard-coded status happens to hit.
 			f.failStatus("/", key, statusForFailure(err))
 			return nil
 		},

--- a/providers/scaleway-sm/errors_test.go
+++ b/providers/scaleway-sm/errors_test.go
@@ -1,71 +1,87 @@
 package scalewaysm
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-// TestClassifyStatusUnmappedIsUnknown asserts that a status classifyStatus has
-// no case for (teapot, chosen because no real Secret Manager response uses
-// it) reports mamori.KindUnknown, and returns statusErr unchanged rather than
-// re-wrapping it.
-func TestClassifyStatusUnmappedIsUnknown(t *testing.T) {
-	base := errors.New(`mamori/scaleway-sm: unexpected status 418 accessing secret "k": teapot`)
-	got := classifyStatus(http.StatusTeapot, base)
-
-	if got != base {
-		t.Fatalf("classifyStatus(418, base) = %v, want base returned unchanged", got)
-	}
-	if kind := mamori.ErrorKind(got); kind != mamori.KindUnknown {
-		t.Fatalf("ErrorKind = %q, want %q", kind, mamori.KindUnknown)
-	}
-}
-
-func TestClassifyStatusNilIsNil(t *testing.T) {
-	if err := classifyStatus(http.StatusForbidden, nil); err != nil {
-		t.Fatalf("classifyStatus(403, nil) = %v, want nil", err)
-	}
-}
-
-// TestClassifyStatusPreservesChain asserts that the diagnostic text in
-// statusErr stays reachable through errors.Is after classification wraps it
-// with a sentinel, so nothing throws away the original context.
-func TestClassifyStatusPreservesChain(t *testing.T) {
-	base := errors.New(`mamori/scaleway-sm: unexpected status 403 accessing secret "k": forbidden`)
-	wrapped := classifyStatus(http.StatusForbidden, base)
-
-	if !errors.Is(wrapped, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", wrapped)
-	}
-	if !errors.Is(wrapped, base) {
-		t.Fatalf("underlying status error no longer reachable: %v", wrapped)
-	}
-}
-
-// TestClassifyStatusMapsOrdinaryHTTPSemantics pins classifyStatus's mapping
-// for every status this provider is documented to recognize.
-func TestClassifyStatusMapsOrdinaryHTTPSemantics(t *testing.T) {
-	tests := []struct {
+// TestResolveClassifiesStatus pins the status-to-kind mapping this provider
+// inherits from httpcore.ClassifyStatus, exercised end to end through Resolve
+// against a real response. There is no longer a hand-rolled classifyStatus to
+// table-test directly: the mapping lives in one place for every httpcore-backed
+// provider.
+//
+// Three rows differ from the mapping this provider carried before it moved onto
+// httpcore, and each is deliberate:
+//
+//   - 422 was previously unclassified (KindUnknown), so mamori treated it as an
+//     unknown failure and kept retrying a request that was well formed and
+//     semantically wrong. It is now KindInvalid.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside 429.
+//   - 418, and every other status neither this provider nor httpcore names, was
+//     previously KindUnknown and is now KindUnavailable: httpcore has one
+//     default for an unrecognized status rather than per-provider silence.
+//
+// 404 is absent on purpose: access takes it back for a message of its own,
+// which TestResolveUnknownSecretIsNotFound covers.
+func TestResolveClassifiesStatus(t *testing.T) {
+	cases := []struct {
 		code int
-		want error
+		want mamori.Kind
 	}{
-		{http.StatusUnauthorized, mamori.ErrUnauthenticated},
-		{http.StatusForbidden, mamori.ErrPermissionDenied},
-		{http.StatusTooManyRequests, mamori.ErrRateLimited},
-		{http.StatusBadRequest, mamori.ErrInvalid},
-		{http.StatusInternalServerError, mamori.ErrUnavailable},
-		{http.StatusBadGateway, mamori.ErrUnavailable},
+		{http.StatusUnauthorized, mamori.KindUnauthenticated},
+		{http.StatusForbidden, mamori.KindPermissionDenied},
+		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
+		{http.StatusBadRequest, mamori.KindInvalid},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusInternalServerError, mamori.KindUnavailable},
+		{http.StatusBadGateway, mamori.KindUnavailable},
+		{http.StatusTeapot, mamori.KindUnavailable},
 	}
-	for _, tc := range tests {
+	for _, tc := range cases {
 		t.Run(http.StatusText(tc.code), func(t *testing.T) {
-			base := errors.New("injected")
-			got := classifyStatus(tc.code, base)
-			if !errors.Is(got, tc.want) {
-				t.Fatalf("classifyStatus(%d, base) = %v, want an error satisfying %v", tc.code, got, tc.want)
+			f := newFakeSM()
+			f.set("/", "k", []byte("v"))
+			f.failStatus("/", "k", tc.code)
+			p := f.provider()
+
+			_, err := p.Resolve(context.Background(), ref(t, "scaleway-sm://k"))
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.code)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.code, got, tc.want, err)
 			}
 		})
+	}
+}
+
+// TestResolveErrorMessagePreservesContext guards what the migration onto
+// httpcore had to keep: the secret name, the HTTP status, and the verbatim
+// (bounded) upstream body all still reach the message, and the classification
+// is still reachable with errors.Is rather than flattened into text.
+func TestResolveErrorMessagePreservesContext(t *testing.T) {
+	f := newFakeSM()
+	f.set("/", "db-password", []byte("v"))
+	f.failStatus("/", "db-password", http.StatusForbidden)
+	p := f.provider()
+
+	_, err := p.Resolve(context.Background(), ref(t, "scaleway-sm://db-password"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
+	}
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
+	}
+	for _, want := range []string{"db-password", "403"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error message lost %q: %v", want, err)
+		}
 	}
 }

--- a/providers/scaleway-sm/fake_test.go
+++ b/providers/scaleway-sm/fake_test.go
@@ -169,7 +169,7 @@ func (f *fakeSM) counts() int {
 // a disabled revision in favor of another. It reports false when no revision
 // satisfies the selector, which the caller turns into a 404 - the same
 // response an unknown secret produces, which is exactly the ambiguity
-// classifyStatus's doc comment warns about.
+// access's 404 branch warns about.
 func resolveRevisionSelector(revs map[uint32]secretRevision, selector string) (uint32, bool) {
 	switch selector {
 	case "latest":

--- a/providers/scaleway-sm/go.mod
+++ b/providers/scaleway-sm/go.mod
@@ -2,7 +2,10 @@ module github.com/xavidop/mamori/providers/scaleway-sm
 
 go 1.26.0
 
-require github.com/xavidop/mamori v0.1.0
+require (
+	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -21,3 +23,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/scaleway-sm/go.sum
+++ b/providers/scaleway-sm/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/scaleway-sm/resolve.go
+++ b/providers/scaleway-sm/resolve.go
@@ -6,22 +6,20 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"io"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 )
 
-// errBodyLimit bounds how much of a non-200 response body access reads, so
-// a hostile or broken upstream cannot put an unbounded response into an
-// error string. The 404 branch drains within this same bound (see access's
-// doc comment on why an absent secret needs that drain), and the 200 path
-// now drains within it too, right after its own Decode call, so every
-// branch that can be entered shares one connection-reuse discipline rather
-// than the 200 and 404 paths silently differing.
+// errBodyLimit bounds how much of a failing response body reaches an error
+// string, so a hostile or broken upstream cannot put an unbounded response
+// into one. httpcore hands errorDetail at most Config.MaxBody bytes and always
+// drains the rest on every branch, so the connection-reuse discipline this
+// file used to hand-roll per branch now comes from one place; this constant is
+// only about how much of that body is worth quoting.
 const errBodyLimit = 4096
 
 // Resolve fetches ref's secret from Secret Manager.
@@ -65,123 +63,101 @@ type accessResponse struct {
 // "latest_enabled", or a decimal revision number - see parseRef's doc
 // comment), and returns the decoded envelope.
 //
-// The full request URL, including its query string, is assembled into u
-// BEFORE http.NewRequestWithContext is called, deliberately: a malformed
-// WithBaseURL makes url.Parse fail inside NewRequestWithContext itself, and
-// that failure - like every other transport-level failure this method can
-// produce - is a *url.Error whose Error() renders the exact string handed to
-// it. Building the query string in first, rather than adding it to req.URL
-// afterwards, means that failure mode genuinely carries the project id, the
-// same way the live-transport failure below does; see
-// sanitizeTransportError's doc comment for why that matters.
+// The project id travels in the query string, which is exactly where
+// httpcore's URL redaction removes it from: every error httpcore returns
+// renders the request URL with its query and any userinfo stripped, and a
+// transport failure's own *url.Error is rebuilt with that redacted URL rather
+// than discarded, so errors.Is still reaches the underlying cause. That is
+// what this package used to keep with a hand-rolled sanitizeTransportError at
+// four call sites. The secret key never appears in a URL at all: it travels in
+// the X-Auth-Token header, which is never rendered.
 func (p *Provider) access(ctx context.Context, s settings, path, name, revision string) (accessResponse, error) {
-	u := p.baseURL + "/regions/" + url.PathEscape(s.region) +
-		"/secrets-by-path/versions/" + url.PathEscape(revision) + "/access"
-
-	q := url.Values{}
-	q.Set("secret_path", path)
-	q.Set("secret_name", name)
-	q.Set("project_id", s.projectID)
-	u += "?" + q.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	client, err := p.clientFor(s)
 	if err != nil {
-		return accessResponse{}, sanitizeTransportError(err)
+		return accessResponse{}, err
 	}
-	req.Header.Set("X-Auth-Token", s.secretKey)
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := client.Do(ctx, httpcore.Request{
+		Path: "/regions/" + url.PathEscape(s.region) +
+			"/secrets-by-path/versions/" + url.PathEscape(revision) + "/access",
+		Query: url.Values{
+			"secret_path": {path},
+			"secret_name": {name},
+			"project_id":  {s.projectID},
+		},
+	})
 	if err != nil {
-		return accessResponse{}, sanitizeTransportError(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
-		// The secret name is absent, the requested revision does not exist,
-		// or the requested revision is DISABLED (Scaleway makes a disabled
-		// version inaccessible, not merely non-default - see the package doc
-		// comment on the ?revision default); see classifyStatus's doc comment
-		// for why the response does not reliably distinguish any of these.
-		//
-		// That a disabled revision arrives here as a 404 specifically is the
-		// one part of this not confirmed from a published source. Scaleway
-		// documents the inaccessibility but not the status it returns, and 404
-		// is the reading consistent with an inaccessible version being absent
-		// from the caller's view. If it turns out to be a 403, the sentinel
-		// changes from ErrNotFound to ErrPermissionDenied and a disabled
-		// revision would fail loudly rather than degrading to the field's
-		// default. The live integration test is what would reveal it.
-		// Drain and discard a bounded amount of the body before returning:
-		// this provider caches nothing (see Resolve's doc comment), so an
-		// absent secret is read again on every poll tick, and leaving the
-		// body unread here would prevent the connection being reused, paying
-		// a fresh TCP and TLS handshake on every one of those ticks.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
-		return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: secret %q not found: %w", name, mamori.ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded amount of the error body for diagnostics. Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
-		statusErr := fmt.Errorf("mamori/scaleway-sm: unexpected status %d accessing secret %q: %s",
-			resp.StatusCode, name, strings.TrimSpace(string(msg)))
-		return accessResponse{}, classifyStatus(resp.StatusCode, statusErr)
+		if errors.Is(err, mamori.ErrNotFound) {
+			// The secret name is absent, the requested revision does not
+			// exist, or the requested revision is DISABLED (Scaleway makes a
+			// disabled version inaccessible, not merely non-default - see the
+			// package doc comment on the ?revision default); the response does
+			// not reliably distinguish any of these.
+			//
+			// That a disabled revision arrives here as a 404 specifically is
+			// the one part of this not confirmed from a published source.
+			// Scaleway documents the inaccessibility but not the status it
+			// returns, and 404 is the reading consistent with an inaccessible
+			// version being absent from the caller's view. If it turns out to
+			// be a 403, the sentinel changes from ErrNotFound to
+			// ErrPermissionDenied and a disabled revision would fail loudly
+			// rather than degrading to the field's default. The live
+			// integration test is what would reveal it.
+			return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: secret %q not found: %w", name, mamori.ErrNotFound)
+		}
+		// One %w: the cause already carries the sentinel httpcore classified
+		// it with, and adding a second would replace that kind rather than
+		// duplicate it.
+		return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: accessing secret %q: %w", name, err)
 	}
 
 	var body accessResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
 		return accessResponse{}, fmt.Errorf("mamori/scaleway-sm: decoding access response for secret %q: %w: %w", name, mamori.ErrInvalid, err)
 	}
-	// Decode consumes a well-formed single JSON value, so this is normally a
-	// no-op; draining explicitly, rather than relying on that, is what makes
-	// this path's connection-reuse behavior a decision instead of an
-	// accident of Decode's internals, matching the 404 branch above (see
-	// errBodyLimit's doc comment).
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errBodyLimit))
 	return body, nil
 }
 
-// sanitizeTransportError strips a *url.Error down to its underlying reason,
-// discarding the request URL it would otherwise render into Error().
+// clientFor builds the httpcore client for one read.
 //
-// The request URL built in access embeds the project id in its query string
-// (see access's doc comment), and http.Client.Do wraps every
-// transport-level failure - a refused connection, a timeout, a cancelled
-// context - in a *url.Error whose Error() renders the full request URL.
-// Without this, an ordinary network hiccup, not even a bug in this
-// provider, would put the project id into a returned error's text, reached
-// here through the client's transport (and, for a malformed WithBaseURL,
-// through url.Parse inside http.NewRequestWithContext itself) instead of a
-// hand-rolled url.Parse call.
-//
-// providers/cloudflare-kv never actually shipped this leak: its own
-// sanitizeTransportError is present in the very commit that introduced its
-// resolve.go. What THAT module shipped, and had to fix in review, was a test
-// gap - only 1 of its 4 sanitize call sites was pinned by a test, not a
-// missing sanitizer. providers/vercel-gc did ship a real leak of this
-// shape, but in a different place: parseConnectionString ran the connection
-// string, token included, through url.Parse, and the fix moved the token out
-// of the URL entirely and into the Authorization header. Its transport path
-// has no sanitizer to this day, correctly, because its URL carries no
-// credential to leak.
-//
-// Wrapping urlErr.Err with %w, rather than discarding it, keeps
-// errors.Is(_, context.Canceled) (and similar checks) working: *url.Error
-// already unwraps to the same underlying error via its own Unwrap method,
-// so this changes only the rendered message, never the errors.Is chain.
-//
-// The final `return err` is deliberate, not a missed case: by construction
-// only a *url.Error carries a rendered request URL, so any other error type
-// already has nothing to strip, and wrapping it here would add noise
-// without removing anything sensitive.
-func sanitizeTransportError(err error) error {
-	if err == nil {
-		return nil
+// It is built per call rather than cached because the secret key, project id
+// and region are resolved per resolve, reading the environment lazily (see
+// settingsFor): caching would pin whichever set happened to be resolved first.
+// Construction performs no network call and reuses the provider's
+// *http.Client, so the connection pool is shared across every read.
+func (p *Provider) clientFor(s settings) (*httpcore.Client, error) {
+	c, err := httpcore.New(httpcore.Config{
+		BaseURL:     p.baseURL,
+		HTTPClient:  p.httpClient,
+		Auth:        httpcore.HeaderAuth("X-Auth-Token", s.secretKey),
+		ErrorDetail: errorDetail,
+	})
+	if err != nil {
+		// The base URL is operator-supplied and carries no credential: the
+		// project id is added per request as a query parameter, and the secret
+		// key is a header. httpcore quotes only the base URL it was given.
+		return nil, fmt.Errorf("mamori/scaleway-sm: building the API client: %w", err)
 	}
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return fmt.Errorf("mamori/scaleway-sm: request failed: %w", urlErr.Err)
+	return c, nil
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it quotes a bounded
+// prefix of a failing response's body into the error message.
+//
+// Embedding the body verbatim, bounded by errBodyLimit, is a deliberate house
+// convention shared with providers/doppler, providers/cloudflare-kv and
+// providers/vercel-gc: the verbatim text is what actually tells an operator
+// what the upstream rejected the request for, and the bound is what stops a
+// hostile or broken upstream turning that diagnostic into an unbounded string.
+//
+// httpcore calls this only for a status it has already decided is a failure,
+// which is what makes it safe in a secret manager: on a 200 the body carries
+// the secret payload, and that body is never shown this hook.
+func errorDetail(_ int, body []byte) string {
+	if len(body) > errBodyLimit {
+		body = body[:errBodyLimit]
 	}
-	return err
+	return strings.TrimSpace(string(body))
 }
 
 // valueFor turns resp into a mamori.Value: it verifies resp.DataCrc32
@@ -270,46 +246,19 @@ func valueFor(resp accessResponse, ref mamori.Ref, region string) (mamori.Value,
 	}, nil
 }
 
-// classifyStatus maps a Secret Manager access-route status onto a mamori
-// classification sentinel, wrapping statusErr so both the sentinel and the
-// diagnostic context survive in the errors.Is chain. 404 is handled by its
-// own branch in access and never reaches this function.
+// Status classification comes from httpcore.ClassifyStatus, inside
+// httpcore.Client.Do, rather than from a mapping copied into this package. 404
+// is the one status access takes back, to give it a message of its own.
 //
-// The mapping follows ordinary HTTP semantics: 401 for a missing or invalid
-// API secret key, 403 for a key that authenticates but lacks permission to
-// read this secret, 429 for rate limiting, and 400 for a malformed request.
-// One caveat is worth being explicit about, because it is exactly the kind
-// of thing a misconfiguration hides behind rather than announces: a 404
-// from this API does not distinguish an unknown secret from a KNOWN secret
-// whose requested revision does not exist OR whose requested revision has
-// been disabled - disabling a version makes it inaccessible on Scaleway, not
-// merely non-default, so a caller who pinned ?revision=latest before a
-// revocation gets the identical 404 an entirely absent secret would. Either
-// way it degrades silently to the field's default or optional handling,
-// exactly as if the secret had never existed at all - see the package doc
-// comment for why ?revision defaults to "latest_enabled" rather than
-// "latest" for precisely this reason. Scaleway has not published a stable
-// enough error-code vocabulary in the response body to key this mapping on
-// anything but the status, so codes not listed here report unknown rather
-// than being guessed at.
-func classifyStatus(code int, statusErr error) error {
-	if statusErr == nil {
-		return nil
-	}
-	var sentinel error
-	switch {
-	case code == http.StatusUnauthorized:
-		sentinel = mamori.ErrUnauthenticated
-	case code == http.StatusForbidden:
-		sentinel = mamori.ErrPermissionDenied
-	case code == http.StatusTooManyRequests:
-		sentinel = mamori.ErrRateLimited
-	case code == http.StatusBadRequest:
-		sentinel = mamori.ErrInvalid
-	case code >= 500:
-		sentinel = mamori.ErrUnavailable
-	default:
-		return statusErr
-	}
-	return fmt.Errorf("%w: %w", sentinel, statusErr)
-}
+// One caveat of that 404 is worth being explicit about, because it is exactly
+// the kind of thing a misconfiguration hides behind rather than announces: a
+// 404 from this API does not distinguish an unknown secret from a KNOWN secret
+// whose requested revision does not exist OR whose requested revision has been
+// disabled - disabling a version makes it inaccessible on Scaleway, not merely
+// non-default, so a caller who pinned ?revision=latest before a revocation
+// gets the identical 404 an entirely absent secret would. Either way it
+// degrades silently to the field's default or optional handling, exactly as if
+// the secret had never existed at all - see the package doc comment for why
+// ?revision defaults to "latest_enabled" rather than "latest" for precisely
+// this reason. Scaleway has not published a stable enough error-code
+// vocabulary in the response body to key anything on but the status.

--- a/providers/scaleway-sm/resolve_test.go
+++ b/providers/scaleway-sm/resolve_test.go
@@ -484,9 +484,8 @@ func TestResolveNeverCaches(t *testing.T) {
 	}
 }
 
-// TestResolveClassifiesFailureStatus exercises classifyStatus through the
-// full Resolve path, using the fake's failStatus injection, rather than only
-// unit-testing classifyStatus in isolation (errors_test.go does that). This
+// TestResolveClassifiesFailureStatus exercises status classification through
+// the full Resolve path, using the fake's failStatus injection. This
 // is also the shape Task 3's conformance Fail hook needs: fail one secret's
 // requests by status code, resolve, observe the classified error.
 func TestResolveClassifiesFailureStatus(t *testing.T) {

--- a/providers/scaleway-sm/scalewaysm.go
+++ b/providers/scaleway-sm/scalewaysm.go
@@ -46,8 +46,8 @@
 // its enabled state; Scaleway does not offer one. A caller who pins
 // ?revision=latest and later has that revision disabled will see the
 // request fail, and because a 404 from this API does not distinguish "no
-// such revision" from "that revision is disabled" (see classifyStatus's doc
-// comment in resolve.go), that failure surfaces as mamori.ErrNotFound - which
+// such revision" from "that revision is disabled" (see the 404 branch
+// of access in resolve.go), that failure surfaces as mamori.ErrNotFound - which
 // means an optional or defaulted field goes quiet and silently falls back to
 // its default instead of announcing the revocation.
 //

--- a/providers/vercel-gc/conformance_test.go
+++ b/providers/vercel-gc/conformance_test.go
@@ -3,33 +3,26 @@ package vercelgc
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 	"github.com/xavidop/mamori/providertest"
 )
 
 // statusForFailure maps the mamori sentinel providertest.RunErrorClassification
-// injects to the HTTP status that would produce it through classifyStatus. The
-// read API surfaces failures as a status code, not as a mamori error, so the
-// conformance Fail hook has to invert that mapping to actually exercise every
-// classification case; injecting one fixed status regardless of err would only
-// ever exercise the case that status happens to map to.
+// injects to the HTTP status that produces it. The read API surfaces failures
+// as a status code, not as a mamori error, so the conformance Fail hook has to
+// invert the classification to actually exercise every case; injecting one
+// fixed status regardless of err would only ever exercise the case that status
+// happens to map to.
+//
+// The inverse is httpcore.StatusForKind rather than a switch copied into this
+// file: a hand-rolled inverse that drifts from the forward table does not fail
+// loudly, it just makes this case exercise one classification five times while
+// still reporting green.
 func statusForFailure(err error) int {
-	switch {
-	case errors.Is(err, mamori.ErrPermissionDenied):
-		return http.StatusForbidden
-	case errors.Is(err, mamori.ErrUnauthenticated):
-		return http.StatusUnauthorized
-	case errors.Is(err, mamori.ErrRateLimited):
-		return http.StatusTooManyRequests
-	case errors.Is(err, mamori.ErrInvalid):
-		return http.StatusBadRequest
-	default: // mamori.ErrUnavailable and anything unrecognized
-		return http.StatusServiceUnavailable
-	}
+	return httpcore.StatusForKind(mamori.ErrorKind(err))
 }
 
 func TestConformance(t *testing.T) {
@@ -63,10 +56,10 @@ func TestConformance(t *testing.T) {
 		Fail: func(_ context.Context, _ string, err error) error {
 			// The read API surfaces failures per request, not per key, so the
 			// whole store is failed and cleared. statusForFailure maps the
-			// injected sentinel to the status that produces it through
-			// classifyStatus, so each of the five ErrorClassification cases
-			// actually round-trips through the real status-to-error mapping
-			// instead of only ever exercising Unavailable.
+			// injected sentinel back to the status that produces it, so each of
+			// the five ErrorClassification cases actually round-trips through
+			// the real status-to-error mapping instead of only ever exercising
+			// Unavailable.
 			f.failStatus(testStore, statusForFailure(err))
 			return nil
 		},

--- a/providers/vercel-gc/errors_test.go
+++ b/providers/vercel-gc/errors_test.go
@@ -1,68 +1,112 @@
 package vercelgc
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/xavidop/mamori"
 )
 
-// TestClassifyStatusUnmappedIsUnknown asserts that a status classifyStatus has
-// no case for (teapot, chosen because no real Global Config response uses it)
-// reports mamori.KindUnknown, matching the "anything else maps to unknown"
-// contract the site page publishes, and returns statusErr unchanged rather
-// than re-wrapping it.
-func TestClassifyStatusUnmappedIsUnknown(t *testing.T) {
-	base := errors.New(`mamori/vercel-gc: unexpected status 418 from items of store ecfg_test: teapot`)
-	got := classifyStatus(http.StatusTeapot, base)
-
-	if got != base {
-		t.Fatalf("classifyStatus(418, base) = %v, want base returned unchanged", got)
+// TestResolveClassifiesStatus pins the status-to-kind mapping this provider
+// inherits from httpcore.ClassifyStatus, exercised end to end through Resolve
+// against a real response. There is no longer a hand-rolled classifyStatus to
+// table-test directly: the mapping lives in one place for every httpcore-backed
+// provider.
+//
+// Three rows differ from the mapping this provider carried before it moved onto
+// httpcore, and each is deliberate:
+//
+//   - 422 was previously unclassified (KindUnknown), so mamori treated it as an
+//     unknown failure and kept retrying a request that was well formed and
+//     semantically wrong. It is now KindInvalid.
+//   - 408 was previously unclassified. It is now KindRateLimited, alongside 429.
+//   - 418, and every other status neither this provider nor httpcore names, was
+//     previously KindUnknown and is now KindUnavailable: httpcore has one
+//     default for an unrecognized status rather than per-provider silence.
+//
+// 401 and 403 are both present, which is the point of including them: they sit
+// next to each other in any status mapping, and a copy-paste swap of the two
+// would still satisfy a test that only ever asserted one of them.
+// TestResolveUnauthorizedIsNotPermissionDenied pins the negative directly.
+//
+// 404 is absent on purpose: get takes it back for a message of its own, which
+// TestResolveUnknownStoreIsNotFound covers.
+func TestResolveClassifiesStatus(t *testing.T) {
+	cases := []struct {
+		code int
+		want mamori.Kind
+	}{
+		{http.StatusUnauthorized, mamori.KindUnauthenticated},
+		{http.StatusForbidden, mamori.KindPermissionDenied},
+		{http.StatusTooManyRequests, mamori.KindRateLimited},
+		{http.StatusRequestTimeout, mamori.KindRateLimited},
+		{http.StatusBadRequest, mamori.KindInvalid},
+		{http.StatusUnprocessableEntity, mamori.KindInvalid},
+		{http.StatusInternalServerError, mamori.KindUnavailable},
+		{http.StatusBadGateway, mamori.KindUnavailable},
+		{http.StatusTeapot, mamori.KindUnavailable},
 	}
-	if kind := mamori.ErrorKind(got); kind != mamori.KindUnknown {
-		t.Fatalf("ErrorKind = %q, want %q", kind, mamori.KindUnknown)
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.code), func(t *testing.T) {
+			f := newFake()
+			f.set(testStore, "k", `"v"`)
+			f.failStatus(testStore, tc.code)
+			p := f.provider()
+
+			_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+			if err == nil {
+				t.Fatalf("status %d: Resolve returned a nil error", tc.code)
+			}
+			if got := mamori.ErrorKind(err); got != tc.want {
+				t.Fatalf("status %d: ErrorKind = %q, want %q (err: %v)", tc.code, got, tc.want, err)
+			}
+		})
 	}
 }
 
-func TestClassifyStatusNilIsNil(t *testing.T) {
-	if err := classifyStatus(http.StatusForbidden, nil); err != nil {
-		t.Fatalf("classifyStatus(403, nil) = %v, want nil", err)
+// TestResolveUnauthorizedIsNotPermissionDenied is the negative half of the 401
+// row above: every other assertion in this package checks only what a status
+// DOES satisfy, never what it must NOT, so a swap of the two adjacent cases
+// would pass everywhere else.
+func TestResolveUnauthorizedIsNotPermissionDenied(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "k", `"v"`)
+	f.failStatus(testStore, http.StatusUnauthorized)
+	p := f.provider()
+
+	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+	if !errors.Is(err, mamori.ErrUnauthenticated) {
+		t.Fatalf("401: got %v, want an error satisfying mamori.ErrUnauthenticated", err)
+	}
+	if errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("401: got %v, must not satisfy mamori.ErrPermissionDenied", err)
 	}
 }
 
-// TestClassifyStatusPreservesChain asserts that the diagnostic text in
-// statusErr - the status code, endpoint, and store name get built into it in
-// get - stays reachable through errors.Is after classification wraps it with
-// a sentinel, so nothing throws away the original context.
-func TestClassifyStatusPreservesChain(t *testing.T) {
-	base := errors.New(`mamori/vercel-gc: unexpected status 403 from items of store ecfg_test: forbidden`)
-	wrapped := classifyStatus(http.StatusForbidden, base)
+// TestResolveErrorMessagePreservesContext guards what the migration onto
+// httpcore had to keep: the endpoint, the store, the HTTP status, and the
+// verbatim (bounded) upstream body all still reach the message, and the
+// classification is still reachable with errors.Is rather than flattened into
+// text.
+func TestResolveErrorMessagePreservesContext(t *testing.T) {
+	f := newFake()
+	f.set(testStore, "k", `"v"`)
+	f.failStatus(testStore, http.StatusForbidden)
+	p := f.provider()
 
-	if !errors.Is(wrapped, mamori.ErrPermissionDenied) {
-		t.Fatalf("classification lost: %v", wrapped)
+	_, err := p.Resolve(context.Background(), ref(t, "vercel-gc://k"))
+	if err == nil {
+		t.Fatal("Resolve returned a nil error for a 403 response")
 	}
-	if !errors.Is(wrapped, base) {
-		t.Fatalf("underlying status error no longer reachable: %v", wrapped)
+	if !errors.Is(err, mamori.ErrPermissionDenied) {
+		t.Fatalf("classification lost: %v", err)
 	}
-}
-
-// TestClassifyStatusUnauthorizedIsNotPermissionDenied is the negative half of
-// TestClassifyStatusPreservesChain's 403 case: 401 and 403 sit next to each
-// other in classifyStatus's switch, and every existing test only asserts what
-// each code DOES satisfy, never what it must NOT. A copy-paste swap of the
-// two cases (401 mapped to ErrPermissionDenied, 403 to ErrUnauthenticated)
-// would still pass every positive assertion elsewhere in this package - each
-// status would just be asserted against the wrong sentinel by a test that
-// only checks its own code - so this pins the negative directly.
-func TestClassifyStatusUnauthorizedIsNotPermissionDenied(t *testing.T) {
-	base := errors.New(`mamori/vercel-gc: unexpected status 401 from items of store ecfg_test: unauthorized`)
-	got := classifyStatus(http.StatusUnauthorized, base)
-
-	if !errors.Is(got, mamori.ErrUnauthenticated) {
-		t.Fatalf("classifyStatus(401, base) = %v, want an error satisfying mamori.ErrUnauthenticated", got)
-	}
-	if errors.Is(got, mamori.ErrPermissionDenied) {
-		t.Fatalf("classifyStatus(401, base) = %v, must not satisfy mamori.ErrPermissionDenied", got)
+	for _, want := range []string{"digest", testStore, "403"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error message lost %q: %v", want, err)
+		}
 	}
 }

--- a/providers/vercel-gc/fake_test.go
+++ b/providers/vercel-gc/fake_test.go
@@ -94,8 +94,8 @@ func (f *fakeGC) failStatus(store string, code int) {
 // ...) instead lets the digest succeed, so snapshotFor is entered, sees a
 // moved digest, and its call to fetchItems is what fails - the only path that
 // can genuinely test that a failed fetch does not install a snapshot, and the
-// only path that exercises classifyStatus from the items fetch rather than the
-// digest fetch.
+// only path that exercises status classification from the items fetch rather
+// than the digest fetch.
 func (f *fakeGC) failEndpoint(store, endpoint string, code int) {
 	f.setFail(store, endpoint, code)
 }

--- a/providers/vercel-gc/go.mod
+++ b/providers/vercel-gc/go.mod
@@ -2,7 +2,10 @@ module github.com/xavidop/mamori/providers/vercel-gc
 
 go 1.26.0
 
-require github.com/xavidop/mamori v0.1.0
+require (
+	github.com/xavidop/mamori v0.1.0
+	github.com/xavidop/mamori/providers/httpcore v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -21,3 +23,5 @@ require (
 )
 
 replace github.com/xavidop/mamori => ../..
+
+replace github.com/xavidop/mamori/providers/httpcore => ../httpcore

--- a/providers/vercel-gc/go.sum
+++ b/providers/vercel-gc/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/vercel-gc/resolve.go
+++ b/providers/vercel-gc/resolve.go
@@ -5,23 +5,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/xavidop/mamori"
+	"github.com/xavidop/mamori/providers/httpcore"
 )
 
-// errBodyLimit bounds how much of a non-200 response body get reads, so a
-// hostile or broken upstream cannot put an unbounded response into an error
-// string. The 404 branch reads within this same bound and folds the result
-// into the returned not-found error (rather than building it and discarding
-// it, which is what this provider used to do), which doubles as the drain
-// that lets net/http reuse the connection - the same reason the other
-// branch below reads a bounded amount rather than none at all. The 200 path
-// needs no matching drain step: it already reads the whole body via
-// io.ReadAll, so the connection is already fully consumed by the time this
-// function returns.
+// errBodyLimit bounds how much of a failing response body reaches an error
+// string, so a hostile or broken upstream cannot put an unbounded response
+// into one. It applies to the 404 branch too, which folds the body into the
+// returned not-found error rather than discarding it: this is the one place a
+// store-not-found body such as "edge_config_not_found" tells a caller what
+// actually went wrong. httpcore hands errorDetail at most Config.MaxBody bytes
+// and always drains the rest on every branch, so the connection-reuse
+// discipline this file used to hand-roll per branch now comes from one place.
 const errBodyLimit = 4096
 
 // Resolve fetches the value for ref.
@@ -178,39 +177,74 @@ func (p *Provider) fetchItems(ctx context.Context, c connection, store string) (
 // the token lives in (see parseConnectionString's doc comment for how that
 // error is stripped before it reaches a caller).
 func (p *Provider) get(ctx context.Context, c connection, store, endpoint string) ([]byte, error) {
-	url := c.host + "/" + store + "/" + endpoint
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	client, err := p.clientFor(c)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/json")
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := client.Do(ctx, httpcore.Request{
+		Path:   "/" + url.PathEscape(store) + "/" + endpoint,
+		Header: http.Header{"Accept": {"application/json"}},
+	})
 	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded amount of the error body for diagnostics (and, on the
-		// 404 branch below, fold it into the returned error instead of
-		// discarding it: this is the one place a store-not-found body such as
-		// "edge_config_not_found" would tell a caller what actually went
-		// wrong). Never log it.
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyLimit))
-		trimmed := strings.TrimSpace(string(msg))
-		if resp.StatusCode == http.StatusNotFound {
-			if trimmed == "" {
-				return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w", store, mamori.ErrNotFound)
-			}
-			return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w: %s", store, mamori.ErrNotFound, trimmed)
+		// One %w on both branches: the cause already carries the sentinel
+		// httpcore classified it with, and adding a second would replace that
+		// kind rather than duplicate it. The bounded body errorDetail lifted
+		// out of the response travels inside that cause, which is what keeps
+		// a store-not-found diagnostic such as "edge_config_not_found" in the
+		// message rather than discarding it.
+		if errors.Is(err, mamori.ErrNotFound) {
+			return nil, fmt.Errorf("mamori/vercel-gc: store %s not found: %w", store, err)
 		}
-		statusErr := fmt.Errorf("mamori/vercel-gc: unexpected status %d from %s of store %s: %s",
-			resp.StatusCode, endpoint, store, trimmed)
-		return nil, classifyStatus(resp.StatusCode, statusErr)
+		return nil, fmt.Errorf("mamori/vercel-gc: %s of store %s: %w", endpoint, store, err)
 	}
-	return io.ReadAll(resp.Body)
+	return resp.Body, nil
+}
+
+// clientFor builds the httpcore client for one request.
+//
+// It is built per call rather than cached because the connection is resolved
+// per resolve, reading GLOBAL_CONFIG and EDGE_CONFIG lazily (see connection):
+// caching would pin whichever one happened to be resolved first. Construction
+// performs no network call and reuses the provider's *http.Client, so the
+// connection pool is shared across every request.
+//
+// The token travels in the Authorization header rather than the documented
+// token query parameter, so an ordinary request cannot leak it into a log
+// line, a trace span, or an error message through a URL. httpcore adds a
+// second guarantee on top of that one: it renders the request URL into its
+// errors with the query string and any userinfo stripped, and rebuilds a
+// transport failure's own *url.Error the same way, so even the misuse
+// WithBaseURL's doc comment warns about - passing a whole connection string
+// where a bare origin belongs, which puts the token in c.host - cannot put
+// the token into an error's text.
+func (p *Provider) clientFor(c connection) (*httpcore.Client, error) {
+	client, err := httpcore.New(httpcore.Config{
+		BaseURL:     c.host,
+		HTTPClient:  p.httpClient,
+		Auth:        httpcore.Bearer(c.token),
+		ErrorDetail: errorDetail,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mamori/vercel-gc: building the API client: %w", err)
+	}
+	return client, nil
+}
+
+// errorDetail is httpcore's Config.ErrorDetail hook: it quotes a bounded
+// prefix of a failing response's body into the error message.
+//
+// Embedding the body verbatim, bounded by errBodyLimit, is a deliberate house
+// convention shared with providers/doppler, providers/cloudflare-kv and
+// providers/scaleway-sm. It matters most on the 404: "edge_config_not_found"
+// is the one thing that distinguishes a store that does not exist from a token
+// that cannot see it. httpcore calls this only for a status it has already
+// decided is a failure, never for the 200 whose body is the store's items.
+func errorDetail(_ int, body []byte) string {
+	if len(body) > errBodyLimit {
+		body = body[:errBodyLimit]
+	}
+	return strings.TrimSpace(string(body))
 }
 
 // ResolveBatch resolves every ref, grouping by store so each store costs one
@@ -278,36 +312,13 @@ func (p *Provider) ResolveBatch(ctx context.Context, refs []mamori.Ref) (map[str
 	return out, nil
 }
 
-// classifyStatus maps a Global Config read API status onto a mamori
-// classification sentinel, wrapping statusErr so both the sentinel and the
-// diagnostic context survive in the errors.Is chain. 404 is handled by its own
-// branch in get and never reaches this function.
+// Status classification comes from httpcore.ClassifyStatus, inside
+// httpcore.Client.Do, rather than from a mapping copied into this package. 404
+// is the one status get takes back, to give it a message of its own.
 //
-// The mapping follows ordinary HTTP semantics. One caveat is worth stating
-// rather than hiding: Vercel's documented error body for a request missing an
-// authentication token carries "code": "forbidden", so a 403 from this API can
-// mean an absent credential rather than an insufficient one. Vercel has not
-// published the full error-code vocabulary, so the mapping keys on status
-// rather than guessing at a body it cannot rely on. Codes not listed report
-// unknown rather than being guessed at.
-func classifyStatus(code int, statusErr error) error {
-	if statusErr == nil {
-		return nil
-	}
-	var sentinel error
-	switch {
-	case code == http.StatusUnauthorized:
-		sentinel = mamori.ErrUnauthenticated
-	case code == http.StatusForbidden:
-		sentinel = mamori.ErrPermissionDenied
-	case code == http.StatusTooManyRequests:
-		sentinel = mamori.ErrRateLimited
-	case code == http.StatusBadRequest:
-		sentinel = mamori.ErrInvalid
-	case code >= 500:
-		sentinel = mamori.ErrUnavailable
-	default:
-		return statusErr
-	}
-	return fmt.Errorf("%w: %w", sentinel, statusErr)
-}
+// One caveat of the mapping is worth stating rather than hiding: Vercel's
+// documented error body for a request missing an authentication token carries
+// "code": "forbidden", so a 403 from this API can mean an absent credential
+// rather than an insufficient one. Vercel has not published the full
+// error-code vocabulary, so classification keys on the status rather than
+// guessing at a body it cannot rely on.

--- a/providers/vercel-gc/resolve_test.go
+++ b/providers/vercel-gc/resolve_test.go
@@ -354,7 +354,7 @@ func TestResolveRecoversAfterFailureCleared(t *testing.T) {
 // TestResolveErrorClassification (above) fails the whole store, so every case
 // there is actually observed through the digest fetch: fetchDigest runs first,
 // and a whole-store failure lands on it before an items fetch ever happens.
-// This exercises the other half of classifyStatus's callers - a failure on the
+// This exercises the other half of the classified callers - a failure on the
 // items fetch itself - which otherwise has zero coverage. As above, the store
 // is bumped after priming so the digest fetch succeeds and snapshotFor
 // actually attempts (and fails) fetchItems.

--- a/site/src/pages/docs/providers/cloudflare-kv.md
+++ b/site/src/pages/docs/providers/cloudflare-kv.md
@@ -74,10 +74,11 @@ Beyond 404, every other failure is classified by HTTP status, identically on bot
 | --- | --- |
 | 401 | `unauthenticated` |
 | 403 | `permission_denied` |
-| 429 | `rate_limited` |
-| 400 | `invalid` |
-| 5xx | `unavailable` |
-| anything else | `unknown` |
+| 408, 429 | `rate_limited` |
+| 400, 422 | `invalid` |
+| 5xx, and any other status not named above | `unavailable` |
+
+The mapping is `httpcore.ClassifyStatus`, shared with every other `httpcore`-backed provider. An unrecognized status reports `unavailable` (transient, so mamori backs off and retries) rather than `unknown`.
 
 An absent key and an absent namespace both return a plain 404 and are indistinguishable in the response. A namespace id that is simply wrong therefore presents exactly like a namespace full of genuinely absent keys: every field in your config silently falls back to its default, on either the single-key or the batch path. If everything unexpectedly defaults at once, check `Status()` before assuming the keys themselves are missing.
 

--- a/site/src/pages/docs/providers/scaleway-sm.md
+++ b/site/src/pages/docs/providers/scaleway-sm.md
@@ -99,10 +99,11 @@ A 404 is detected before status classification runs and reports `not_found` dire
 | --- | --- |
 | 401 | `unauthenticated` |
 | 403 | `permission_denied` |
-| 429 | `rate_limited` |
-| 400 | `invalid` |
-| 5xx | `unavailable` |
-| anything else | `unknown` |
+| 408, 429 | `rate_limited` |
+| 400, 422 | `invalid` |
+| 5xx, and any other status not named above | `unavailable` |
+
+The mapping is `httpcore.ClassifyStatus`, shared with every other `httpcore`-backed provider. An unrecognized status reports `unavailable` (transient, so mamori backs off and retries) rather than `unknown`.
 
 An unknown secret, a known secret whose pinned revision does not exist, and a known secret whose pinned revision is **disabled** all return the identical 404, with no error code in the body to tell them apart. A ref asking for `?revision=99` against a secret that has only reached revision 12 degrades silently to the field's default, exactly as if the secret had never existed at all - and so does a ref pinning `?revision=latest` after an operator disables the newest revision.
 


### PR DESCRIPTION
Migrates `cloudflare-kv`, `doppler`, `firebase-rc`, `onepassword`, `scaleway-sm` and `vercel-gc` onto `providers/httpcore`.

## Judge this on correctness, not deduplication

**It removes almost no code**: 2554 to 2547 non-blank lines, or 1550 to 1469 once comments are stripped. I said earlier it would remove meaningful duplication. On line count, it does not. Three things make it worth shipping anyway.

### 1. It fixes a real bug in all six

**None of them mapped 422.** It fell through to the transient default, so mamori backed off and **retried a request that can never succeed**. `httpcore.ClassifyStatus` maps 422 to `invalid` and 408 to `rate_limited`.

Each module's error test was rewritten to exercise the mapping end to end through `Resolve`, rather than unit-testing a function this PR deletes.

**One behaviour change is not suppressed and should be reviewed:** a status none of the six named (409, for example) moves from `unknown` to `unavailable`. That is inseparable from adopting a single default.

### 2. It closes a path-leak gap in `httpcore`

`redactURL` stripped the query and userinfo but rendered the **path** verbatim into every error. `cloudflare-kv` carries an account id and a namespace id as path segments and has tests forbidding exactly that leak, so a straight migration failed them.

Rather than let `cloudflare-kv` keep a local workaround the next provider would re-hand-roll, `httpcore` gains **`Config.RedactPath`**, applied at every site that renders a URL into an error, **including the rebuilt `*url.Error`**, with `OAuth2Config.RedactPath` threaded through for token endpoints carrying a tenant id. `hcp-vault-secrets` and `heroku` both put identifiers in paths and can now use it.

Mutation-checked, including the subtle site: removing the hook from the `*url.Error` rebuild leaks the id through the wrapped cause and fails a test.

### 3. Two more tests that could not fail

`cloudflare-kv`'s malformed-`BaseURL` leak tests asserted no id reached an error, but that error is `BaseURL "..." is not a URL`, which never contains one. No redaction change could fail them. Narrowed to what they actually check and renamed to match, with mutation proof in both directions.

## Two corrections to things I claimed earlier

**`httpcore.Revalidator` applies to none of the six.** I said three of them hand-rolled conditional GET. They do not: `cloudflare-kv` and `scaleway-sm` hold no cache, and `vercel-gc` gates on a separate `/digest` endpoint compared by value, which `Revalidator` cannot express. I read that from the README watch column instead of the code. Not forced.

**The spec's "sixteen providers" claim is corrected in place.** It was measured by import rather than by use; eight of those fetch through a vendor SDK. `consul` cannot harvest `httpcore.LongPoll` either, since its blocking query is `api.QueryOptions.WaitIndex` inside the HashiCorp SDK, so `LongPoll` is justified by Nacos alone.

## Verification

- `make test` exit 0, 58 modules, 0 failures
- `make lint` exit 0, 52 modules `0 issues.`
- `GOWORK=off go test -race ./...` ok in all seven touched modules
- `GOWORK=off go vet -tags integration ./...` clean in all six migrated modules
- `providertest.Run` unchanged in all six; no goleak ignore added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error classification across multiple providers, including clearer handling for timeouts, validation errors, conflicts, and unrecognized responses.
  * Preserved error context and classification checks while limiting sensitive response details.
  * Prevented credentials and identifiers from appearing in request error messages.
  * Improved not-found behavior for provider-specific resource lookups.

* **Documentation**
  * Updated provider documentation to reflect revised error mappings and retry-related behavior.
  * Corrected provider scope, migration sequencing, delivery notes, and risk estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->