### PR TITLE
fix(site): lay the five idea cards out as three and two, not four and one

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -36,6 +36,12 @@ const features = [
   },
 ];
 
+// The heading below counts these cards rather than stating a number somebody has
+// to remember to change: it read "Four ideas, composed." for as long as the fifth
+// card had been sitting under it. Same reasoning as the category counts below.
+const numberWords = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"];
+const featureCount = numberWords[features.length] ?? String(features.length);
+
 // Providers are summarized on the landing by category; the full gallery lives in
 // the docs. Each card links to a representative provider page.
 //
@@ -169,10 +175,10 @@ const operational = [
     <div class="wrap">
       <div class="section__head">
         <span class="eyebrow">principles</span>
-        <h2>Four ideas, composed.</h2>
+        <h2>{featureCount} ideas, composed.</h2>
         <p>Each does one thing, through a well-defined interface, testable on its own.</p>
       </div>
-      <div class="features">
+      <div class="features features--ideas">
         {
           features.map((f) => (
             <article class="card feature">
@@ -516,6 +522,42 @@ cfg := w.<span class="f">Get</span>() <span class="c">// lock-free; always the l
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 1.1rem;
+  }
+  /* An odd number of cards leaves the last one stranded in a row of its own on
+     the default auto-fit track list, which reads as a mistake rather than a
+     card. Laying the ideas out on six columns lets five of them fill two whole
+     rows: three at two columns each, then two at three. The wider bottom pair
+     also absorbs the longest copy, so the row heights stay close. */
+  .features--ideas {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .features--ideas > * {
+    grid-column: span 2;
+  }
+  .features--ideas > *:nth-child(n + 4) {
+    grid-column: span 3;
+  }
+  /* Two up, with the last card spanning the pair so it is never orphaned. */
+  @media (max-width: 1024px) {
+    .features--ideas {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .features--ideas > *,
+    .features--ideas > *:nth-child(n + 4) {
+      grid-column: span 1;
+    }
+    .features--ideas > *:last-child {
+      grid-column: span 2;
+    }
+  }
+  @media (max-width: 640px) {
+    .features--ideas {
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .features--ideas > *,
+    .features--ideas > *:last-child {
+      grid-column: span 1;
+    }
   }
   .feature__k {
     font-family: var(--font-mono);


### PR DESCRIPTION
The bootstrap cache card made five, and a wide viewport fits four per row, so the fifth sat alone in a row of its own. It read as a rendering fault rather than a card.

## What changed

The ideas section now lays out on six columns, so five cards fill two whole rows: three spanning two columns, then two spanning three. The wider bottom pair also takes the longest copy, so the rows come out close in height instead of leaving the short cards padded with whitespace.

| Width | Layout |
| --- | --- |
| wide | 3 up, then 2 wide |
| below 1024px | 2 up, last card spans the pair |
| below 640px | 1 up |

No width leaves an orphan. Scoped to a `--ideas` modifier because the operational section shares `.features` and has exactly four cards, which the default track list already handles.

Also: the heading read "Four ideas, composed." while five cards sat under it. It now derives the number from the array, the same way the provider category counts already do, so the next card cannot reintroduce the drift.

## Verification

Rendered at 1400px, 900px and 500px and checked each; site builds at 108 pages with no broken internal links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the concepts heading to accurately reflect the number of feature cards.
  * Improved the concepts grid layout across large, medium, and small screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->