### PR TITLE
docs: keep the root README a snapshot, not a design document

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,15 @@ go get github.com/xavidop/mamori/providers/vault          # vault://
 go get github.com/xavidop/mamori/providers/k8s            # k8s-secret://  k8s-cm://
 go get github.com/xavidop/mamori/providers/vercel-gc      # vercel-gc://
 go get github.com/xavidop/mamori/providers/cloudflare-kv  # cloudflare-kv://
-go get github.com/xavidop/mamori/providers/heroku         # heroku:// (config vars, batched)
-go get github.com/xavidop/mamori/providers/https          # https:// (generic REST)
+go get github.com/xavidop/mamori/providers/heroku         # heroku://
+go get github.com/xavidop/mamori/providers/https          # https://
 go get github.com/xavidop/mamori/providers/hcp-vault-secrets # hcp-vs://
 go get github.com/xavidop/mamori/providers/infisical      # infisical://
 go get github.com/xavidop/mamori/providers/scaleway-sm    # scaleway-sm://
-go get github.com/xavidop/mamori/providers/supabase       # supabase:// (Supabase Vault)
+go get github.com/xavidop/mamori/providers/supabase       # supabase://
 go get github.com/xavidop/mamori/providers/bitwarden      # bitwarden-sm://
 # ... gcp, azure, consul, doppler, nacos, onepassword, sops
-
-go get github.com/xavidop/mamori/providers/httpcore       # no scheme: the shared HTTP core
 ```
-
-[`providers/httpcore`](providers/httpcore/) is a library rather than a provider:
-it registers no scheme and you never blank-import it. It is what you build a
-REST-backed provider **on** - request building, authenticators, status
-classification, conditional GET, and a bounded, always-drained response body,
-with no dependency outside the standard library. See
-[Write a provider: HTTP core](https://mamorigo.dev/docs/writing-a-provider/httpcore).
 
 ## Quick start
 
@@ -152,8 +143,8 @@ cfg := w.Get() // lock-free snapshot; always the last *valid* config
 | `providers/nacos` | `nacos://` | **native** (long-poll listener) | ✅ |
 | `providers/vercel-gc` | `vercel-gc://` | poll (digest) | ✅ |
 | `providers/cloudflare-kv` | `cloudflare-kv://` | poll | ✅ |
-| `providers/heroku` | `heroku://` (batched: one request per app) | poll | ✅ |
-| `providers/https` | `https://` (generic, operator-declared endpoints) | poll (conditional GET) | ✅ |
+| `providers/heroku` | `heroku://` | poll | ✅ |
+| `providers/https` | `https://` | poll | ✅ |
 | `providers/firestore` | `firestore://` | **native** (snapshot listeners) | ✅ |
 | `providers/firebase-rc` | `firebase-rc://` | poll | ✅ |
 | `providers/firebase-rtdb` | `firebase-rtdb://` | **native** (streaming) | no (chain preserved) |


### PR DESCRIPTION
The root README is the project at a glance. I had been putting design material in it.

The worst of it was an install line for `providers/httpcore` plus a six-line paragraph about request building, authenticators, status classification, conditional GET and bounded, always-drained response bodies. **`httpcore` registers no scheme and nobody installs it to use mamori.** It is what you build a provider *on*, and that is already documented in the writing-a-provider guide, which is where a provider author actually looks.

Also trimmed implementation detail I had added elsewhere:

| Was | Now |
| --- | --- |
| `heroku://` (batched: one request per app) | `heroku://` |
| `https://` (generic, operator-declared endpoints), `poll (conditional GET)` | `https://`, `poll` |
| `# heroku:// (config vars, batched)` | `# heroku://` |
| `# supabase:// (Supabase Vault)` | `# supabase://` |
| `# https:// (generic REST)` | `# https://` |

Every neighbouring row in that table is a scheme and a watch mode. These now match.

Net: 5 insertions, 14 deletions. Nothing was removed that a reader scanning the project needs; the provider rows and install lines all stay.

I left the pre-existing entries alone (`poll (ETag)`, `lease-aware poll (NotAfter)`, `(chain preserved)` and the note under the table), since those predate my work and are yours to keep or cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)