### PR TITLE
test: assert the upstream body these tests promise to preserve

### DIFF
--- a/providers/scaleway-sm/errors_test.go
+++ b/providers/scaleway-sm/errors_test.go
@@ -79,7 +79,10 @@ func TestResolveErrorMessagePreservesContext(t *testing.T) {
 	if !errors.Is(err, mamori.ErrPermissionDenied) {
 		t.Fatalf("classification lost: %v", err)
 	}
-	for _, want := range []string{"db-password", "403"} {
+	for _, want := range []string{"db-password", "403", "injected failure"} {
+		// "injected failure" is the fake's response body. Without it the
+		// comment above promises the upstream body reaches the message while
+		// nothing checks it, so a regression dropping only the body passes.
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error message lost %q: %v", want, err)
 		}

--- a/providers/vercel-gc/errors_test.go
+++ b/providers/vercel-gc/errors_test.go
@@ -104,7 +104,10 @@ func TestResolveErrorMessagePreservesContext(t *testing.T) {
 	if !errors.Is(err, mamori.ErrPermissionDenied) {
 		t.Fatalf("classification lost: %v", err)
 	}
-	for _, want := range []string{"digest", testStore, "403"} {
+	for _, want := range []string{"digest", testStore, "403", "injected failure"} {
+		// "injected failure" is the fake's response body. Without it the
+		// comment above promises the upstream body reaches the message while
+		// nothing checks it, so a regression dropping only the body passes.
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error message lost %q: %v", want, err)
 		}


### PR DESCRIPTION
Addresses the review comment on #143, which merged before I got to it.

Both `TestResolveErrorMessagePreservesContext` cases carry a doc comment saying the migration onto `httpcore` had to keep "the verbatim (bounded) upstream body" in the error message. Neither asserted a body marker:

```go
for _, want := range []string{"db-password", "403"} {   // scaleway-sm
for _, want := range []string{"digest", testStore, "403"} {  // vercel-gc
```

**A regression that dropped only the body passed both.** The reviewer was right.

Each fake already sends a distinctive failure body (`{"message":"injected failure"}` and `{"error":{"code":"injected","message":"injected failure"}}`), so the fix is just adding the marker to the assertion list.

**Verified by mutation**, which is worth showing because my first two attempts at proving it were themselves worthless: the first ran against cached results, and the second used a regex that silently matched nothing. Neither would have caught anything.

Replacing each provider's `httpcore` `ErrorDetail` hook with one returning `""`:

```
scaleway-sm    --- FAIL: TestResolveErrorMessagePreservesContext
vercel-gc      --- FAIL: TestResolveErrorMessagePreservesContext
```

Reverted, both pass. Test-only change; `resolve.go` is byte-identical in both.

That makes fifteen tests in this programme that could not have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)